### PR TITLE
Vector search and embeddings generation

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,8 @@ If you are new here, start with either the `AI: Chat on current page` command or
 - **Generate Tags for Note**: Generates tags for the current note using AI.  Custom rules can also be specified to steer towards better tags.
 - **Generate and Insert Image using Dall-E**: Generates an image based on a prompt and inserts it into the note.
 - **Rename a note based on Note Context**: Sends the note, including enriched data, to the LLM and asks for a new note title.  Custom rules or examples can also be provided to generate better titles.
+- **Generate vector embeddings**: Chunks each page, generates vector embeddings of the text, and indexes those embeddings.  No external database required.
+- **Similarity search**: Allows doing a similarity search based on indexed embeddings.
 <!-- end-features -->
 
 ### Available commands
@@ -46,6 +48,13 @@ Valid templates must have a value for aiprompt.description in the frontmatter.
 - **AI: Suggest Page Name**: Ask the LLM to provide a name for the current note, allow the user to choose from the suggestions, and then rename the page.
 - **AI: Select Text Model from Config**: undefined
 - **AI: Select Image Model from Config**: undefined
+- **AI: Select Embedding Model from Config**: undefined
+- **AI: Test Embedding Generation**: Function to test generating embeddings.  Just puts the result in the current note, but
+isn't too helpful for most cases.
+- **AI: Debug Search Embeddings**: undefined
+- **AI: Search**: Ask the user for a search query, and then navigate to the search results page.
+Search results are provided by calculating the cosine similarity between the
+query embedding and each indexed embedding.
 
 <!-- end-commands-and-functions -->
 

--- a/docs/AI Core Library.md
+++ b/docs/AI Core Library.md
@@ -3,7 +3,7 @@ tags: sidebar
 navOrder: 10
 ---
 
-**WARNING**: This doesn’t quite work yet, sorry!  See 
+> **warning** This doesn’t quite work yet, sorry!
 
 # Installation
 To import this library, run the {[Library: Import]} command in your SilverBullet space and enter:

--- a/docs/Commands/AI: Search.md
+++ b/docs/Commands/AI: Search.md
@@ -1,0 +1,7 @@
+---
+tags: commands
+commandName: "AI: Search"
+commandSummary: "Ask the user for a search query, and then navigate to the search results page.
+Search results are provided by calculating the cosine similarity between the
+query embedding and each indexed embedding."
+---

--- a/docs/Commands/AI: Test Embedding Generation.md
+++ b/docs/Commands/AI: Test Embedding Generation.md
@@ -1,0 +1,6 @@
+---
+tags: commands
+commandName: "AI: Test Embedding Generation"
+commandSummary: "Function to test generating embeddings.  Just puts the result in the current note, but
+isn't too helpful for most cases."
+---

