### PR TITLE
Add new "AI: Enhance Note" and "AI: Generate Note Frontmatter" commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,7 @@ If you are new here, start with either the `AI: Chat on current page` command or
 - **Generate vector embeddings**: Chunks each page, generates vector embeddings of the text, and indexes those embeddings.  No external database required.
 - **Similarity search**: Allows doing a similarity search based on indexed embeddings.
 - **Note Summary generation and search**: **Experimental** generates a summary of each note, then generates embeddings and indexes that summary to be searched using a similarity/semantic search.
+- **FrontMatter generation**: **Experimental** extracts useful information from a note’s context and generates frontmatter attributes for it.
 <!-- end-features -->
 
 ### Available commands
@@ -48,6 +49,10 @@ New responses are always appended to the end of the page.
 - **AI: Execute AI Prompt from Custom Template**: Prompts the user to select a template, renders that template, sends it to the LLM, and then inserts the result into the page.
 Valid templates must have a value for aiprompt.description in the frontmatter.
 - **AI: Suggest Page Name**: Ask the LLM to provide a name for the current note, allow the user to choose from the suggestions, and then rename the page.
+- **AI: Generate Note FrontMatter**: Extracts important information from the current note and converts it
+to frontmatter attributes.
+- **AI: Enhance Note**: Enhances the current note by running the commands to generate tags for a note,
+generate new frontmatter attributes, and a new note name.
 - **AI: Select Text Model from Config**: undefined
 - **AI: Select Image Model from Config**: undefined
 - **AI: Select Embedding Model from Config**: undefined

--- a/docs/Changelog.md
+++ b/docs/Changelog.md
@@ -5,7 +5,8 @@ This page is a brief overview of each version.
 ---
 ## Unreleased
 - Don't index and generate embeddings for pages in Library/
-- Add new `AI: Enhance Note` command to call existing `AI: Tag Note` and `AI: Suggest Page Name` commands on a note
+- Add new `AI: Enhance Note` command to call existing `AI: Tag Note` and `AI: Suggest Page Name` commands on a note, and the new frontmatter command
+- Add new `AI: Generate Note FrontMatter` command to extract useful facts from a note and add them to the frontmatter
 
 ---
 ## 0.2.0

--- a/docs/Changelog.md
+++ b/docs/Changelog.md
@@ -4,7 +4,7 @@ This page is a brief overview of each version.
 
 ---
 ## Unreleased
-- Nothing yet
+- Don't index and generate embeddings for pages in Library/
 
 ---
 ## 0.2.0

--- a/docs/Changelog.md
+++ b/docs/Changelog.md
@@ -5,6 +5,7 @@ This page is a brief overview of each version.
 ---
 ## Unreleased
 - Don't index and generate embeddings for pages in Library/
+- Add new `AI: Enhance Note` command to call existing `AI: Tag Note` and `AI: Suggest Page Name` commands on a note
 
 ---
 ## 0.2.0

--- a/docs/Changelog.md
+++ b/docs/Changelog.md
@@ -7,6 +7,7 @@ This page is a brief overview of each version.
 - Don't index and generate embeddings for pages in Library/
 - Add new `AI: Enhance Note` command to call existing `AI: Tag Note` and `AI: Suggest Page Name` commands on a note, and the new frontmatter command
 - Add new `AI: Generate Note FrontMatter` command to extract useful facts from a note and add them to the frontmatter
+- Always include the note’s current name in [[Commands/AI: Suggest Page Name]] as an option.
 
 ---
 ## 0.2.0

--- a/docs/Commands/AI: Enhance Note.md
+++ b/docs/Commands/AI: Enhance Note.md
@@ -1,0 +1,12 @@
+---
+tags: commands
+commandName: "AI: Enhance Note"
+commandSummary: "Enhances the current note by running the commands to generate tags for a note,
+and a new name."
+---
+
+This command does not do anything special on its own, but is a shortcut for running this sequence of commands:
+
+- [[Commands/AI: Generate tags for note]]
+- [[Commands/AI: Generate Note FrontMatter]]
+- [[Commands/AI: Suggest Page Name]]

--- a/docs/Commands/AI: Generate Note FrontMatter.md
+++ b/docs/Commands/AI: Generate Note FrontMatter.md
@@ -1,0 +1,12 @@
+---
+tags: commands
+commandName: "AI: Generate Note FrontMatter"
+commandSummary: "Extracts important information from the current note and converts it
+to frontmatter attributes."
+---
+
+**Experimental**: This is new and not well-tested.  Please submit feedback if you have ideas for making it better.
+
+This command will attempt to extract useful information from a note and then generate frontmatter attributes for that note.
+
+To add additional rules and instructions, `ai.promptInstructions.enhanceFrontMatterPrompt` can be set.  See [[Configuration/Prompt Instructions]].

--- a/docs/Configuration/Prompt Instructions.md
+++ b/docs/Configuration/Prompt Instructions.md
@@ -8,11 +8,18 @@ ai:
     pageRenameRules: ""
     pageRenameSystem: ""
     tagRules: ""
