### PR TITLE
Improve AI Search page and prevent timeouts

### DIFF
--- a/docs/Changelog.md
+++ b/docs/Changelog.md
@@ -7,7 +7,11 @@ This page is a brief overview of each version.
 - Don't index and generate embeddings for pages in Library/
 - Add new `AI: Enhance Note` command to call existing `AI: Tag Note` and `AI: Suggest Page Name` commands on a note, and the new frontmatter command
 - Add new `AI: Generate Note FrontMatter` command to extract useful facts from a note and add them to the frontmatter
-- Always include the note’s current name in [[Commands/AI: Suggest Page Name]] as an option.
+- Always include the note’s current name in [[Commands/AI: Suggest Page Name]] as an option
+- Log how long it takes to index each page when generating embeddings
+- Improve the layout and UX of the `AI: Search` page
+- Fix the `AI: Search` page so it works in sync/online mode
+- Fix bug preventing changing models in sync mode
 
 ---
 ## 0.2.0

--- a/docs/Configuration.md
+++ b/docs/Configuration.md
@@ -42,6 +42,9 @@ ai:
   chat:
     # If bakeMessages is true, SilverBullet query and template blocks are rendered before sending
     bakeMessages: true
+    # If searchEmbeddings is true, the Chat command will search indexed embeddings and provide relevant pages as context.
+    searchEmbeddings: true
+    # When using chat, the userInformation and userInstructions included in the system prompt.
     userInformation: >
       I'm a software developer who likes taking notes.
     userInstructions: >

--- a/scripts/update-readme.ts
+++ b/scripts/update-readme.ts
@@ -57,10 +57,14 @@ async function updateReadme(tag: string) {
         if (error instanceof Deno.errors.NotFound) {
           // Command doc does not exist, create a new one
           if (docs) {
+            const sanitizedDocs = docs.replace(/\\/g, "\\\\").replace(
+              /"/g,
+              '\\"',
+            );
             const commandDocsContent = `---
 tags: commands
 commandName: "${value.command.name}"
-commandSummary: "${docs.replace(/"/g, '\\"')}"
+commandSummary: "${sanitizedDocs}"
 ---`;
             await Deno.writeTextFile(commandDocsPath, commandDocsContent);
           }

--- a/src/embeddings.ts
+++ b/src/embeddings.ts
@@ -54,6 +54,8 @@ export async function indexEmbeddings({ name: page, tree }: IndexTreeEvent) {
 
   const objects: EmbeddingObject[] = [];
 
+  const startTime = Date.now();
+
   for (const paragraph of paragraphs) {
     const paragraphText = renderToText(paragraph).trim();
 
@@ -93,9 +95,12 @@ export async function indexEmbeddings({ name: page, tree }: IndexTreeEvent) {
 
   await indexObjects<EmbeddingObject>(page, objects);
 
+  const endTime = Date.now();
+  const duration = (endTime - startTime) / 1000;
+
   log(
     "any",
-    `AI: Indexed ${objects.length} embedding objects for page ${page}`,
+    `AI: Indexed ${objects.length} embedding objects for page ${page} in ${duration} seconds`,
   );
 }
 

--- a/src/init.ts
+++ b/src/init.ts
@@ -43,7 +43,7 @@ export async function initIfNeeded() {
 }
 
 export async function getSelectedTextModel() {
-  if (await system.getEnv() != "client") {
+  if (await system.getEnv() == "server") {
     // We can't use clientStore in the server process
     return undefined;
   }
@@ -57,7 +57,7 @@ export async function getSelectedTextModel() {
 }
 
 export async function getSelectedImageModel() {
-  if (await system.getEnv() != "client") {
+  if (await system.getEnv() == "server") {
     // We can't use clientStore in the server process
     return undefined;
   }
@@ -71,7 +71,7 @@ export async function getSelectedImageModel() {
 }
 
 export async function getSelectedEmbeddingModel() {
-  if (await system.getEnv() != "client") {
+  if (await system.getEnv() == "server") {
     // We can't use clientStore in the server process
     return;
   }
@@ -85,7 +85,7 @@ export async function getSelectedEmbeddingModel() {
 }
 
 export async function setSelectedImageModel(model: ImageModelConfig) {
-  if (await system.getEnv() != "client") {
+  if (await system.getEnv() == "server") {
     // We can't use clientStore in the server process
     return;
   }
@@ -93,7 +93,7 @@ export async function setSelectedImageModel(model: ImageModelConfig) {
 }
 
 export async function setSelectedTextModel(model: ModelConfig) {
-  if (await system.getEnv() != "client") {
+  if (await system.getEnv() == "server") {
     // We can't use clientStore in the server process
     return;
   }
@@ -101,7 +101,7 @@ export async function setSelectedTextModel(model: ModelConfig) {
 }
 
 export async function setSelectedEmbeddingModel(model: EmbeddingModelConfig) {
-  if (await system.getEnv() != "client") {
+  if (await system.getEnv() == "server") {
     // We can't use clientStore in the server process
     return;
   }


### PR DESCRIPTION
Related to #47 

- queryObjects happens only on the server
- processing of the returned embeddings happens wherever depending on sync mode
- results page is updated with the current progress in case there are a lot of embeddings, or searching is slow