--- a/docs/Configuration/Embedding Models.md
+++ b/docs/Configuration/Embedding Models.md
@@ -1,0 +1,59 @@
+All embedding model providers can be configured using the following configuration options.  Not all options are required for every model.
+
+An embedding model is configured in the `SETTINGS` page like this, very similar to the [[Configuration/Text Models]] and [[Configuration/Image Models]]:
+
+```yaml
+ai:
+  embeddingModels:
+  # Only the first model is currently used
+  - name: <name>
+    provider: <provider>
+    modelName: <model name>
+    baseUrl: <base url of api>
+    requireAuth: <true or false>
+    secretName: <secret name>
+```
+
+
+Options:
+- **name**: Name to use inside of silverbullet for this model.  This is used to identify different versions of the same model in one config, or just to give your own custom names to them.
+- **provider**: Currently supported: OpenAI, Gemini, or Ollama.
+- **modelName**: Name of the model to send to the provider api.  This should be the actual model name.
+- **baseUrl**: Base url and path of the provider api.
+- **requireAuth**: If false, the Authorization headers will not be sent.  Needed as a workaround for some CORS issues with Ollama.
+- **secretName**: Name of secret to look for in SECRETS.
+
+## Enabling and Using Embeddings
+
+Generating vector embeddings is **disabled by default** for privacy (and cost) reasons. It is recommended to only enable it if using a locally hosted model using Ollama or an openai-compatible api.
+
+When turned on, **every page** in your space will end up being sent to the embeddings provider. We recommend using a locally-hosted model.
+
+> **warning** If you are not comfortable sending all of your notes to a 3rd party, do not use a 3rd party api for embeddings.
+
+To enable generation and indexing of embeddings, add the following section to SETTINGS:
+
+```yaml
+ai:
+  indexEmbeddings: true
+  indexEmbeddingsExcludePages:
+  - my_passwords
+  indexEmbeddingsExcludeStrings:
+  - "**user**:"
+  - "Daily Quote:"
+  embeddingModels:
+  # Only the first model is currently used
+  - name: ollama-all-minilm
+    modelName: all-minilm
+    provider: ollama
+    baseUrl: http://localhost:11434
+    requireAuth: false
+```
+
+Options:
+- **indexEmbeddings**: true to enable this feature.
+- **indexEmbeddingsExcludePages**: List of exact page names to exclude from indexing.  By default, pages starting with _, SECRETS, and SETTINGS are never indexed.
+- **indexEmbeddingsExcludeStrings**: List of exact strings to exclude from indexing. If a paragraph or line contains only one of these strings, it won’t be indexed.  This helps from polluting search results in some cases.
+- **embeddingModels**: Explained above.  Only the first model in the list is used for indexing.
+
+After setting **indexEmbeddings** to **true** OR changing the **first embeddingModels model**, you must run the `Space: Reindex` command.

--- a/docs/Features.md
+++ b/docs/Features.md
@@ -7,3 +7,5 @@
 - **Generate Tags for Note**: Generates tags for the current note using AI.  Custom rules can also be specified to steer towards better tags.
 - **Generate and Insert Image using Dall-E**: Generates an image based on a prompt and inserts it into the note.
 - **Rename a note based on Note Context**: Sends the note, including enriched data, to the LLM and asks for a new note title.  Custom rules or examples can also be provided to generate better titles.
+- **Generate vector embeddings**: Chunks each page, generates vector embeddings of the text, and indexes those embeddings.  No external database required.
+- **Similarity search**: Allows doing a similarity search based on indexed embeddings.

--- a/docs/Providers/DallE.md
+++ b/docs/Providers/DallE.md
@@ -3,6 +3,7 @@ tags: provider
 textProvider: false
 imageProvider: true
 apiProvider: dalle
+embeddingProvider: false
 ---
 
 Dall-E can be configured to use for generating images with these settings:

--- a/docs/Providers/Google Gemini.md
+++ b/docs/Providers/Google Gemini.md
@@ -3,6 +3,7 @@ tags: provider
 textProvider: true
 imageProvider: false
 apiProvider: gemini
+embeddingProvider: true
 ---
 
 Google does not offer an openai-compatible api, so consider the support for Gemini to be very experimental for now.

--- a/docs/Providers/Mistral Ai.md
+++ b/docs/Providers/Mistral Ai.md
@@ -3,6 +3,7 @@ tags: provider
 textProvider: true
 imageProvider: false
 apiProvider: openai
+embeddingProvider: false
 ---
 
 Mistral.ai is a hosted service that offers an openai-compatible api.  You can use it with settings like this:

--- a/docs/Providers/Ollama (ollama).md
+++ b/docs/Providers/Ollama (ollama).md
@@ -1,0 +1,23 @@
+---
+tags: provider
+textProvider: false
+imageProvider: false
+apiProvider: ollama
+embeddingProvider: true
+---
+
+Currently the `ollama` provider is specific to embeddings.  For text/llm usage, see [[Providers/Ollama (openai)]].
+
+To use Ollama locally, make sure you have it running first and the desired models downloaded.  Then, set the `baseUrl` to the url of your ollama instance:
+
+```yaml
+ai:
+  embeddingModels:
+  - name: ollama-all-minilm
+    modelName: all-minilm
+    provider: ollama
+    baseUrl: http://localhost:11434
+    requireAuth: false
+```
+
+**requireAuth**: When using Ollama and chrome, requireAuth needs to be set to false so that the Authorization header isn't set.  Otherwise you will get a CORS error.