+    indexSummaryPrompt: ""
+    enhanceFrontMatterPrompt: ""
 ```
 
 `pageRenameSystem` can be used to completely override the system prompt used when requesting note title suggestions.  If not specified or left blank, the default prompt will be used.
 
 `pageRenameRules` is appended to the system prompt and can be used to extend the default system prompt without completely overriding it.
+
+`indexSummaryPrompt` is appended to the system prompt when generating a summary of a page that will be indexed.
+
+`enhanceFrontMatterPrompt` is appended to the system prompt when generating new frontmatter for a note.
+
 
 For example, the following example does a few things:
 

--- a/docs/Features.md
+++ b/docs/Features.md
@@ -11,3 +11,4 @@
 - **Generate vector embeddings**: Chunks each page, generates vector embeddings of the text, and indexes those embeddings.  No external database required.
 - **Similarity search**: Allows doing a similarity search based on indexed embeddings.
 - **Note Summary generation and search**: **Experimental** generates a summary of each note, then generates embeddings and indexes that summary to be searched using a similarity/semantic search.
+- **FrontMatter generation**: **Experimental** extracts useful information from a note’s context and generates frontmatter attributes for it.

--- a/sbai.ts
+++ b/sbai.ts
@@ -311,34 +311,18 @@ export async function suggestPageName() {
     - Do not use markdown or any other formatting in your response.`;
   }
 
