### PR TITLE
Add option to generate summaries of each note and index them.

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,7 @@ If you are new here, start with either the `AI: Chat on current page` command or
 - **Rename a note based on Note Context**: Sends the note, including enriched data, to the LLM and asks for a new note title.  Custom rules or examples can also be provided to generate better titles.
 - **Generate vector embeddings**: Chunks each page, generates vector embeddings of the text, and indexes those embeddings.  No external database required.
 - **Similarity search**: Allows doing a similarity search based on indexed embeddings.
+- **Note Summary generation and search**: **Experimental** generates a summary of each note, then generates embeddings and indexes that summary to be searched using a similarity/semantic search.
 <!-- end-features -->
 
 ### Available commands

--- a/docs/Commands/AI: Search.md
+++ b/docs/Commands/AI: Search.md
@@ -5,3 +5,5 @@ commandSummary: "Ask the user for a search query, and then navigate to the searc
 Search results are provided by calculating the cosine similarity between the
 query embedding and each indexed embedding."
 ---
+
+Requires configuring [[Configuration/Embedding Models]] first.  Once properly configured, this command can be used to do a similarity or semantic search against all of the notes in a space.

--- a/docs/Configuration.md
+++ b/docs/Configuration.md
@@ -2,6 +2,15 @@ To change the text generation model used by all commands, or other configurable 
 
 ```yaml
 ai:
+  # Disabled by default, indexEmbeddings and indexSummary can be set
+  # to true to provide the AI: Search command.
+  # Be sure to read the relevant documentation and warnings first.
+  indexEmbeddings: false
+  indexEmbeddingsExcludePages: []
+  indexEmbeddingsExcludeStrings: []
+  indexSummaryModelName: ollama-gemma2
+  indexSummary: false
+  
   # configure one or more image models.  Only OpenAI's api is currently supported
   imageModels:
   - name: dall-e-3

--- a/docs/Configuration/Embedding Models.md
+++ b/docs/Configuration/Embedding Models.md
@@ -57,3 +57,40 @@ Options:
 - **embeddingModels**: Explained above.  Only the first model in the list is used for indexing.
 
 After setting **indexEmbeddings** to **true** OR changing the **first embeddingModels model**, you must run the `Space: Reindex` command.
+
+## Generating and indexing note summaries
+
+> **warning** This is an experimental feature, mostly due to the amount of extra time and resources it takes during the indexing process.  If you try it out, please report your experience!
+
+In addition to generating embeddings for each paragraph of a note, we can also use the llm model to generate a summary of the entire note and then index that.
+
+This can be helpful for larger notes or notes where each paragraph may not contain enough context by itself.
+
+To enable this feature, ensure you have these options in your SETTINGS:
+
+```yaml
+aiSettings:
+  indexSummaryModelName: ollama-gemma2
+  indexSummary: true
+  textModels:
+  - name: ollama-gemma2
+    modelName: gemma2
+    provider: openai
+    baseUrl: http://localhost:11434/v1
+    requireAuth: false
+```
+
+Options:
+- **indexSummary**: Off by default.  Set to true to start generating page summaries and indexing their embeddings.
+- **indexSummaryModelName**: Which [[Configuration/Text Models|text model]] to use for generating summaries.  It’s recommended to use a locally hosted model since every note in your space will be sent to it.
+
+> **warning** If you are not comfortable sending all of your notes to a 3rd party, do not use a 3rd party api for embeddings or summary generation.
+
+### Suggested models for summary generation
+
+> **info** Please report your experiences with using different models!
+
+These models have been tested with Ollama for generating note summaries, along with their quality.  Please report any other models you test with and your success (or not) with them.
+
+- **phi3**: Can generate summaries relatively quickly, but often includes hallucinations and weird changes that don’t match the source material.
+- **gemma2**: This model is a bit bigger, but generates much better summaries than phi3.

--- a/docs/Features.md
+++ b/docs/Features.md
@@ -10,3 +10,4 @@
 - **Rename a note based on Note Context**: Sends the note, including enriched data, to the LLM and asks for a new note title.  Custom rules or examples can also be provided to generate better titles.
 - **Generate vector embeddings**: Chunks each page, generates vector embeddings of the text, and indexes those embeddings.  No external database required.
 - **Similarity search**: Allows doing a similarity search based on indexed embeddings.
+- **Note Summary generation and search**: **Experimental** generates a summary of each note, then generates embeddings and indexes that summary to be searched using a similarity/semantic search.

--- a/silverbullet-ai.plug.yaml
+++ b/silverbullet-ai.plug.yaml
@@ -70,6 +70,10 @@ functions:
     path: src/embeddings.ts:indexEmbeddings
     events:
       - page:index
+  indexSummaryEmbeddings:
+    path: src/embeddings.ts:indexSummary
+    events:
+      - page:index
   debugSearchEmbeddings:
     path: src/embeddings.ts:debugSearchEmbeddings
     command:

--- a/src/cache.ts
+++ b/src/cache.ts
@@ -1,0 +1,33 @@
+let cache: { [key: string]: any } = {};
+
+export function setCache(key: string, value: any) {
+  cache[key] = value;
+}
+
+export function getCache(key: string): any {
+  return cache[key];
+}
+
+export function clearCache() {
+  cache = {};
+}
+
+export function removeCache(key: string) {
+  delete cache[key];
+}
+
+export function hasCache(key: string): boolean {
+  return Object.prototype.hasOwnProperty.call(cache, key);
+}
+
+// https://stackoverflow.com/questions/59777670/how-can-i-hash-a-string-with-sha256
+export async function hashStrings(...inputs: string[]): Promise<string> {
+  const concatenatedInput = inputs.join("");
+  const textAsBuffer = new TextEncoder().encode(concatenatedInput);
+  const hashBuffer = await crypto.subtle.digest("SHA-256", textAsBuffer);
+  const hashArray = Array.from(new Uint8Array(hashBuffer));
+  const hash = hashArray
+    .map((item) => item.toString(16).padStart(2, "0"))
+    .join("");
+  return hash;
+}

--- a/src/init.ts
+++ b/src/init.ts
@@ -172,6 +172,8 @@ function setupAIProvider(model: ModelConfig) {
         `Unsupported AI provider: ${model.provider}. Please configure a supported provider.`,
       );
   }
+
+  return currentAIProvider;
 }
 
 function setupEmbeddingProvider(model: EmbeddingModelConfig) {
@@ -225,7 +227,7 @@ export async function configureSelectedModel(model: ModelConfig) {
   }
 
   currentModel = model;
-  setupAIProvider(model);
+  return setupAIProvider(model);
 }
 
 export async function configureSelectedImageModel(model: ImageModelConfig) {
@@ -287,6 +289,8 @@ async function loadAndMergeSettings() {
     embeddingModels: [],
     textModels: [],
     indexEmbeddings: false,
+    indexSummary: false,
+    indexSummaryModelName: "",
     indexEmbeddingsExcludePages: [],
     indexEmbeddingsExcludeStrings: ["**user**:"],
   };
@@ -302,6 +306,7 @@ async function loadAndMergeSettings() {
     pageRenameSystem: "",
     pageRenameRules: "",
     tagRules: "",
+    indexSummaryPrompt: "",
   };
   const newSettings = await readSetting("ai", {});
   const newCombinedSettings = { ...defaultSettings, ...newSettings };

--- a/src/interfaces/Provider.ts
+++ b/src/interfaces/Provider.ts
@@ -1,6 +1,6 @@
 import { editor } from "$sb/syscalls.ts";
 import { getPageLength } from "../editorUtils.ts";
-import { StreamChatOptions } from "../types.ts";
+import { ChatMessage, StreamChatOptions } from "../types.ts";
 
 export interface ProviderInterface {
   name: string;
@@ -12,6 +12,10 @@ export interface ProviderInterface {
     options: StreamChatOptions,
     cursorStart: number,
   ) => Promise<void>;
+  singleMessageChat: (
+    userMessage: string,
+    systemPrompt?: string,
+  ) => Promise<string>;
 }
 
 export abstract class AbstractProvider implements ProviderInterface {
@@ -78,5 +82,29 @@ export abstract class AbstractProvider implements ProviderInterface {
     };
 
     await this.chatWithAI({ ...options, onDataReceived: onData });
+  }
+
+  async singleMessageChat(
+    userMessage: string,
+    systemPrompt?: string,
+  ): Promise<string> {
+    const messages: ChatMessage[] = [
+      {
+        role: "user",
+        content: userMessage,
+      },
+    ];
+
+    if (systemPrompt) {
+      messages.unshift({
+        role: "system",
+        content: systemPrompt,
+      });
+    }
+
+    return await this.chatWithAI({
+      messages,
+      stream: false,
+    });
   }
 }

--- a/src/providers/gemini.ts
+++ b/src/providers/gemini.ts
@@ -195,7 +195,7 @@ export class GeminiEmbeddingProvider extends AbstractEmbeddingProvider {
     super(apiKey, baseUrl, "Gemini", modelName, requireAuth);
   }
 
-  async generateEmbeddings(
+  async _generateEmbeddings(
     options: { text: string },
   ): Promise<Array<number>> {
     const body = JSON.stringify({

--- a/src/providers/ollama.ts
+++ b/src/providers/ollama.ts
@@ -17,7 +17,7 @@ export class OllamaEmbeddingProvider extends AbstractEmbeddingProvider {
   }
 
   // Ollama doesn't have an openai compatible api for embeddings yet, so it gets its own provider
-  async generateEmbeddings(
+  async _generateEmbeddings(
     options: EmbeddingGenerationOptions,
   ): Promise<Array<number>> {
     const body = JSON.stringify({

--- a/src/providers/openai.ts
+++ b/src/providers/openai.ts
@@ -168,7 +168,7 @@ export class OpenAIEmbeddingProvider extends AbstractEmbeddingProvider {
     super(apiKey, baseUrl, "OpenAI", modelName, requireAuth);
   }
 
-  async generateEmbeddings(
+  async _generateEmbeddings(
     options: EmbeddingGenerationOptions,
   ): Promise<Array<number>> {
     const body = JSON.stringify({

--- a/src/types.ts
+++ b/src/types.ts
@@ -32,6 +32,15 @@ export type EmbeddingObject = ObjectValue<
   } & Record<string, any>
 >;
 
+export type AISummaryObject = ObjectValue<
+  {
+    text: string;
+    page: string;
+    embedding: number[];
+    tag: "aiSummary";
+  } & Record<string, any>
+>;
+
 export type EmbeddingResult = {
   page: string;
   ref: string;
@@ -78,6 +87,7 @@ export type PromptInstructions = {
   pageRenameSystem: string;
   pageRenameRules: string;
   tagRules: string;
+  indexSummaryPrompt: string;
 };
 
 export type AISettings = {
@@ -89,6 +99,8 @@ export type AISettings = {
   indexEmbeddings: boolean;
   indexEmbeddingsExcludePages: string[];
   indexEmbeddingsExcludeStrings: string[];
+  indexSummary: boolean;
+  indexSummaryModelName: string;
 
   // These are deprecated and will be removed in a future release
   openAIBaseUrl: string;


### PR DESCRIPTION
Extension to #34 

I'm not sure about this yet.

The general idea is to generate a short one-paragraph summary of each note, generate embeddings for it, and index it.  This is in addition to the recently added embeddings index that is per paragraph.

So far I'm testing out the `phi-3` model with ollama and some summaries are _okay_, but a lot include random hallucinations.

I'm probably going to add this to the AI: Search page and merge it as an experimental feature for now, but the prompt will definitely need some tweaking, and will need to test other local models.

edit:

I'm merging this in with the setting off by default (like the normal embeddings).   I had much better luck using `gemma2` as the model to generate summaries.  It does make indexing take quite a bit longer though when using a locally hosted model.

I also added some in-memory caching so that repeatedly editing a page doesn't cause the same thing to be regenerating over and over.