--- a/docs/Providers/Ollama (openai).md
+++ b/docs/Providers/Ollama (openai).md
@@ -3,6 +3,7 @@ tags: provider
 textProvider: true
 imageProvider: false
 apiProvider: openai
+embeddingProvider: false
 ---
 
 To use Ollama locally, make sure you have it running first and the desired models downloaded.  Then, set the `openAIBaseUrl` to the url of your ollama instance:

--- a/docs/Providers/OpenAI.md
+++ b/docs/Providers/OpenAI.md
@@ -3,6 +3,7 @@ tags: provider
 textProvider: true
 imageProvider: false
 apiProvider: openai
+embeddingProvider: true
 ---
 
 [OpenAI](https://platform.openai.com/) itself is supported, but any openai api compatible services are also supported by the same provider in this plugin.  See [[Providers/Ollama]] as an example.

--- a/docs/Providers/OpenRouter.md
+++ b/docs/Providers/OpenRouter.md
@@ -3,6 +3,7 @@ tags: provider
 textProvider: true
 imageProvider: false
 apiProvider: openai
+embeddingProvider: true
 ---
 
 [OpenRouter](https://openrouter.ai/) provides access to a lot of different models, some of them even being free.  Since it exposes all of these LLMs through an openai compatible api, we can use the openai provider to configure them.

--- a/docs/Providers/Perplexity Ai.md
+++ b/docs/Providers/Perplexity Ai.md
@@ -3,6 +3,7 @@ tags: provider
 textProvider: true
 imageProvider: false
 apiProvider: openai
+embeddingProvider: false
 ---
 
 Perplexity.ai is another hosted service that offers an openai-compatible api and [various models](https://docs.perplexity.ai/docs/model-cards).  You can use it with settings like this:

--- a/docs/Quick Start.md
+++ b/docs/Quick Start.md
@@ -19,7 +19,7 @@ For example, for OpenAI, use OPENAI_API_KEY:
     OPENAI_API_KEY: "openai key here"
     ```
 
-Update your `SETTINGS` page and configure one or more textModels, and optionally an image model.  Example below is for OpenAI and DallE.  You may also want to configure [[Configuration/Chat Instructions]] at this time.  See [[Providers]] for examples other than OpenAI, including self-hosted ones.
+Update your `SETTINGS` page and configure one or more textModels, and optionally an image model and embeddings model.  Example below is for OpenAI and DallE.  You may also want to configure [[Configuration/Chat Instructions]] at this time.  See [[Providers]] for examples other than OpenAI, including self-hosted ones.
 
 ```yaml
 ai:
@@ -28,12 +28,16 @@ ai:
     modelName: dall-e-3
     provider: dalle
   textModels:
-  - name: gpt-4-turbo
+  - name: gpt-4o
     provider: openai
-    modelName: gpt-4-0125-preview
+    modelName: gpt-4o
   - name: gpt-3-turbo
     provider: openai
     modelName: gpt-3.5-turbo-0125
+  embeddingModels:
+  - name: text-embedding-3-small
+    provider: openai
+    modelName: text-embedding-3-small
 
   # Chat section is optional, but may help provide better results when using the Chat On Page command
   chat:
@@ -47,7 +51,11 @@ ai:
 
 Run `AI: Select Text Model from Config`, choose one of the models you just configured.
 
+> **note** If you only have one model configured, it will be selected automatically.
+
 Open a new note, run [[Commands/AI: Chat on current page]] or press (CTRL|CMD)+SHIFT+ENTER to start a chat session.
+
+Or try searching with [[Commands/AI: Search]] after configuring an [[Configuration/Embedding Models|Embedding model]] and re-indexing the space.
 
 And that’s it!  Look at the other [[Commands]] available, as well as check out the [[Templated Prompts]] to go futher.
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -6,7 +6,7 @@ silverbullet-ai is very new and is still in early development.  It may not work 
 
 If you are new here, start with [[Quick Start]], and then [[AI Core Library]]!
 
-**Warning**: Please backup your notes before using this plug.  It inserts and replaces text at certain points and isn't well-tested yet, so back up your data!
+> **warning** **Warning**: Please backup your notes before using this plug.  It inserts and replaces text at certain points and isn't well-tested yet, so back up your data!
 
 ## Features
 

--- a/docs/template/ProviderList.md
+++ b/docs/template/ProviderList.md
@@ -1,4 +1,4 @@
 ---
 tags: template
 ---
-- **[[{{name}}]]** (api: {{apiProvider}}, Text: {{textProvider}}, Images: {{imageProvider}})
+- **[[{{name}}]]** (api: {{apiProvider}}, Text: {{textProvider}}, Images: {{imageProvider}}, Embeddings: {{embeddingProvider}})

--- a/silverbullet-ai.plug.yaml
+++ b/silverbullet-ai.plug.yaml
@@ -93,3 +93,7 @@ functions:
     pageNamespace:
       pattern: "🤖 .+"
       operation: getFileMeta
+  searchCommand:
+    path: src/embeddings.ts:searchCommand
+    command:
+      name: "AI: Search"

--- a/silverbullet-ai.plug.yaml
+++ b/silverbullet-ai.plug.yaml
@@ -58,4 +58,11 @@ functions:
     path: sbai.ts:selectImageModelFromConfig
     command:
       name: "AI: Select Image Model from Config"
-
+  selectEmbeddingModel:
+    path: sbai.ts:selectEmbeddingModelFromConfig
+    command:
+      name: "AI: Select Embedding Model from Config"
+  testEmbeddingGeneration:
+    path: sbai.ts:testEmbeddingGeneration
+    command:
+      name: "AI: Test Embedding Generation"

--- a/silverbullet-ai.plug.yaml
+++ b/silverbullet-ai.plug.yaml
@@ -66,3 +66,30 @@ functions:
     path: sbai.ts:testEmbeddingGeneration
     command:
       name: "AI: Test Embedding Generation"
+  indexEmbeddings:
+    path: src/embeddings.ts:indexEmbeddings
+    events:
+      - page:index
+  debugSearchEmbeddings:
+    path: src/embeddings.ts:debugSearchEmbeddings
+    command:
+      name: "AI: Debug Search Embeddings"
+  embeddingsQueryProvider:
+    path: src/embeddings.ts:embeddingsQueryProvider
+    events:
+      - query:full-text
+  readPageSearchEmbeddings:
+    path: src/embeddings.ts:readFileEmbeddings
+    pageNamespace:
+      pattern: "🤖 .+"
+      operation: readFile
+  writePageSearchEmbeddings:
+    path: src/embeddings.ts:readFileEmbeddings
+    pageNamespace:
+      pattern: "🤖 .+"
+      operation: readFile
+  getPageMetaSearchEmbeddings:
+    path: src/embeddings.ts:getFileMetaEmbeddings
+    pageNamespace:
+      pattern: "🤖 .+"
+      operation: getFileMeta

--- a/src/embeddings.ts
+++ b/src/embeddings.ts
@@ -1,0 +1,133 @@
+import type { IndexTreeEvent } from "$sb/types.ts";
+import { indexObjects, queryObjects } from "$sbplugs/index/plug_api.ts";
+import { renderToText } from "$sb/lib/tree.ts";
+import { ObjectValue } from "$sb/types.ts";
+import { currentEmbeddingProvider, initIfNeeded } from "../src/init.ts";
+import { log } from "./utils.ts";
+import { editor } from "$sb/syscalls.ts";
+
+export type EmbeddingObject = ObjectValue<
+  {
+    // TODO: Do we need to store the text?  Maybe just the page+pos is enough
+    // text: string;
+    page: string;
+    pos: number;
+    embedding: number[];
+    tag: "embedding";
+  } & Record<string, any>
+>;
+
+export type EmbeddingResult = {
+  page: string;
+  ref: string;
+  similarity: number;
+};
+
+export async function indexEmbeddings({ name: page, tree }: IndexTreeEvent) {
+  // TODO: Allow user to exclude certain pages
+  const excludePatterns = ["_", "SETTINGS", "SECRETS"];
+  if (excludePatterns.some((pattern) => page.includes(pattern))) {
+    return;
+  }
+
+  log("any", "AI: Indexing embeddings for", page);
+
+  await initIfNeeded();
+
+  // Splitting embeddings up by paragraph, but there could be better ways to do it
+  const paragraphs = tree.children.filter((node) => node.type === "Paragraph");
+
+  const objects: EmbeddingObject[] = [];
+
+  for (const paragraph of paragraphs) {
+    const paragraphText = renderToText(paragraph);
+    // Skip empty paragraphs and lines with less than 10 characters (TODO: remove that limit?)
+    if (!paragraphText.trim() || paragraphText.length < 10) {
+      continue;
+    }
+
+    const embedding = await currentEmbeddingProvider.generateEmbeddings({
+      text: paragraphText,
+    });
+
+    const pos = paragraph.from ?? 0;
+
+    const embeddingObject: EmbeddingObject = {
+      ref: `${page}@${pos}`,
+      page: page,
+      pos: pos,
+      embedding: embedding,
+      tag: "embedding",
+    };
+
+    // log("any", "Indexing embedding object", embeddingObject);
+    objects.push(embeddingObject);
+  }
+
+  await indexObjects<EmbeddingObject>(page, objects);
+
+  log(
+    "any",
+    `AI: Indexed ${objects.length} embedding objects for page ${page}`,
+  );
+}
+
+export async function getAllEmbeddings(): Promise<EmbeddingObject[]> {
+  return (await queryObjects<EmbeddingObject>("embedding", {}));
+}
+
+// Full disclosure, I don't really understand how this part works - thanks chatgpt!
+//   ^ If anyone can make it better, please do.
+function cosineSimilarity(vecA: number[], vecB: number[]): number {
+  const dotProduct = vecA.reduce((sum, a, idx) => sum + a * vecB[idx], 0);
+  const magnitudeA = Math.sqrt(vecA.reduce((sum, val) => sum + val * val, 0));
+  const magnitudeB = Math.sqrt(vecB.reduce((sum, val) => sum + val * val, 0));
+  return dotProduct / (magnitudeA * magnitudeB);
+}
+
+/**
+ * Loop over every single embedding object and calculate the cosine similarity between the query embedding and each embedding object.
+ * Return the most similar embedding objects.
+ */
+export async function searchEmbeddings(
+  query: string,
+  numResults = 10,
+): Promise<EmbeddingResult[]> {
+  await initIfNeeded();
+  const queryEmbedding = await currentEmbeddingProvider.generateEmbeddings({
+    text: query,
+  });
+  const embeddings = await getAllEmbeddings();
+
+  const results: EmbeddingResult[] = embeddings.map((embedding) => ({
+    page: embedding.page,
+    ref: embedding.ref,
+    similarity: cosineSimilarity(queryEmbedding, embedding.embedding),
+  }));
+
+  log("any", "AI: searchEmbeddings", results);
+
+  return results
+    .sort((a, b) => b.similarity - a.similarity)
+    .slice(0, numResults);
+}
+
+export async function debugSearchEmbeddings() {
+  const text = await editor.prompt("Enter some text to embed:");
+  if (!text) {
+    await editor.flashNotification("No text entered.", "error");
+    return;
+  }
+
+  const searchResults = await searchEmbeddings(text);
+  await editor.flashNotification(`Found ${searchResults.length} results`);
+  const formattedResults = searchResults.map((result) => ({
+    page: result.page,
+    ref: result.ref,
+    similarity: result.similarity,
+  }));
+  log("any", "AI: Search results", formattedResults);
+  await editor.insertAtCursor(
+    `\n\nSearch results: ${JSON.stringify(formattedResults)}`,
+  );
+}

--- a/src/embeddings.ts
+++ b/src/embeddings.ts
@@ -272,3 +272,15 @@ export function getFileMetaEmbeddings(name: string): FileMeta {
     perm: "ro",
   };
 }
+
+/**
+ * Ask the user for a search query, and then navigate to the search results page.
+ * Search results are provided by calculating the cosine similarity between the
+ * query embedding and each indexed embedding.
+ */
+export async function searchCommand() {
+  const phrase = await editor.prompt("Search for: ");
+  if (phrase) {
+    await editor.navigate({ page: `${searchPrefix}${phrase}` });
+  }
+}

--- a/src/init.ts
+++ b/src/init.ts
@@ -52,6 +52,9 @@ export type AISettings = {
   embeddingModels: EmbeddingModelConfig[];
   chat: ChatSettings;
   promptInstructions: PromptInstructions;
+  indexEmbeddings: boolean;
+  indexEmbeddingsExcludePages: string[];
+  indexEmbeddingsExcludeStrings: string[];
 
   // These are deprecated and will be removed in a future release
   openAIBaseUrl: string;
@@ -357,6 +360,9 @@ async function loadAndMergeSettings() {
     promptInstructions: {},
     imageModels: [],
     embeddingModels: [],
+    indexEmbeddings: false,
+    indexEmbeddingsExcludePages: [],
+    indexEmbeddingsExcludeStrings: ["**user**:"],
   };
   const defaultChatSettings: ChatSettings = {
     userInformation: "",

--- a/src/init.ts
+++ b/src/init.ts
@@ -9,6 +9,7 @@ import {
   ProviderInterface,
 } from "./interfaces.ts";
 import { OpenAIEmbeddingProvider, OpenAIProvider } from "./openai.ts";
+import { OllamaEmbeddingProvider } from "./ollama.ts";
 import { log } from "./utils.ts";
 
 export type ChatMessage = {
@@ -42,6 +43,7 @@ enum ImageProvider {
 enum EmbeddingProvider {
   OpenAI = "openai",
   Gemini = "gemini",
+  Ollama = "ollama",
 }
 
 export type AISettings = {
@@ -258,6 +260,14 @@ function setupEmbeddingProvider(model: EmbeddingModelConfig) {
       currentEmbeddingProvider = new GeminiEmbeddingProvider(
         apiKey,
         model.modelName,
+      );
+      break;
+    case EmbeddingProvider.Ollama:
+      currentEmbeddingProvider = new OllamaEmbeddingProvider(
+        apiKey,
+        model.modelName,
+        model.baseUrl || "http://localhost:11434",
+        model.requireAuth,
       );
       break;
     default:

--- a/src/init.ts
+++ b/src/init.ts
@@ -2,7 +2,7 @@ import { readSecret } from "$sb/lib/secrets_page.ts";
 import { readSetting } from "$sb/lib/settings_page.ts";
 import { clientStore } from "$sb/syscalls.ts";
 import { DallEProvider } from "./dalle.ts";
-import { GeminiProvider } from "./gemini.ts";
+import { GeminiEmbeddingProvider, GeminiProvider } from "./gemini.ts";
 import {
   EmbeddingProviderInterface,
   ImageProviderInterface,
@@ -40,6 +40,7 @@ enum ImageProvider {
 
 enum EmbeddingProvider {
   OpenAI = "openai",
+  Gemini = "gemini",
 }
 
 export type AISettings = {
@@ -228,6 +229,16 @@ function setupEmbeddingProvider(model: EmbeddingModelConfig) {
         model.baseUrl || aiSettings.openAIBaseUrl,
       );
       break;
+    case EmbeddingProvider.Gemini:
+      currentEmbeddingProvider = new GeminiEmbeddingProvider(
+        apiKey,
+        model.modelName,
+      );
+      break;
+    default:
+      throw new Error(
+        `Unsupported embedding provider: ${model.provider}. Please configure a supported provider.`,
+      );
   }
 }
 

--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -71,9 +71,6 @@ export abstract class AbstractProvider implements ProviderInterface {
     this.apiKey = apiKey;
     this.baseUrl = baseUrl;
     this.modelName = modelName;
-    console.log(
-      `New AI Provider initialized: ${this.name}, Base URL: ${this.baseUrl}, Model Name: ${this.modelName}`,
-    );
   }
 
   abstract chatWithAI(options: StreamChatOptions): Promise<any>;

--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -41,6 +41,20 @@ export interface ImageProviderInterface {
   ) => Promise<string>;
 }
 
+export type EmbeddingGenerationOptions = {
+  text: string;
+};
+
+export interface EmbeddingProviderInterface {
+  name: string;
+  apiKey: string;
+  baseUrl: string;
+  modelName: string;
+  generateEmbeddings: (
+    options: EmbeddingGenerationOptions,
+  ) => Promise<Array<number>>;
+}
+
 export abstract class AbstractProvider implements ProviderInterface {
   name: string;
   apiKey: string;
@@ -135,4 +149,31 @@ export abstract class AbstractImageProvider implements ImageProviderInterface {
   abstract generateImage(
     options: ImageGenerationOptions,
   ): Promise<string>;
+}
+
+export abstract class AbstractEmbeddingProvider
+  implements EmbeddingProviderInterface {
+  apiKey: string;
+  baseUrl: string;
+  name: string;
+  modelName: string;
+  requireAuth: boolean;
+
+  constructor(
+    apiKey: string,
+    baseUrl: string,
+    name: string,
+    modelName: string,
+    requireAuth: boolean = true,
+  ) {
+    this.apiKey = apiKey;
+    this.baseUrl = baseUrl;
+    this.name = name;
+    this.modelName = modelName;
+    this.requireAuth = requireAuth;
+  }
+
+  abstract generateEmbeddings(
+    options: EmbeddingGenerationOptions,
+  ): Promise<Array<number>>;
 }

--- a/src/ollama.ts
+++ b/src/ollama.ts
@@ -1,0 +1,60 @@
+import {
+  AbstractEmbeddingProvider,
+  EmbeddingGenerationOptions,
+} from "./interfaces.ts";
+
+type HttpHeaders = {
+  "Content-Type": string;
+  "Authorization"?: string;
+};
+
+export class OllamaEmbeddingProvider extends AbstractEmbeddingProvider {
+  constructor(
+    apiKey: string,
+    modelName: string,
+    baseUrl: string,
+    requireAuth: boolean = false,
+  ) {
+    super(apiKey, baseUrl, "Ollama", modelName, requireAuth);
+  }
+
+  // Ollama doesn't have an openai compatible api for embeddings yet, so it gets its own provider
+  async generateEmbeddings(
+    options: EmbeddingGenerationOptions,
+  ): Promise<Array<number>> {
+    const body = JSON.stringify({
+      model: this.modelName,
+      prompt: options.text,
+    });
+
+    const headers: HttpHeaders = {
+      "Content-Type": "application/json",
+    };
+
+    if (this.requireAuth) {
+      headers["Authorization"] = `Bearer ${this.apiKey}`;
+    }
+
+    const response = await nativeFetch(
+      `${this.baseUrl}/api/embeddings`,
+      {
+        method: "POST",
+        headers: headers,
+        body: body,
+      },
+    );
+
+    if (!response.ok) {
+      console.error("HTTP response: ", response);
+      console.error("HTTP response body: ", await response.json());
+      throw new Error(`HTTP error, status: ${response.status}`);
+    }
+
+    const data = await response.json();
+    if (!data || !data.embedding || data.embedding.length === 0) {
+      throw new Error("Invalid response from Ollama.");
+    }
+
+    return data.embedding;
+  }
+}

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -8,6 +8,17 @@ export function folderName(path: string) {
 }
 
 /**
+ * Console logs can get noisy on the server side, this lets us still have
+ * useful debug logs on the client by default without polluting the server logs.
+ */
+export async function log(env: "client" | "server" | "any", ...args: any[]) {
+  const currentEnv = await system.getEnv();
+  if (currentEnv === env || env === "any") {
+    console.log(...args);
+  }
+}
+
+/**
  * Converts the current page into a list of messages for the LLM.
  * Each message is a line of text, with the role being the bolded word at the beginning of the line.
  * Each message can also be multiple lines.


### PR DESCRIPTION
For #34 

Needs more testing, but so far:

- Added support for generating embeddings using openai, ollama, and gemini
- Stores generated embeddings in silverbullet's native datastore
- Listens for page:index events and indexes pages automatically when they change
- Generates an embedding per paragraph
- Added a new 🤖 virtual page to test searching with

Todo:

- [x] make this whole thing optional
- [x] add docs and make sure to recommend using local first, like ollama
- [x] more testing to make sure nothing blows up