### PR TITLE
Use a separate queue for indexing embeddings and summaries, to prevent blocking the main SB indexing thread

### DIFF
--- a/silverbullet-ai.plug.yaml
+++ b/silverbullet-ai.plug.yaml
@@ -81,16 +81,25 @@ functions:
   searchEmbeddings:
     path: src/embeddings.ts:searchEmbeddings
     env: server
-  indexEmbeddings:
-    path: src/embeddings.ts:indexEmbeddings
+  queueEmbeddingGeneration:
+    path: src/embeddings.ts:queueEmbeddingGeneration
     env: server
     events:
       - page:index
-  indexSummaryEmbeddings:
-    path: src/embeddings.ts:indexSummary
-    env: server
-    events:
-      - page:index
+  processEmbeddingsQueue:
+    path: src/embeddings.ts:processEmbeddingsQueue
+    mqSubscriptions:
+    - queue: aiEmbeddingsQueue
+      batchSize: 1
+      autoAck: true
+      pollInterval: 600000
+  processSummaryQueue:
+    path: src/embeddings.ts:processSummaryQueue
+    mqSubscriptions:
+    - queue: aiSummaryQueue
+      batchSize: 1
+      autoAck: true
+      pollInterval: 600000
   generateEmbeddings:
     path: src/embeddings.ts:generateEmbeddings
   generateEmbeddingsOnServer:


### PR DESCRIPTION
related: https://github.com/silverbulletmd/silverbullet/issues/1021

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
    - Introduced queuing mechanisms for embedding and summary indexing, enhancing performance.
    - Simplified function signatures for indexing embeddings and summaries.
  
- **Bug Fixes**
    - Improved logging for the indexing process, providing clear insights into execution duration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->