-  const messages: ChatMessage[] = [
-    {
-      role: "system",
-      content: `${systemPrompt}
+  const response = await currentAIProvider.singleMessageChat(
+    `Current Page Title: ${noteName}\n\nPage Content:\n${noteContent}`,
+    `${systemPrompt}
 
 Always follow the below rules, if any, given by the user:
 ${aiSettings.promptInstructions.pageRenameRules}`,
-    },
-    {
-      role: "user",
-      content:
-        `Current Page Title: ${noteName}\n\nPage Content:\n${noteContent}`,
-    },
-  ];
-
-  // TODO: Should this be optional?
-  const enrichedMessages = await enrichChatMessages(messages);
-  console.log("enrichedMessages", enrichedMessages);
-
-  const response = await currentAIProvider.chatWithAI({
-    messages: enrichedMessages,
-    stream: false,
-  });
+    true,
+  );
 
   const suggestions = response.trim().split("\n").filter((line: string) =>
     line.trim() !== ""
   ).map((line: string) => line.replace(/^[*-]\s*/, "").trim());
-  // ).map((line: string) => line.replace(/[<>:"\/\\|?*\x00-\x1F]/g, "").trim());
 
   if (suggestions.length === 0) {
     await editor.flashNotification("No suggestions available.");

--- a/sbai.ts
+++ b/sbai.ts
@@ -321,9 +321,15 @@ ${aiSettings.promptInstructions.pageRenameRules}`,
     true,
   );
 
-  const suggestions = response.trim().split("\n").filter((line: string) =>
+  let suggestions = response.trim().split("\n").filter((line: string) =>
     line.trim() !== ""
   ).map((line: string) => line.replace(/^[*-]\s*/, "").trim());
+
+  // Always include the note's current name in the suggestions
+  suggestions.push(noteName);
+
+  // Remove duplicates
+  suggestions = [...new Set(suggestions)];
 
   if (suggestions.length === 0) {
     await editor.flashNotification("No suggestions available.");

--- a/sbai.ts
+++ b/sbai.ts
@@ -231,30 +231,23 @@ export async function tagNoteWithAI() {
     "tag select name where parent = 'page' order by name",
   )).map((tag: any) => tag.name);
   console.log("All tags:", allTags);
-  const response = await currentAIProvider.chatWithAI({
-    messages: [
-      {
-        role: "system",
-        content:
-          `You are an AI tagging assistant. Please provide a short list of tags, separated by spaces. Follow these guidelines:
-          - Only return tags and no other content.
-          - Tags must be one word only and in lowercase.
-          - Use existing tags as a starting point.
-          - Suggest tags sparingly, treating them as thematic descriptors rather than keywords.
+  const systemPrompt =
+    `You are an AI tagging assistant. Please provide a short list of tags, separated by spaces. Follow these guidelines:
+    - Only return tags and no other content.
+    - Tags must be one word only and in lowercase.
+    - Use existing tags as a starting point.
+    - Suggest tags sparingly, treating them as thematic descriptors rather than keywords.
 
-          The following tags are currently being used by other notes:
-          ${allTags.join(", ")}
-          
-          Always follow the below rules, if any, given by the user:
-          ${aiSettings.promptInstructions.tagRules}`,
-      },
-      {
-        role: "user",
-        content: `Page Title: ${noteName}\n\nPage Content:\n${noteContent}`,
-      },
-    ],
-    stream: false,
-  });
+    The following tags are currently being used by other notes:
+    ${allTags.join(", ")}
+    
+    Always follow the below rules, if any, given by the user:
+    ${aiSettings.promptInstructions.tagRules}`;
+  const userPrompt = `Page Title: ${noteName}\n\nPage Content:\n${noteContent}`;
+  const response = await currentAIProvider.singleMessageChat(
+    userPrompt,
+    systemPrompt,
+  );
   const tags = response.trim().replace(/,/g, "").split(/\s+/);
 
   // Extract current frontmatter from the note

--- a/sbai.ts
+++ b/sbai.ts
@@ -353,6 +353,15 @@ ${aiSettings.promptInstructions.pageRenameRules}`,
 }
 
 /**
+ * Enhances the current note by running the commands to generate tags for a note,
+ * and a new name.
+ */
+export async function enhanceNoteWithAI() {
+  await tagNoteWithAI();
+  await suggestPageName();
+}
+
+/**
  * Streams a conversation with the LLM, inserting the responses at the cursor position as it is received.
  */
 export async function streamOpenAIWithSelectionAsPrompt() {

--- a/sbai.ts
+++ b/sbai.ts
@@ -434,7 +434,7 @@ ${aiSettings.promptInstructions.enhanceFrontMatterPrompt}`,
 
 /**
  * Enhances the current note by running the commands to generate tags for a note,
- * and a new name.
+ * generate new frontmatter attributes, and a new note name.
  */
 export async function enhanceNoteWithAI() {
   await tagNoteWithAI();

--- a/silverbullet-ai.plug.yaml
+++ b/silverbullet-ai.plug.yaml
@@ -50,6 +50,10 @@ functions:
     path: sbai.ts:suggestPageName
     command:
       name: "AI: Suggest Page Name"
+  enhanceNoteFrontMatter:
+    path: sbai.ts:enhanceNoteFrontMatter
+    command:
+      name: "AI: Generate Note FrontMatter"
   enhanceNoteWithAI:
     path: sbai.ts:enhanceNoteWithAI
     command:

--- a/silverbullet-ai.plug.yaml
+++ b/silverbullet-ai.plug.yaml
@@ -50,6 +50,10 @@ functions:
     path: sbai.ts:suggestPageName
     command:
       name: "AI: Suggest Page Name"
+  enhanceNoteWithAI:
+    path: sbai.ts:enhanceNoteWithAI
+    command:
+      name: "AI: Enhance Note"
   selectTextModel:
     path: sbai.ts:selectModelFromConfig
     command:

--- a/src/embeddings.ts
+++ b/src/embeddings.ts
@@ -35,6 +35,7 @@ export async function indexEmbeddings({ name: page, tree }: IndexTreeEvent) {
     !aiSettings.indexEmbeddings ||
     excludePages.includes(page) ||
     page.startsWith("_") ||
+    page.startsWith("Library/") ||
     /\.conflicted\.\d+$/.test(page)
   ) {
     return;

--- a/src/init.ts
+++ b/src/init.ts
@@ -307,6 +307,7 @@ async function loadAndMergeSettings() {
     pageRenameRules: "",
     tagRules: "",
     indexSummaryPrompt: "",
+    enhanceFrontMatterPrompt: "",
   };
   const newSettings = await readSetting("ai", {});
   const newCombinedSettings = { ...defaultSettings, ...newSettings };

--- a/src/interfaces/Provider.ts
+++ b/src/interfaces/Provider.ts
@@ -1,6 +1,7 @@
 import { editor } from "$sb/syscalls.ts";
 import { getPageLength } from "../editorUtils.ts";
 import { ChatMessage, StreamChatOptions } from "../types.ts";
+import { enrichChatMessages } from "../utils.ts";
 
 export interface ProviderInterface {
   name: string;
@@ -15,6 +16,7 @@ export interface ProviderInterface {
   singleMessageChat: (
     userMessage: string,
     systemPrompt?: string,
+    enrichMessages?: boolean,
   ) => Promise<string>;
 }
 
@@ -87,8 +89,9 @@ export abstract class AbstractProvider implements ProviderInterface {
   async singleMessageChat(
     userMessage: string,
     systemPrompt?: string,
+    enrichMessages: boolean = false,
   ): Promise<string> {
-    const messages: ChatMessage[] = [
+    let messages: ChatMessage[] = [
       {
         role: "user",
         content: userMessage,
@@ -100,6 +103,10 @@ export abstract class AbstractProvider implements ProviderInterface {
         role: "system",
         content: systemPrompt,
       });
+    }
+
+    if (enrichMessages) {
+      messages = await enrichChatMessages(messages);
     }
 
     return await this.chatWithAI({

--- a/src/types.ts
+++ b/src/types.ts
@@ -88,6 +88,7 @@ export type PromptInstructions = {
   pageRenameRules: string;
   tagRules: string;
   indexSummaryPrompt: string;
+  enhanceFrontMatterPrompt: string;
 };
 
 export type AISettings = {


### PR DESCRIPTION
From a suggestion here:

https://community.silverbullet.md/t/thoughts-on-applications-of-ai-or-smarts-in-silverbullet/559/8

`AI: Enhance Note` should work as expected, but `AI: Generate Note Frontmatter` is a little finicky right now.  The llm returns a lot of probably useless suggestions.

I think an enhancement would probably be to get a list of all frontmatter attributes from existing notes and provide it.  There is an option to override the system prompt to add your own rules though, like "If a note is tagged with person, ONLY set the age and location attributes."