### PR TITLE
Add support for Space Config

### DIFF
--- a/docs/Changelog.md
+++ b/docs/Changelog.md
@@ -7,6 +7,7 @@ This page is a brief overview of each version.
 - Use a separate queue for indexing embeddings and summaries, to prevent blocking the main SB indexing thread
 - Refactor to use JSR for most Silverbullet imports, and lots of related changes
 - Reduced bundle size
+- Add support for [space-config](https://silverbullet.md/Space%20Config)
 
 ---
 ## 0.3.2

--- a/sbai.ts
+++ b/sbai.ts
@@ -44,11 +44,19 @@ import {
  * This should prevent us from having to reload or refresh when changing the settings.
  * TODO: This gets triggered when other settings are changed too, but shouldn't make a difference
  *       when there are no changes to the objects we care about.
+ * TODO: Remove after space-config has been around for a while
  */
-export async function reloadConfig(pageName: string) {
+export async function reloadSettingsPage(pageName: string) {
   if (pageName === "SETTINGS" || pageName === "SECRETS") {
     await initializeOpenAI(true);
   }
+}
+
+/**
+ * Similar to the above function, but meant for the config:loaded event.
+ */
+export async function reloadConfig() {
+  await initializeOpenAI(true);
 }
 
 /**

--- a/silverbullet-ai.plug.js
+++ b/silverbullet-ai.plug.js
@@ -1,170 +1,5815 @@
-var Z0=Object.defineProperty;var gt=(e,t)=>{for(var i in t)Z0(e,i,{get:t[i],enumerable:!0})};var lo=typeof window>"u"&&typeof globalThis.WebSocketPair>"u";typeof Deno>"u"&&(self.Deno={args:[],build:{arch:"x86_64"},env:{get(){}}});var ao=new Map,oo=0;function hn(e){self.postMessage(e)}lo&&(globalThis.syscall=async(e,...t)=>await new Promise((i,r)=>{oo++,ao.set(oo,{resolve:i,reject:r}),hn({type:"sys",id:oo,name:e,args:t})}));function Lh(e,t){lo&&(self.addEventListener("message",i=>{(async()=>{let r=i.data;switch(r.type){case"inv":{let n=e[r.name];if(!n)throw new Error(`Function not loaded: ${r.name}`);try{let s=await Promise.resolve(n(...r.args||[]));hn({type:"invr",id:r.id,result:s})}catch(s){console.error("An exception was thrown as a result of invoking function",r.name,"error:",s.message),hn({type:"invr",id:r.id,error:s.message})}}break;case"sysr":{let n=r.id,s=ao.get(n);if(!s)throw Error("Invalid request id");ao.delete(n),r.error?s.reject(new Error(r.error)):s.resolve(r.result)}break}})().catch(console.error)}),hn({type:"manifest",manifest:t}))}function E0(e){let t=atob(e),i=t.length,r=new Uint8Array(i);for(let n=0;n<i;n++)r[n]=t.charCodeAt(n);return r}function Vh(e){typeof e=="string"&&(e=new TextEncoder().encode(e));let t="",i=e.byteLength;for(let r=0;r<i;r++)t+=String.fromCharCode(e[r]);return btoa(t)}async function R0(e,t){if(typeof e!="string"){let i=new Uint8Array(await e.arrayBuffer()),r=i.length>0?Vh(i):void 0;t={method:e.method,headers:Object.fromEntries(e.headers.entries()),base64Body:r},e=e.url}return syscall("sandboxFetch.fetch",e,t)}globalThis.nativeFetch=globalThis.fetch;function X0(){globalThis.fetch=async function(e,t){let i=t&&t.body?Vh(new Uint8Array(await new Response(t.body).arrayBuffer())):void 0,r=await R0(e,t&&{method:t.method,headers:t.headers,base64Body:i});return new Response(r.base64Body?E0(r.base64Body):null,{status:r.status,headers:r.headers})}}lo&&X0();function ho(e){if(e.children)for(let t of e.children){if(t.parent)return;t.parent=e,ho(t)}}function M0(e,t){return cn(e,i=>i.type===t)}function cn(e,t){if(t(e))return[e];let i=[];if(e.children)for(let r of e.children)i=[...i,...cn(r,t)];return i}async function Nh(e,t){if(await t(e))return[e];let i=[];if(e.children)for(let r of e.children)i=[...i,...await Nh(r,t)];return i}function co(e,t){if(e.children){let i=e.children.slice();for(let r of i){let n=t(r);if(n!==void 0){let s=e.children.indexOf(r);n?e.children.splice(s,1,n):e.children.splice(s,1)}else co(r,t)}}}async function ar(e,t){if(e.children){let i=e.children.slice();for(let r of i){let n=await t(r);if(n!==void 0){let s=e.children.indexOf(r);n?e.children.splice(s,1,n):e.children.splice(s,1)}else await ar(r,t)}}}function ot(e,t){return cn(e,i=>i.type===t)[0]}function uo(e,t){cn(e,t)}async function jh(e,t){await Nh(e,t)}function be(e){if(!e)return"";let t=[];if(e.text!==void 0)return e.text;for(let i of e.children)t.push(be(i));return t.join("")}function fo(e,t=!0){if(M0(e,"\u26A0").length>0)throw new Error(`Parse error in: ${be(e)}`);if(e.text!==void 0)return e.text;let r=[e.type];for(let n of e.children)n.type&&!n.type.endsWith("Mark")&&r.push(fo(n,t)),n.text&&(t&&n.text.trim()||!t)&&r.push(n.text);return r}function W0(e){return e.getUTCHours()===0&&e.getUTCMinutes()===0&&e.getUTCSeconds()===0?e.getFullYear()+"-"+String(e.getMonth()+1).padStart(2,"0")+"-"+String(e.getDate()).padStart(2,"0"):e.toISOString()}function $i(e){if(!e||typeof e!="object")return e;if(Array.isArray(e))return e.map($i);if(e instanceof Date)return W0(e);let t={};for(let i of Object.keys(e)){let r=i.split("."),n=t;for(let s=0;s<r.length-1;s++){let o=r[s];n[o]||(n[o]={}),n=n[o]}n[r[r.length-1]]=$i(e[i])}return t}var x={};gt(x,{confirm:()=>uy,copyToClipboard:()=>xy,deleteLine:()=>Py,dispatch:()=>hy,downloadFile:()=>J0,filterBox:()=>iy,flashNotification:()=>ty,fold:()=>Oy,foldAll:()=>yy,getCurrentPage:()=>q0,getCursor:()=>V0,getSelection:()=>N0,getText:()=>I0,getUiOption:()=>dy,goHistory:()=>K0,hidePanel:()=>ny,insertAtCursor:()=>ly,insertAtPos:()=>sy,moveCursor:()=>ay,navigate:()=>_0,openCommandPalette:()=>z0,openPageNavigator:()=>U0,openSearchPanel:()=>Sy,openUrl:()=>H0,prompt:()=>cy,redo:()=>vy,reloadPage:()=>B0,reloadSettingsAndCommands:()=>F0,reloadUI:()=>G0,replaceRange:()=>oy,save:()=>D0,setPage:()=>Y0,setSelection:()=>j0,setText:()=>L0,setUiOption:()=>fy,showPanel:()=>ry,toggleFold:()=>gy,undo:()=>wy,unfold:()=>my,unfoldAll:()=>by,uploadFile:()=>ey,vimEx:()=>py});typeof self>"u"&&(self={syscall:()=>{throw new Error("Not implemented here")}});var v=globalThis.syscall;function q0(){return v("editor.getCurrentPage")}function Y0(e){return v("editor.setPage",e)}function I0(){return v("editor.getText")}function L0(e){return v("editor.setText",e)}function V0(){return v("editor.getCursor")}function N0(){return v("editor.getSelection")}function j0(e,t){return v("editor.setSelection",e,t)}function D0(){return v("editor.save")}function _0(e,t=!1,i=!1){return v("editor.navigate",e,t,i)}function U0(e="page"){return v("editor.openPageNavigator",e)}function z0(){return v("editor.openCommandPalette")}function B0(){return v("editor.reloadPage")}function G0(){return v("editor.reloadUI")}function F0(){return v("editor.reloadSettingsAndCommands")}function H0(e,t=!1){return v("editor.openUrl",e,t)}function K0(e){return v("editor.goHistory",e)}function J0(e,t){return v("editor.downloadFile",e,t)}function ey(e,t){return v("editor.uploadFile",e,t)}function ty(e,t="info"){return v("editor.flashNotification",e,t)}function iy(e,t,i="",r=""){return v("editor.filterBox",e,t,i,r)}function ry(e,t,i,r=""){return v("editor.showPanel",e,t,i,r)}function ny(e){return v("editor.hidePanel",e)}function sy(e,t){return v("editor.insertAtPos",e,t)}function oy(e,t,i){return v("editor.replaceRange",e,t,i)}function ay(e,t=!1){return v("editor.moveCursor",e,t)}function ly(e){return v("editor.insertAtCursor",e)}function hy(e){return v("editor.dispatch",e)}function cy(e,t=""){return v("editor.prompt",e,t)}function uy(e){return v("editor.confirm",e)}function dy(e){return v("editor.getUiOption",e)}function fy(e,t){return v("editor.setUiOption",e,t)}function py(e){return v("editor.vimEx",e)}function Oy(){return v("editor.fold")}function my(){return v("editor.unfold")}function gy(){return v("editor.toggleFold")}function yy(){return v("editor.foldAll")}function by(){return v("editor.unfoldAll")}function wy(){return v("editor.undo")}function vy(){return v("editor.redo")}function Sy(){return v("editor.openSearchPanel")}function xy(e){return v("editor.copyToClipboard",e)}function Py(){return v("editor.deleteLine")}var Oe={};gt(Oe,{parseMarkdown:()=>ky});function ky(e){return v("markdown.parseMarkdown",e)}var me={};gt(me,{deleteAttachment:()=>Wy,deleteFile:()=>Vy,deletePage:()=>Ay,getAttachmentMeta:()=>Ry,getFileMeta:()=>Iy,getPageMeta:()=>$y,listAttachments:()=>Ey,listFiles:()=>qy,listPages:()=>Qy,listPlugs:()=>Zy,readAttachment:()=>Xy,readFile:()=>Yy,readPage:()=>Ty,writeAttachment:()=>My,writeFile:()=>Ly,writePage:()=>Cy});function Qy(e=!1){return v("space.listPages",e)}function $y(e){return v("space.getPageMeta",e)}function Ty(e){return v("space.readPage",e)}function Cy(e,t){return v("space.writePage",e,t)}function Ay(e){return v("space.deletePage",e)}function Zy(){return v("space.listPlugs")}function Ey(){return v("space.listAttachments")}function Ry(e){return v("space.getAttachmentMeta",e)}function Xy(e){return v("space.readAttachment",e)}function My(e,t){return v("space.writeAttachment",e,t)}function Wy(e){return v("space.deleteAttachment",e)}function qy(){return v("space.listFiles")}function Yy(e){return v("space.readFile",e)}function Iy(e){return v("space.getFileMeta",e)}function Ly(e,t){return v("space.writeFile",e,t)}function Vy(e){return v("space.deleteFile",e)}var K={};gt(K,{applyAttributeExtractors:()=>zy,getEnv:()=>Gy,getMode:()=>Fy,getVersion:()=>Hy,invokeCommand:()=>jy,invokeFunction:()=>Ny,invokeSpaceFunction:()=>Uy,listCommands:()=>Dy,listSyscalls:()=>_y,reloadPlugs:()=>By});function Ny(e,...t){return v("system.invokeFunction",e,...t)}function jy(e,t){return v("system.invokeCommand",e,t)}function Dy(){return v("system.listCommands")}function _y(){return v("system.listSyscalls")}function Uy(e,...t){return v("system.invokeSpaceFunction",e,...t)}function zy(e,t,i){return v("system.applyAttributeExtractors",e,t,i)}function By(){return v("system.reloadPlugs")}function Gy(){return v("system.getEnv")}function Fy(){return v("system.getMode")}function Hy(){return v("system.getVersion")}var Ct={};gt(Ct,{del:()=>e1,get:()=>Jy,set:()=>Ky});function Ky(e,t){return v("clientStore.set",e,t)}function Jy(e){return v("clientStore.get",e)}function e1(e){return v("clientStore.delete",e)}var un={};gt(un,{listLanguages:()=>n1,parseLanguage:()=>r1});function r1(e,t){return v("language.parseLanguage",e,t)}function n1(){return v("language.listLanguages")}var Ti={};gt(Ti,{parseTemplate:()=>o1,renderTemplate:()=>s1});function s1(e,t,i={}){return v("template.renderTemplate",e,t,i)}function o1(e){return v("template.parseTemplate",e)}var li={};gt(li,{dispatchEvent:()=>h1,listEvents:()=>c1});function h1(e,t,i){return new Promise((r,n)=>{let s=-1;i&&(s=setTimeout(()=>{console.log("Timeout!"),n("timeout")},i)),v("event.dispatch",e,t).then(o=>{s!==-1&&clearTimeout(s),r(o)}).catch(n)})}function c1(){return v("event.list")}var ke={};gt(ke,{parse:()=>d1,stringify:()=>f1});function d1(e){return v("yaml.parse",e)}function f1(e){return v("yaml.stringify",e)}var hi={};gt(hi,{ack:()=>m1,batchAck:()=>g1,batchSend:()=>O1,getQueueStats:()=>y1,send:()=>p1});function p1(e,t){return v("mq.send",e,t)}function O1(e,t){return v("mq.batchSend",e,t)}function m1(e,t){return v("mq.ack",e,t)}function g1(e,t){return v("mq.batchAck",e,t)}function y1(e){return v("mq.getQueueStats",e)}async function At(e,t={}){let i={tags:[]},r=[];ho(e),await ar(e,async n=>{if(n.type==="Paragraph"&&n.parent?.type==="Document"){let s=!0,o=new Set;for(let a of n.children)if(a.text){if(a.text.startsWith(`
-`)&&a.text!==`
-`)break;if(a.text.trim()){s=!1;break}}else if(a.type==="Hashtag"){let l=a.children[0].text.substring(1);o.add(l),(t.removeTags===!0||t.removeTags?.includes(l))&&(a.children[0].text="")}else if(a.type){s=!1;break}s&&r.push(...o)}if(n.type==="FrontMatter"){let s=n.children[1].children[0],o=be(s);try{let a=await ke.parse(o),l={...a};if(i={...i,...a},i.tags||(i.tags=[]),typeof i.tags=="string"&&r.push(...i.tags.split(/,\s*|\s+/)),Array.isArray(i.tags)&&r.push(...i.tags),t.removeKeys&&t.removeKeys.length>0){let h=!1;for(let c of t.removeKeys)c in l&&(delete l[c],h=!0);h&&(s.text=await ke.stringify(l))}if(Object.keys(l).length===0||t.removeFrontmatterSection)return null}catch(a){console.warn("Could not parse frontmatter",a.message)}}});try{i.tags=[...new Set([...r.map(n=>String(n).replace(/^#/,""))])]}catch(n){console.error("Error while processing tags",n)}return i=$i(i),i}async function po(e,t){let i=null;if(await jh(e,async r=>{if(r.type==="FrontMatter"){let n=r.children[1].children[0],s=be(n);try{let o="";if(typeof t=="string")o=s+t+`
-`;else{let l={...await ke.parse(s),...t};o=await ke.stringify(l)}i={changes:{from:n.from,to:n.to,insert:o}}}catch(o){console.error("Error parsing YAML",o)}return!0}return!1}),!i){let r="";typeof t=="string"?r=t+`
-`:r=await ke.stringify(t),i={changes:{from:0,to:0,insert:`---
-`+r+`---
-`}}}return i}var dn=class{constructor(t,i={}){this.maxSize=t;this.map=new Map(Object.entries(i))}map;set(t,i,r){let n={value:i,la:Date.now()};if(r){let s=this.map.get(t);s?.expTimer&&clearTimeout(s.expTimer),n.expTimer=setTimeout(()=>{this.map.delete(t)},r)}if(this.map.size>=this.maxSize){let s=this.getOldestKey();this.map.delete(s)}this.map.set(t,n)}get(t){let i=this.map.get(t);if(i)return i.la=Date.now(),i.value}remove(t){this.map.delete(t)}toJSON(){return Object.fromEntries(this.map.entries())}getOldestKey(){let t,i;for(let[r,n]of this.map.entries())(!i||n.la<i)&&(t=r,i=n.la);return t}};var Dh=new dn(50);async function _h(e,t,i){if(!i)return t(e);let r=JSON.stringify(e),n=Dh.get(r);if(n)return n;let s=await t(e);return Dh.set(r,s,i*1e3),s}function Oo(e,t){return K.invokeFunction("index.indexObjects",e,t)}function Ci(e,t,i){return _h(t,()=>K.invokeFunction("index.queryObjects",e,t),i)}async function fn(e,t={},i={}){try{let r=await Oe.parseMarkdown(e),n=await At(r,{removeFrontmatterSection:!0,removeTags:["template"]});e=be(r).trimStart();let s;return n.frontmatter&&(typeof n.frontmatter=="string"?s=n.frontmatter:s=await ke.stringify(n.frontmatter),s=await Ti.renderTemplate(s,t,i)),{frontmatter:n,renderedFrontmatter:s,text:await Ti.renderTemplate(e,t,i)}}catch(r){throw console.error("Error rendering template",r),r}}async function w1(){let e=await x.getSelection(),t="";return e.from===e.to?t="":t=(await x.getText()).slice(e.from,e.to),{from:e.from,to:e.to,text:t}}async function pn(){let e=await w1(),t=await x.getText();if(e.text==="")return{from:0,to:t.length,text:t,isWholeNote:!0};let i=e.from===0&&e.to===t.length;return{...e,isWholeNote:i}}async function ci(){return(await x.getText()).length}async function v1(e,t){let i=await me.readPage(e),r=await Oe.parseMarkdown(i),n;return uo(r,s=>{if(s.type!=="FencedCode")return!1;let o=ot(s,"CodeInfo");if(t&&!o||t&&!t.includes(o.children[0].text))return!1;let a=ot(s,"CodeText");return a?(n=a.children[0].text,!0):!1}),n}async function On(e,t=["yaml"]){let i=await v1(e,t);if(i!==void 0)try{return ke.parse(i)}catch(r){throw console.error("YAML Page parser error",r),new Error(`YAML Error: ${r.message}`)}}async function mn(e){try{let i=(await On("SECRETS",["yaml","secrets"]))[e];if(i===void 0)throw new Error(`No such secret: ${e}`);return i}catch(t){throw t.message==="Not found"?new Error(`No such secret: ${e}`):t}}var S1="SETTINGS";async function Uh(e,t){try{let r=(await On(S1,["yaml"])||{})[e];return r===void 0?t:r}catch(i){if(i.message==="Not found")return t;throw i}}var Ai=class{apiKey;baseUrl;name;modelName;requireAuth;constructor(t,i,r,n,s=!0){this.apiKey=t,this.baseUrl=i,this.name=r,this.modelName=n,this.requireAuth=s}};var gn=class extends Ai{constructor(t,i,r){super(t,r,"DALL-E",i)}async generateImage(t){try{oe||await Nt();let i=await nativeFetch(`${this.baseUrl}/images/generations`,{method:"POST",headers:{Authorization:`Bearer ${this.apiKey}`,"Content-Type":"application/json"},body:JSON.stringify({model:this.modelName,prompt:t.prompt,n:t.numImages,size:t.size,quality:t.quality,response_format:"b64_json"})});if(!i.ok)throw new Error(`HTTP error, status: ${i.status}`);let r=await i.json();if(!r||r.length===0)throw new Error("Invalid response from DALL-E.");return r}catch(i){throw console.error("Error calling DALL\xB7E image generation endpoint:",i),i}}};var ui=function(e,t){if(!(this instanceof ui))return new ui(e,t);this.INITIALIZING=-1,this.CONNECTING=0,this.OPEN=1,this.CLOSED=2,this.url=e,t=t||{},this.headers=t.headers||{},this.payload=t.payload!==void 0?t.payload:"",this.method=t.method||this.payload&&"POST"||"GET",this.withCredentials=!!t.withCredentials,this.debug=!!t.debug,this.FIELD_SEPARATOR=":",this.listeners={},this.xhr=null,this.readyState=this.INITIALIZING,this.progress=0,this.chunk="",this.addEventListener=function(i,r){this.listeners[i]===void 0&&(this.listeners[i]=[]),this.listeners[i].indexOf(r)===-1&&this.listeners[i].push(r)},this.removeEventListener=function(i,r){if(this.listeners[i]!==void 0){var n=[];this.listeners[i].forEach(function(s){s!==r&&n.push(s)}),n.length===0?delete this.listeners[i]:this.listeners[i]=n}},this.dispatchEvent=function(i){if(!i)return!0;this.debug&&console.debug(i),i.source=this;var r="on"+i.type;return this.hasOwnProperty(r)&&(this[r].call(this,i),i.defaultPrevented)?!1:this.listeners[i.type]?this.listeners[i.type].every(function(n){return n(i),!i.defaultPrevented}):!0},this._setReadyState=function(i){var r=new CustomEvent("readystatechange");r.readyState=i,this.readyState=i,this.dispatchEvent(r)},this._onStreamFailure=function(i){var r=new CustomEvent("error");r.data=i.currentTarget.response,this.dispatchEvent(r),this.close()},this._onStreamAbort=function(i){this.dispatchEvent(new CustomEvent("abort")),this.close()},this._onStreamProgress=function(i){if(this.xhr){if(this.xhr.status!==200){this._onStreamFailure(i);return}this.readyState==this.CONNECTING&&(this.dispatchEvent(new CustomEvent("open")),this._setReadyState(this.OPEN));var r=this.xhr.responseText.substring(this.progress);this.progress+=r.length;var n=(this.chunk+r).split(/(\r\n\r\n|\r\r|\n\n)/g),s=n.pop();n.forEach(function(o){o.trim().length>0&&this.dispatchEvent(this._parseEventChunk(o))}.bind(this)),this.chunk=s}},this._onStreamLoaded=function(i){this._onStreamProgress(i),this.dispatchEvent(this._parseEventChunk(this.chunk)),this.chunk=""},this._parseEventChunk=function(i){if(!i||i.length===0)return null;this.debug&&console.debug(i);var r={id:null,retry:null,data:null,event:null};i.split(/\n|\r\n|\r/).forEach(function(s){var o=s.indexOf(this.FIELD_SEPARATOR),a,l;if(o>0){var h=s[o+1]===" "?2:1;a=s.substring(0,o),l=s.substring(o+h)}else if(o<0)a=s,l="";else return;a in r&&(a==="data"&&r[a]!==null?r.data+=`
-`+l:r[a]=l)}.bind(this));var n=new CustomEvent(r.event||"message");return n.data=r.data||"",n.id=r.id,n},this._checkStreamClosed=function(){this.xhr&&this.xhr.readyState===XMLHttpRequest.DONE&&this._setReadyState(this.CLOSED)},this.stream=function(){if(!this.xhr){this._setReadyState(this.CONNECTING),this.xhr=new XMLHttpRequest,this.xhr.addEventListener("progress",this._onStreamProgress.bind(this)),this.xhr.addEventListener("load",this._onStreamLoaded.bind(this)),this.xhr.addEventListener("readystatechange",this._checkStreamClosed.bind(this)),this.xhr.addEventListener("error",this._onStreamFailure.bind(this)),this.xhr.addEventListener("abort",this._onStreamAbort.bind(this)),this.xhr.open(this.method,this.url);for(var i in this.headers)this.xhr.setRequestHeader(i,this.headers[i]);this.xhr.withCredentials=this.withCredentials,this.xhr.send(this.payload)}},this.close=function(){this.readyState!==this.CLOSED&&(this.xhr.abort(),this.xhr=null,this._setReadyState(this.CLOSED))},(t.start===void 0||t.start)&&this.stream()};typeof exports<"u"&&(exports.SSE=ui);var zh={};function yn(e,t){zh[e]=t}function bn(e){return zh[e]}async function wn(...e){let t=e.join(""),i=new TextEncoder().encode(t),r=await crypto.subtle.digest("SHA-256",i);return Array.from(new Uint8Array(r)).map(o=>o.toString(16).padStart(2,"0")).join("")}var yt=class{apiKey;baseUrl;name;modelName;requireAuth;constructor(t,i,r,n,s=!0){this.apiKey=t,this.baseUrl=i,this.name=r,this.modelName=n,this.requireAuth=s}async generateEmbeddings(t){let i=await wn(this.modelName,t.text),r=bn(i);if(r)return r;let n=await this._generateEmbeddings(t);return yn(i,n),n}};var Gh=/@(\d+)$/,Fh=/\$([a-zA-Z\.\-\/]+[\w\.\-\/]*)$/,Hh=/#([^#]*)$/;function Kh(e){e.startsWith("[[")&&e.endsWith("]]")&&(e=e.slice(2,-2));let t={page:e},i=t.page.match(Gh);i&&(t.pos=parseInt(i[1]),t.page=t.page.replace(Gh,""));let r=t.page.match(Fh);r&&(t.anchor=r[1],t.page=t.page.replace(Fh,""));let n=t.page.match(Hh);return n&&(t.header=n[1],t.page=t.page.replace(Hh,"")),t}function Jh(e){return co(e,t=>{switch(t.type){case"FrontMatter":return null;case"WikiLink":{let i=ot(t,"WikiLinkPage").children[0].text,r=i.split("/").pop(),n=ot(t,"WikiLinkAlias");n&&(r=n.children[0].text);let s=Kh(i);return{text:`[${r}](${typeof location<"u"?location.origin:""}/${encodeURI(s.page)})`}}case"NamedAnchor":return null;case"CommandLink":{let r=t.children[1].children[0].text,n=ot(t,"CommandLinkAlias");return n&&(r=n.children[0].text),{text:"`"+r+"`"}}case"Attribute":return null}}),e}async function ec(e,t,i){let r={};await ar(t,async o=>{if(o.type==="ListItem")return o;if(o.type==="Attribute"){let a=ot(o,"AttributeName"),l=ot(o,"AttributeValue");if(a&&l){let h=a.children[0].text,c=l.children[0].text;try{r[h]=$i(await ke.parse(c))}catch(u){console.error("Error parsing attribute value as YAML",c,u)}}return i?null:o}});let n=be(t),s=await K.applyAttributeExtractors(e,n,t);return r={...r,...s},r}function tc(e,t,i=0){let r=[],n,s=t.firstChild;for(;s;)r.push(tc(e,s)),s=s.nextSibling;if(r.length===0)r=[{from:t.from+i,to:t.to+i,text:e.substring(t.from,t.to)}];else{let a=[],l=t.from;for(let c of r){let u=e.substring(l,c.from);u&&a.push({from:l+i,to:c.from+i,text:u}),a.push(c),l=c.to}let h=e.substring(l,t.to);h&&a.push({from:l+i,to:t.to+i,text:h}),r=a}let o={type:t.name,from:t.from+i,to:t.to+i};return r.length>0&&(o.children=r),n&&(o.text=n),o}function ic(e,t){return t=t.replaceAll("\r",""),tc(t,e.parser.parse(t).topNode)}var rc=/^\{\[([^\]\|]+)(\|([^\]]+))?\](\(([^\)]+)\))?\}/;var x1=["true","false","on","off","yes","no"],P1=new RegExp("\\b(("+x1.join(")|(")+"))$","i"),nc={name:"yaml",token:function(e,t){var i=e.peek(),r=t.escaped;if(t.escaped=!1,i=="#"&&(e.pos==0||/\s/.test(e.string.charAt(e.pos-1))))return e.skipToEnd(),"comment";if(e.match(/^('([^']|\\.)*'?|"([^"]|\\.)*"?)/))return"string";if(t.literal&&e.indentation()>t.keyCol)return e.skipToEnd(),"string";if(t.literal&&(t.literal=!1),e.sol()){if(t.keyCol=0,t.pair=!1,t.pairStart=!1,e.match("---")||e.match("..."))return"def";if(e.match(/^\s*-\s+/))return"meta"}if(e.match(/^(\{|\}|\[|\])/))return i=="{"?t.inlinePairs++:i=="}"?t.inlinePairs--:i=="["?t.inlineList++:t.inlineList--,"meta";if(t.inlineList>0&&!r&&i==",")return e.next(),"meta";if(t.inlinePairs>0&&!r&&i==",")return t.keyCol=0,t.pair=!1,t.pairStart=!1,e.next(),"meta";if(t.pairStart){if(e.match(/^\s*(\||\>)\s*/))return t.literal=!0,"meta";if(e.match(/^\s*(\&|\*)[a-z0-9\._-]+\b/i))return"variable";if(t.inlinePairs==0&&e.match(/^\s*-?[0-9\.\,]+\s?$/)||t.inlinePairs>0&&e.match(/^\s*-?[0-9\.\,]+\s?(?=(,|}))/))return"number";if(e.match(P1))return"keyword"}return!t.pair&&e.match(/^\s*(?:[,\[\]{}&*!|>'"%@`][^\s'":]|[^,\[\]{}#&*!|>'"%@`])[^#]*?(?=\s*:($|\s))/)?(t.pair=!0,t.keyCol=e.indentation(),"atom"):t.pair&&e.match(/^:\s*/)?(t.pairStart=!0,"meta"):(t.pairStart=!1,t.escaped=i=="\\",e.next(),null)},startState:function(){return{pair:!1,pairStart:!1,keyCol:0,inlinePairs:0,inlineList:0,literal:!1,escaped:!1}},languageData:{commentTokens:{line:"#"}}};var pc=1024,k1=0,et=class{constructor(e,t){this.from=e,this.to=t}},M=class{constructor(e={}){this.id=k1++,this.perNode=!!e.perNode,this.deserialize=e.deserialize||(()=>{throw new Error("This node type doesn't define a deserialize function")})}add(e){if(this.perNode)throw new RangeError("Can't add per-node props to node types");return typeof e!="function"&&(e=le.match(e)),t=>{let i=e(t);return i===void 0?null:[this,i]}}};M.closedBy=new M({deserialize:e=>e.split(" ")});M.openedBy=new M({deserialize:e=>e.split(" ")});M.group=new M({deserialize:e=>e.split(" ")});M.isolate=new M({deserialize:e=>{if(e&&e!="rtl"&&e!="ltr"&&e!="auto")throw new RangeError("Invalid value for isolate: "+e);return e||"auto"}});M.contextHash=new M({perNode:!0});M.lookAhead=new M({perNode:!0});M.mounted=new M({perNode:!0});var hr=class{constructor(e,t,i){this.tree=e,this.overlay=t,this.parser=i}static get(e){return e&&e.props&&e.props[M.mounted.id]}},Q1=Object.create(null),le=class Oc{constructor(t,i,r,n=0){this.name=t,this.props=i,this.id=r,this.flags=n}static define(t){let i=t.props&&t.props.length?Object.create(null):Q1,r=(t.top?1:0)|(t.skipped?2:0)|(t.error?4:0)|(t.name==null?8:0),n=new Oc(t.name||"",i,t.id,r);if(t.props){for(let s of t.props)if(Array.isArray(s)||(s=s(n)),s){if(s[0].perNode)throw new RangeError("Can't store a per-node prop on a node type");i[s[0].id]=s[1]}}return n}prop(t){return this.props[t.id]}get isTop(){return(this.flags&1)>0}get isSkipped(){return(this.flags&2)>0}get isError(){return(this.flags&4)>0}get isAnonymous(){return(this.flags&8)>0}is(t){if(typeof t=="string"){if(this.name==t)return!0;let i=this.prop(M.group);return i?i.indexOf(t)>-1:!1}return this.id==t}static match(t){let i=Object.create(null);for(let r in t)for(let n of r.split(" "))i[n]=t[r];return r=>{for(let n=r.prop(M.group),s=-1;s<(n?n.length:0);s++){let o=i[s<0?r.name:n[s]];if(o)return o}}}};le.none=new le("",Object.create(null),0,8);var fi=class mc{constructor(t){this.types=t;for(let i=0;i<t.length;i++)if(t[i].id!=i)throw new RangeError("Node type ids should correspond to array positions when creating a node set")}extend(...t){let i=[];for(let r of this.types){let n=null;for(let s of t){let o=s(r);o&&(n||(n=Object.assign({},r.props)),n[o[0].id]=o[1])}i.push(n?new le(r.name,n,r.id,r.flags):r)}return new mc(i)}},vn=new WeakMap,sc=new WeakMap,B;(function(e){e[e.ExcludeBuffers=1]="ExcludeBuffers",e[e.IncludeAnonymous=2]="IncludeAnonymous",e[e.IgnoreMounts=4]="IgnoreMounts",e[e.IgnoreOverlays=8]="IgnoreOverlays"})(B||(B={}));var L=class mo{constructor(t,i,r,n,s){if(this.type=t,this.children=i,this.positions=r,this.length=n,this.props=null,s&&s.length){this.props=Object.create(null);for(let[o,a]of s)this.props[typeof o=="number"?o:o.id]=a}}toString(){let t=hr.get(this);if(t&&!t.overlay)return t.tree.toString();let i="";for(let r of this.children){let n=r.toString();n&&(i&&(i+=","),i+=n)}return this.type.name?(/\W/.test(this.type.name)&&!this.type.isError?JSON.stringify(this.type.name):this.type.name)+(i.length?"("+i+")":""):i}cursor(t=0){return new Pn(this.topNode,t)}cursorAt(t,i=0,r=0){let n=vn.get(this)||this.topNode,s=new Pn(n);return s.moveTo(t,i),vn.set(this,s._tree),s}get topNode(){return new tt(this,0,0,null)}resolve(t,i=0){let r=cr(vn.get(this)||this.topNode,t,i,!1);return vn.set(this,r),r}resolveInner(t,i=0){let r=cr(sc.get(this)||this.topNode,t,i,!0);return sc.set(this,r),r}resolveStack(t,i=0){return A1(this,t,i)}iterate(t){let{enter:i,leave:r,from:n=0,to:s=this.length}=t,o=t.mode||0,a=(o&B.IncludeAnonymous)>0;for(let l=this.cursor(o|B.IncludeAnonymous);;){let h=!1;if(l.from<=s&&l.to>=n&&(!a&&l.type.isAnonymous||i(l)!==!1)){if(l.firstChild())continue;h=!0}for(;h&&r&&(a||!l.type.isAnonymous)&&r(l),!l.nextSibling();){if(!l.parent())return;h=!0}}}prop(t){return t.perNode?this.props?this.props[t.id]:void 0:this.type.prop(t)}get propValues(){let t=[];if(this.props)for(let i in this.props)t.push([+i,this.props[i]]);return t}balance(t={}){return this.children.length<=8?this:vo(le.none,this.children,this.positions,0,this.children.length,0,this.length,(i,r,n)=>new mo(this.type,i,r,n,this.propValues),t.makeTree||((i,r,n)=>new mo(le.none,i,r,n)))}static build(t){return Z1(t)}};L.empty=new L(le.none,[],[],0);var $1=class gc{constructor(t,i){this.buffer=t,this.index=i}get id(){return this.buffer[this.index-4]}get start(){return this.buffer[this.index-3]}get end(){return this.buffer[this.index-2]}get size(){return this.buffer[this.index-1]}get pos(){return this.index}next(){this.index-=4}fork(){return new gc(this.buffer,this.index)}},Zi=class yc{constructor(t,i,r){this.buffer=t,this.length=i,this.set=r}get type(){return le.none}toString(){let t=[];for(let i=0;i<this.buffer.length;)t.push(this.childString(i)),i=this.buffer[i+3];return t.join(",")}childString(t){let i=this.buffer[t],r=this.buffer[t+3],n=this.set.types[i],s=n.name;if(/\W/.test(s)&&!n.isError&&(s=JSON.stringify(s)),t+=4,r==t)return s;let o=[];for(;t<r;)o.push(this.childString(t)),t=this.buffer[t+3];return s+"("+o.join(",")+")"}findChild(t,i,r,n,s){let{buffer:o}=this,a=-1;for(let l=t;l!=i&&!(bc(s,n,o[l+1],o[l+2])&&(a=l,r>0));l=o[l+3]);return a}slice(t,i,r){let n=this.buffer,s=new Uint16Array(i-t),o=0;for(let a=t,l=0;a<i;){s[l++]=n[a++],s[l++]=n[a++]-r;let h=s[l++]=n[a++]-r;s[l++]=n[a++]-t,o=Math.max(o,h)}return new yc(s,o,this.set)}};function bc(e,t,i,r){switch(e){case-2:return i<t;case-1:return r>=t&&i<t;case 0:return i<t&&r>t;case 1:return i<=t&&r>t;case 2:return r>t;case 4:return!0}}function cr(e,t,i,r){for(var n;e.from==e.to||(i<1?e.from>=t:e.from>t)||(i>-1?e.to<=t:e.to<t);){let o=!r&&e instanceof tt&&e.index<0?null:e.parent;if(!o)return e;e=o}let s=r?0:B.IgnoreOverlays;if(r)for(let o=e,a=o.parent;a;o=a,a=o.parent)o instanceof tt&&o.index<0&&((n=a.enter(t,i,s))===null||n===void 0?void 0:n.from)!=o.from&&(e=a);for(;;){let o=e.enter(t,i,s);if(!o)return e;e=o}}var wc=class{cursor(e=0){return new Pn(this,e)}getChild(e,t=null,i=null){let r=oc(this,e,t,i);return r.length?r[0]:null}getChildren(e,t=null,i=null){return oc(this,e,t,i)}resolve(e,t=0){return cr(this,e,t,!1)}resolveInner(e,t=0){return cr(this,e,t,!0)}matchContext(e){return go(this,e)}enterUnfinishedNodesBefore(e){let t=this.childBefore(e),i=this;for(;t;){let r=t.lastChild;if(!r||r.to!=t.to)break;r.type.isError&&r.from==r.to?(i=t,t=r.prevSibling):t=r}return i}get node(){return this}get next(){return this.parent}},tt=class Sn extends wc{constructor(t,i,r,n){super(),this._tree=t,this.from=i,this.index=r,this._parent=n}get type(){return this._tree.type}get name(){return this._tree.type.name}get to(){return this.from+this._tree.length}nextChild(t,i,r,n,s=0){for(let o=this;;){for(let{children:a,positions:l}=o._tree,h=i>0?a.length:-1;t!=h;t+=i){let c=a[t],u=l[t]+o.from;if(bc(n,r,u,u+c.length)){if(c instanceof Zi){if(s&B.ExcludeBuffers)continue;let d=c.findChild(0,c.buffer.length,i,r-u,n);if(d>-1)return new ur(new T1(o,c,t,u),null,d)}else if(s&B.IncludeAnonymous||!c.type.isAnonymous||wo(c)){let d;if(!(s&B.IgnoreMounts)&&(d=hr.get(c))&&!d.overlay)return new Sn(d.tree,u,t,o);let f=new Sn(c,u,t,o);return s&B.IncludeAnonymous||!f.type.isAnonymous?f:f.nextChild(i<0?c.children.length-1:0,i,r,n)}}}if(s&B.IncludeAnonymous||!o.type.isAnonymous||(o.index>=0?t=o.index+i:t=i<0?-1:o._parent._tree.children.length,o=o._parent,!o))return null}}get firstChild(){return this.nextChild(0,1,0,4)}get lastChild(){return this.nextChild(this._tree.children.length-1,-1,0,4)}childAfter(t){return this.nextChild(0,1,t,2)}childBefore(t){return this.nextChild(this._tree.children.length-1,-1,t,-2)}enter(t,i,r=0){let n;if(!(r&B.IgnoreOverlays)&&(n=hr.get(this._tree))&&n.overlay){let s=t-this.from;for(let{from:o,to:a}of n.overlay)if((i>0?o<=s:o<s)&&(i<0?a>=s:a>s))return new Sn(n.tree,n.overlay[0].from+this.from,-1,this)}return this.nextChild(0,1,t,i,r)}nextSignificantParent(){let t=this;for(;t.type.isAnonymous&&t._parent;)t=t._parent;return t}get parent(){return this._parent?this._parent.nextSignificantParent():null}get nextSibling(){return this._parent&&this.index>=0?this._parent.nextChild(this.index+1,1,0,4):null}get prevSibling(){return this._parent&&this.index>=0?this._parent.nextChild(this.index-1,-1,0,4):null}get tree(){return this._tree}toTree(){return this._tree}toString(){return this._tree.toString()}};function oc(e,t,i,r){let n=e.cursor(),s=[];if(!n.firstChild())return s;if(i!=null){for(let o=!1;!o;)if(o=n.type.is(i),!n.nextSibling())return s}for(;;){if(r!=null&&n.type.is(r))return s;if(n.type.is(t)&&s.push(n.node),!n.nextSibling())return r==null?s:[]}}function go(e,t,i=t.length-1){for(let r=e.parent;i>=0;r=r.parent){if(!r)return!1;if(!r.type.isAnonymous){if(t[i]&&t[i]!=r.name)return!1;i--}}return!0}var T1=class{constructor(e,t,i,r){this.parent=e,this.buffer=t,this.index=i,this.start=r}},ur=class lr extends wc{get name(){return this.type.name}get from(){return this.context.start+this.context.buffer.buffer[this.index+1]}get to(){return this.context.start+this.context.buffer.buffer[this.index+2]}constructor(t,i,r){super(),this.context=t,this._parent=i,this.index=r,this.type=t.buffer.set.types[t.buffer.buffer[r]]}child(t,i,r){let{buffer:n}=this.context,s=n.findChild(this.index+4,n.buffer[this.index+3],t,i-this.context.start,r);return s<0?null:new lr(this.context,this,s)}get firstChild(){return this.child(1,0,4)}get lastChild(){return this.child(-1,0,4)}childAfter(t){return this.child(1,t,2)}childBefore(t){return this.child(-1,t,-2)}enter(t,i,r=0){if(r&B.ExcludeBuffers)return null;let{buffer:n}=this.context,s=n.findChild(this.index+4,n.buffer[this.index+3],i>0?1:-1,t-this.context.start,i);return s<0?null:new lr(this.context,this,s)}get parent(){return this._parent||this.context.parent.nextSignificantParent()}externalSibling(t){return this._parent?null:this.context.parent.nextChild(this.context.index+t,t,0,4)}get nextSibling(){let{buffer:t}=this.context,i=t.buffer[this.index+3];return i<(this._parent?t.buffer[this._parent.index+3]:t.buffer.length)?new lr(this.context,this._parent,i):this.externalSibling(1)}get prevSibling(){let{buffer:t}=this.context,i=this._parent?this._parent.index+4:0;return this.index==i?this.externalSibling(-1):new lr(this.context,this._parent,t.findChild(i,this.index,-1,0,4))}get tree(){return null}toTree(){let t=[],i=[],{buffer:r}=this.context,n=this.index+4,s=r.buffer[this.index+3];if(s>n){let o=r.buffer[this.index+1];t.push(r.slice(n,s,o)),i.push(0)}return new L(this.type,t,i,this.to-this.from)}toString(){return this.context.buffer.childString(this.index)}};function vc(e){if(!e.length)return null;let t=0,i=e[0];for(let s=1;s<e.length;s++){let o=e[s];(o.from>i.from||o.to<i.to)&&(i=o,t=s)}let r=i instanceof tt&&i.index<0?null:i.parent,n=e.slice();return r?n[t]=r:n.splice(t,1),new C1(n,i)}var C1=class{constructor(e,t){this.heads=e,this.node=t}get next(){return vc(this.heads)}};function A1(e,t,i){let r=e.resolveInner(t,i),n=null;for(let s=r instanceof tt?r:r.context.parent;s;s=s.parent)if(s.index<0){let o=s.parent;(n||(n=[r])).push(o.resolve(t,i)),s=o}else{let o=hr.get(s.tree);if(o&&o.overlay&&o.overlay[0].from<=t&&o.overlay[o.overlay.length-1].to>=t){let a=new tt(o.tree,o.overlay[0].from+s.from,-1,s);(n||(n=[r])).push(cr(a,t,i,!1))}}return n?vc(n):r}var Pn=class{get name(){return this.type.name}constructor(e,t=0){if(this.mode=t,this.buffer=null,this.stack=[],this.index=0,this.bufferNode=null,e instanceof tt)this.yieldNode(e);else{this._tree=e.context.parent,this.buffer=e.context;for(let i=e._parent;i;i=i._parent)this.stack.unshift(i.index);this.bufferNode=e,this.yieldBuf(e.index)}}yieldNode(e){return e?(this._tree=e,this.type=e.type,this.from=e.from,this.to=e.to,!0):!1}yieldBuf(e,t){this.index=e;let{start:i,buffer:r}=this.buffer;return this.type=t||r.set.types[r.buffer[e]],this.from=i+r.buffer[e+1],this.to=i+r.buffer[e+2],!0}yield(e){return e?e instanceof tt?(this.buffer=null,this.yieldNode(e)):(this.buffer=e.context,this.yieldBuf(e.index,e.type)):!1}toString(){return this.buffer?this.buffer.buffer.childString(this.index):this._tree.toString()}enterChild(e,t,i){if(!this.buffer)return this.yield(this._tree.nextChild(e<0?this._tree._tree.children.length-1:0,e,t,i,this.mode));let{buffer:r}=this.buffer,n=r.findChild(this.index+4,r.buffer[this.index+3],e,t-this.buffer.start,i);return n<0?!1:(this.stack.push(this.index),this.yieldBuf(n))}firstChild(){return this.enterChild(1,0,4)}lastChild(){return this.enterChild(-1,0,4)}childAfter(e){return this.enterChild(1,e,2)}childBefore(e){return this.enterChild(-1,e,-2)}enter(e,t,i=this.mode){return this.buffer?i&B.ExcludeBuffers?!1:this.enterChild(1,e,t):this.yield(this._tree.enter(e,t,i))}parent(){if(!this.buffer)return this.yieldNode(this.mode&B.IncludeAnonymous?this._tree._parent:this._tree.parent);if(this.stack.length)return this.yieldBuf(this.stack.pop());let e=this.mode&B.IncludeAnonymous?this.buffer.parent:this.buffer.parent.nextSignificantParent();return this.buffer=null,this.yieldNode(e)}sibling(e){if(!this.buffer)return this._tree._parent?this.yield(this._tree.index<0?null:this._tree._parent.nextChild(this._tree.index+e,e,0,4,this.mode)):!1;let{buffer:t}=this.buffer,i=this.stack.length-1;if(e<0){let r=i<0?0:this.stack[i]+4;if(this.index!=r)return this.yieldBuf(t.findChild(r,this.index,-1,0,4))}else{let r=t.buffer[this.index+3];if(r<(i<0?t.buffer.length:t.buffer[this.stack[i]+3]))return this.yieldBuf(r)}return i<0?this.yield(this.buffer.parent.nextChild(this.buffer.index+e,e,0,4,this.mode)):!1}nextSibling(){return this.sibling(1)}prevSibling(){return this.sibling(-1)}atLastNode(e){let t,i,{buffer:r}=this;if(r){if(e>0){if(this.index<r.buffer.buffer.length)return!1}else for(let n=0;n<this.index;n++)if(r.buffer.buffer[n+3]<this.index)return!1;({index:t,parent:i}=r)}else({index:t,_parent:i}=this._tree);for(;i;{index:t,_parent:i}=i)if(t>-1)for(let n=t+e,s=e<0?-1:i._tree.children.length;n!=s;n+=e){let o=i._tree.children[n];if(this.mode&B.IncludeAnonymous||o instanceof Zi||!o.type.isAnonymous||wo(o))return!1}return!0}move(e,t){if(t&&this.enterChild(e,0,4))return!0;for(;;){if(this.sibling(e))return!0;if(this.atLastNode(e)||!this.parent())return!1}}next(e=!0){return this.move(1,e)}prev(e=!0){return this.move(-1,e)}moveTo(e,t=0){for(;(this.from==this.to||(t<1?this.from>=e:this.from>e)||(t>-1?this.to<=e:this.to<e))&&this.parent(););for(;this.enterChild(1,e,t););return this}get node(){if(!this.buffer)return this._tree;let e=this.bufferNode,t=null,i=0;if(e&&e.context==this.buffer)e:for(let r=this.index,n=this.stack.length;n>=0;){for(let s=e;s;s=s._parent)if(s.index==r){if(r==this.index)return s;t=s,i=n+1;break e}r=this.stack[--n]}for(let r=i;r<this.stack.length;r++)t=new ur(this.buffer,t,this.stack[r]);return this.bufferNode=new ur(this.buffer,t,this.index)}get tree(){return this.buffer?null:this._tree._tree}iterate(e,t){for(let i=0;;){let r=!1;if(this.type.isAnonymous||e(this)!==!1){if(this.firstChild()){i++;continue}this.type.isAnonymous||(r=!0)}for(;r&&t&&t(this),r=this.type.isAnonymous,!this.nextSibling();){if(!i)return;this.parent(),i--,r=!0}}}matchContext(e){if(!this.buffer)return go(this.node,e);let{buffer:t}=this.buffer,{types:i}=t.set;for(let r=e.length-1,n=this.stack.length-1;r>=0;n--){if(n<0)return go(this.node,e,r);let s=i[t.buffer[this.stack[n]]];if(!s.isAnonymous){if(e[r]&&e[r]!=s.name)return!1;r--}}return!0}};function wo(e){return e.children.some(t=>t instanceof Zi||!t.type.isAnonymous||wo(t))}function Z1(e){var t;let{buffer:i,nodeSet:r,maxBufferLength:n=1024,reused:s=[],minRepeatType:o=r.types.length}=e,a=Array.isArray(i)?new $1(i,i.length):i,l=r.types,h=0,c=0;function u(k,Z,T,q,N,D){let{id:I,start:Y,end:H,size:U}=a,se=c;for(;U<0;)if(a.next(),U==-1){let fe=s[I];T.push(fe),q.push(Y-k);return}else if(U==-3){h=I;return}else if(U==-4){c=I;return}else throw new RangeError(`Unrecognized record size: ${U}`);let Ze=l[I],Ee,je,Ke=Y-k;if(H-Y<=n&&(je=g(a.pos-Z,N))){let fe=new Uint16Array(je.size-je.skip),Je=a.pos-je.size,mt=fe.length;for(;a.pos>Je;)mt=y(je.start,fe,mt);Ee=new Zi(fe,H-je.start,r),Ke=je.start-k}else{let fe=a.pos-U;a.next();let Je=[],mt=[],ai=I>=o?I:-1,Qi=0,ln=H;for(;a.pos>fe;)ai>=0&&a.id==ai&&a.size>=0?(a.end<=ln-n&&(p(Je,mt,Y,Qi,a.end,ln,ai,se),Qi=Je.length,ln=a.end),a.next()):D>2500?d(Y,fe,Je,mt):u(Y,fe,Je,mt,ai,D+1);if(ai>=0&&Qi>0&&Qi<Je.length&&p(Je,mt,Y,Qi,Y,ln,ai,se),Je.reverse(),mt.reverse(),ai>-1&&Qi>0){let Ih=f(Ze);Ee=vo(Ze,Je,mt,0,Je.length,0,H-Y,Ih,Ih)}else Ee=O(Ze,Je,mt,H-Y,se-H)}T.push(Ee),q.push(Ke)}function d(k,Z,T,q){let N=[],D=0,I=-1;for(;a.pos>Z;){let{id:Y,start:H,end:U,size:se}=a;if(se>4)a.next();else{if(I>-1&&H<I)break;I<0&&(I=U-n),N.push(Y,H,U),D++,a.next()}}if(D){let Y=new Uint16Array(D*4),H=N[N.length-2];for(let U=N.length-3,se=0;U>=0;U-=3)Y[se++]=N[U],Y[se++]=N[U+1]-H,Y[se++]=N[U+2]-H,Y[se++]=se;T.push(new Zi(Y,N[2]-H,r)),q.push(H-k)}}function f(k){return(Z,T,q)=>{let N=0,D=Z.length-1,I,Y;if(D>=0&&(I=Z[D])instanceof L){if(!D&&I.type==k&&I.length==q)return I;(Y=I.prop(M.lookAhead))&&(N=T[D]+I.length+Y)}return O(k,Z,T,q,N)}}function p(k,Z,T,q,N,D,I,Y){let H=[],U=[];for(;k.length>q;)H.push(k.pop()),U.push(Z.pop()+T-N);k.push(O(r.types[I],H,U,D-N,Y-D)),Z.push(N-T)}function O(k,Z,T,q,N=0,D){if(h){let I=[M.contextHash,h];D=D?[I].concat(D):[I]}if(N>25){let I=[M.lookAhead,N];D=D?[I].concat(D):[I]}return new L(k,Z,T,q,D)}function g(k,Z){let T=a.fork(),q=0,N=0,D=0,I=T.end-n,Y={size:0,start:0,skip:0};e:for(let H=T.pos-k;T.pos>H;){let U=T.size;if(T.id==Z&&U>=0){Y.size=q,Y.start=N,Y.skip=D,D+=4,q+=4,T.next();continue}let se=T.pos-U;if(U<0||se<H||T.start<I)break;let Ze=T.id>=o?4:0,Ee=T.start;for(T.next();T.pos>se;){if(T.size<0)if(T.size==-3)Ze+=4;else break e;else T.id>=o&&(Ze+=4);T.next()}N=Ee,q+=U,D+=Ze}return(Z<0||q==k)&&(Y.size=q,Y.start=N,Y.skip=D),Y.size>4?Y:void 0}function y(k,Z,T){let{id:q,start:N,end:D,size:I}=a;if(a.next(),I>=0&&q<o){let Y=T;if(I>4){let H=a.pos-(I-4);for(;a.pos>H;)T=y(k,Z,T)}Z[--T]=Y,Z[--T]=D-k,Z[--T]=N-k,Z[--T]=q}else I==-3?h=q:I==-4&&(c=q);return T}let b=[],S=[];for(;a.pos>0;)u(e.start||0,e.bufferStart||0,b,S,-1,0);let w=(t=e.length)!==null&&t!==void 0?t:b.length?S[0]+b[0].length:0;return new L(l[e.topID],b.reverse(),S.reverse(),w)}var ac=new WeakMap;function xn(e,t){if(!e.isAnonymous||t instanceof Zi||t.type!=e)return 1;let i=ac.get(t);if(i==null){i=1;for(let r of t.children){if(r.type!=e||!(r instanceof L)){i=1;break}i+=xn(e,r)}ac.set(t,i)}return i}function vo(e,t,i,r,n,s,o,a,l){let h=0;for(let p=r;p<n;p++)h+=xn(e,t[p]);let c=Math.ceil(h*1.5/8),u=[],d=[];function f(p,O,g,y,b){for(let S=g;S<y;){let w=S,k=O[S],Z=xn(e,p[S]);for(S++;S<y;S++){let T=xn(e,p[S]);if(Z+T>=c)break;Z+=T}if(S==w+1){if(Z>c){let T=p[w];f(T.children,T.positions,0,T.children.length,O[w]+b);continue}u.push(p[w])}else{let T=O[S-1]+p[S-1].length-k;u.push(vo(e,p,O,w,S,k,T,null,l))}d.push(k+b-s)}}return f(t,i,r,n,0),(a||l)(u,d,o)}var kn=class{constructor(){this.map=new WeakMap}setBuffer(e,t,i){let r=this.map.get(e);r||this.map.set(e,r=new Map),r.set(t,i)}getBuffer(e,t){let i=this.map.get(e);return i&&i.get(t)}set(e,t){e instanceof ur?this.setBuffer(e.context.buffer,e.index,t):e instanceof tt&&this.map.set(e.tree,t)}get(e){return e instanceof ur?this.getBuffer(e.context.buffer,e.index):e instanceof tt?this.map.get(e.tree):void 0}cursorSet(e,t){e.buffer?this.setBuffer(e.buffer.buffer,e.index,t):this.map.set(e.tree,t)}cursorGet(e){return e.buffer?this.getBuffer(e.buffer.buffer,e.index):this.map.get(e.tree)}},di=class yo{constructor(t,i,r,n,s=!1,o=!1){this.from=t,this.to=i,this.tree=r,this.offset=n,this.open=(s?1:0)|(o?2:0)}get openStart(){return(this.open&1)>0}get openEnd(){return(this.open&2)>0}static addTree(t,i=[],r=!1){let n=[new yo(0,t.length,t,0,!1,r)];for(let s of i)s.to>t.length&&n.push(s);return n}static applyChanges(t,i,r=128){if(!i.length)return t;let n=[],s=1,o=t.length?t[0]:null;for(let a=0,l=0,h=0;;a++){let c=a<i.length?i[a]:null,u=c?c.fromA:1e9;if(u-l>=r)for(;o&&o.from<u;){let d=o;if(l>=d.from||u<=d.to||h){let f=Math.max(d.from,l)-h,p=Math.min(d.to,u)-h;d=f>=p?null:new yo(f,p,d.tree,d.offset+h,a>0,!!c)}if(d&&n.push(d),o.to>u)break;o=s<t.length?t[s++]:null}if(!c)break;l=c.toA,h=c.toA-c.toB}return n}},pi=class{startParse(e,t,i){return typeof e=="string"&&(e=new E1(e)),i=i?i.length?i.map(r=>new et(r.from,r.to)):[new et(0,0)]:[new et(0,e.length)],this.createParse(e,t||[],i)}parse(e,t,i){let r=this.startParse(e,t,i);for(;;){let n=r.advance();if(n)return n}}},E1=class{constructor(e){this.string=e}get length(){return this.string.length}chunk(e){return this.string.slice(e)}get lineChunks(){return!1}read(e,t){return this.string.slice(e,t)}};function Qn(e){return(t,i,r,n)=>new X1(t,e,i,r,n)}var lc=class{constructor(e,t,i,r,n){this.parser=e,this.parse=t,this.overlay=i,this.target=r,this.from=n}};function hc(e){if(!e.length||e.some(t=>t.from>=t.to))throw new RangeError("Invalid inner parse ranges given: "+JSON.stringify(e))}var R1=class{constructor(e,t,i,r,n,s,o){this.parser=e,this.predicate=t,this.mounts=i,this.index=r,this.start=n,this.target=s,this.prev=o,this.depth=0,this.ranges=[]}},bo=new M({perNode:!0}),X1=class{constructor(e,t,i,r,n){this.nest=t,this.input=i,this.fragments=r,this.ranges=n,this.inner=[],this.innerDone=0,this.baseTree=null,this.stoppedAt=null,this.baseParse=e}advance(){if(this.baseParse){let i=this.baseParse.advance();if(!i)return null;if(this.baseParse=null,this.baseTree=i,this.startInner(),this.stoppedAt!=null)for(let r of this.inner)r.parse.stopAt(this.stoppedAt)}if(this.innerDone==this.inner.length){let i=this.baseTree;return this.stoppedAt!=null&&(i=new L(i.type,i.children,i.positions,i.length,i.propValues.concat([[bo,this.stoppedAt]]))),i}let e=this.inner[this.innerDone],t=e.parse.advance();if(t){this.innerDone++;let i=Object.assign(Object.create(null),e.target.props);i[M.mounted.id]=new hr(t,e.overlay,e.parser),e.target.props=i}return null}get parsedPos(){if(this.baseParse)return 0;let e=this.input.length;for(let t=this.innerDone;t<this.inner.length;t++)this.inner[t].from<e&&(e=Math.min(e,this.inner[t].parse.parsedPos));return e}stopAt(e){if(this.stoppedAt=e,this.baseParse)this.baseParse.stopAt(e);else for(let t=this.innerDone;t<this.inner.length;t++)this.inner[t].parse.stopAt(e)}startInner(){let e=new q1(this.fragments),t=null,i=null,r=new Pn(new tt(this.baseTree,this.ranges[0].from,0,null),B.IncludeAnonymous|B.IgnoreMounts);e:for(let n,s;;){let o=!0,a;if(this.stoppedAt!=null&&r.from>=this.stoppedAt)o=!1;else if(e.hasNode(r)){if(t){let l=t.mounts.find(h=>h.frag.from<=r.from&&h.frag.to>=r.to&&h.mount.overlay);if(l)for(let h of l.mount.overlay){let c=h.from+l.pos,u=h.to+l.pos;c>=r.from&&u<=r.to&&!t.ranges.some(d=>d.from<u&&d.to>c)&&t.ranges.push({from:c,to:u})}}o=!1}else if(i&&(s=M1(i.ranges,r.from,r.to)))o=s!=2;else if(!r.type.isAnonymous&&(n=this.nest(r,this.input))&&(r.from<r.to||!n.overlay)){r.tree||W1(r);let l=e.findMounts(r.from,n.parser);if(typeof n.overlay=="function")t=new R1(n.parser,n.overlay,l,this.inner.length,r.from,r.tree,t);else{let h=dc(this.ranges,n.overlay||(r.from<r.to?[new et(r.from,r.to)]:[]));h.length&&hc(h),(h.length||!n.overlay)&&this.inner.push(new lc(n.parser,h.length?n.parser.startParse(this.input,fc(l,h),h):n.parser.startParse(""),n.overlay?n.overlay.map(c=>new et(c.from-r.from,c.to-r.from)):null,r.tree,h.length?h[0].from:r.from)),n.overlay?h.length&&(i={ranges:h,depth:0,prev:i}):o=!1}}else t&&(a=t.predicate(r))&&(a===!0&&(a=new et(r.from,r.to)),a.from<a.to&&t.ranges.push(a));if(o&&r.firstChild())t&&t.depth++,i&&i.depth++;else for(;!r.nextSibling();){if(!r.parent())break e;if(t&&!--t.depth){let l=dc(this.ranges,t.ranges);l.length&&(hc(l),this.inner.splice(t.index,0,new lc(t.parser,t.parser.startParse(this.input,fc(t.mounts,l),l),t.ranges.map(h=>new et(h.from-t.start,h.to-t.start)),t.target,l[0].from))),t=t.prev}i&&!--i.depth&&(i=i.prev)}}}};function M1(e,t,i){for(let r of e){if(r.from>=i)break;if(r.to>t)return r.from<=t&&r.to>=i?2:1}return 0}function cc(e,t,i,r,n,s){if(t<i){let o=e.buffer[t+1];r.push(e.slice(t,i,o)),n.push(o-s)}}function W1(e){let{node:t}=e,i=[],r=t.context.buffer;do i.push(e.index),e.parent();while(!e.tree);let n=e.tree,s=n.children.indexOf(r),o=n.children[s],a=o.buffer,l=[s];function h(c,u,d,f,p,O){let g=i[O],y=[],b=[];cc(o,c,g,y,b,f);let S=a[g+1],w=a[g+2];l.push(y.length);let k=O?h(g+4,a[g+3],o.set.types[a[g]],S,w-S,O-1):t.toTree();return y.push(k),b.push(S-f),cc(o,a[g+3],u,y,b,f),new L(d,y,b,p)}n.children[s]=h(0,a.length,le.none,0,o.length,i.length-1);for(let c of l){let u=e.tree.children[c],d=e.tree.positions[c];e.yield(new tt(u,d+e.from,c,e._tree))}}var uc=class{constructor(e,t){this.offset=t,this.done=!1,this.cursor=e.cursor(B.IncludeAnonymous|B.IgnoreMounts)}moveTo(e){let{cursor:t}=this,i=e-this.offset;for(;!this.done&&t.from<i;)t.to>=e&&t.enter(i,1,B.IgnoreOverlays|B.ExcludeBuffers)||t.next(!1)||(this.done=!0)}hasNode(e){if(this.moveTo(e.from),!this.done&&this.cursor.from+this.offset==e.from&&this.cursor.tree)for(let t=this.cursor.tree;;){if(t==e.tree)return!0;if(t.children.length&&t.positions[0]==0&&t.children[0]instanceof L)t=t.children[0];else break}return!1}},q1=class{constructor(e){var t;if(this.fragments=e,this.curTo=0,this.fragI=0,e.length){let i=this.curFrag=e[0];this.curTo=(t=i.tree.prop(bo))!==null&&t!==void 0?t:i.to,this.inner=new uc(i.tree,-i.offset)}else this.curFrag=this.inner=null}hasNode(e){for(;this.curFrag&&e.from>=this.curTo;)this.nextFrag();return this.curFrag&&this.curFrag.from<=e.from&&this.curTo>=e.to&&this.inner.hasNode(e)}nextFrag(){var e;if(this.fragI++,this.fragI==this.fragments.length)this.curFrag=this.inner=null;else{let t=this.curFrag=this.fragments[this.fragI];this.curTo=(e=t.tree.prop(bo))!==null&&e!==void 0?e:t.to,this.inner=new uc(t.tree,-t.offset)}}findMounts(e,t){var i;let r=[];if(this.inner){this.inner.cursor.moveTo(e,1);for(let n=this.inner.cursor.node;n;n=n.parent){let s=(i=n.tree)===null||i===void 0?void 0:i.prop(M.mounted);if(s&&s.parser==t)for(let o=this.fragI;o<this.fragments.length;o++){let a=this.fragments[o];if(a.from>=n.to)break;a.tree==this.curFrag.tree&&r.push({frag:a,pos:n.from-a.offset,mount:s})}}}return r}};function dc(e,t){let i=null,r=t;for(let n=1,s=0;n<e.length;n++){let o=e[n-1].to,a=e[n].from;for(;s<r.length;s++){let l=r[s];if(l.from>=a)break;l.to<=o||(i||(r=i=t.slice()),l.from<o?(i[s]=new et(l.from,o),l.to>a&&i.splice(s+1,0,new et(a,l.to))):l.to>a?i[s--]=new et(a,l.to):i.splice(s--,1))}}return r}function Y1(e,t,i,r){let n=0,s=0,o=!1,a=!1,l=-1e9,h=[];for(;;){let c=n==e.length?1e9:o?e[n].to:e[n].from,u=s==t.length?1e9:a?t[s].to:t[s].from;if(o!=a){let d=Math.max(l,i),f=Math.min(c,u,r);d<f&&h.push(new et(d,f))}if(l=Math.min(c,u),l==1e9)break;c==l&&(o?(o=!1,n++):o=!0),u==l&&(a?(a=!1,s++):a=!0)}return h}function fc(e,t){let i=[];for(let{pos:r,mount:n,frag:s}of e){let o=r+(n.overlay?n.overlay[0].from:0),a=o+n.tree.length,l=Math.max(s.from,o),h=Math.min(s.to,a);if(n.overlay){let c=n.overlay.map(d=>new et(d.from+r,d.to+r)),u=Y1(t,c,l,h);for(let d=0,f=l;;d++){let p=d==u.length,O=p?h:u[d].from;if(O>f&&i.push(new di(f,O,n.tree,-o,s.from>=f||s.openStart,s.to<=O||s.openEnd)),p)break;f=u[d].to}}else i.push(new di(l,h,n.tree,-o,s.from>=o||s.openStart,s.to<=a||s.openEnd))}return i}var I1=0,V=class kc{constructor(t,i,r){this.set=t,this.base=i,this.modified=r,this.id=I1++}static define(t){if(t?.base)throw new Error("Can not derive from a modified tag");let i=new kc([],null,[]);if(i.set.push(i),t)for(let r of t.set)i.set.push(r);return i}static defineModifier(){let t=new Sc;return i=>i.modified.indexOf(t)>-1?i:Sc.get(i.base||i,i.modified.concat(t).sort((r,n)=>r.id-n.id))}},L1=0,Sc=class Qc{constructor(){this.instances=[],this.id=L1++}static get(t,i){if(!i.length)return t;let r=i[0].instances.find(a=>a.base==t&&V1(i,a.modified));if(r)return r;let n=[],s=new V(n,t,i);for(let a of i)a.instances.push(s);let o=N1(i);for(let a of t.set)if(!a.modified.length)for(let l of o)n.push(Qc.get(a,l));return s}};function V1(e,t){return e.length==t.length&&e.every((i,r)=>i==t[r])}function N1(e){let t=[[]];for(let i=0;i<e.length;i++)for(let r=0,n=t.length;r<n;r++)t.push(t[r].concat(e[i]));return t.sort((i,r)=>r.length-i.length)}function Re(e){let t=Object.create(null);for(let i in e){let r=e[i];Array.isArray(r)||(r=[r]);for(let n of i.split(" "))if(n){let s=[],o=2,a=n;for(let u=0;;){if(a=="..."&&u>0&&u+3==n.length){o=1;break}let d=/^"(?:[^"\\]|\\.)*?"|[^\/!]+/.exec(a);if(!d)throw new RangeError("Invalid path: "+n);if(s.push(d[0]=="*"?"":d[0][0]=='"'?JSON.parse(d[0]):d[0]),u+=d[0].length,u==n.length)break;let f=n[u++];if(u==n.length&&f=="!"){o=0;break}if(f!="/")throw new RangeError("Invalid path: "+n);a=n.slice(u)}let l=s.length-1,h=s[l];if(!h)throw new RangeError("Invalid path: "+n);let c=new An(r,o,l>0?s.slice(0,l):null);t[h]=c.sort(t[h])}}return $c.add(t)}var $c=new M,An=class{constructor(e,t,i,r){this.tags=e,this.mode=t,this.context=i,this.next=r}get opaque(){return this.mode==0}get inherit(){return this.mode==1}sort(e){return!e||e.depth<this.depth?(this.next=e,this):(e.next=this.sort(e.next),e)}get depth(){return this.context?this.context.length:0}};An.empty=new An([],2,null);function Po(e,t){let i=Object.create(null);for(let s of e)if(!Array.isArray(s.tag))i[s.tag.id]=s.class;else for(let o of s.tag)i[o.id]=s.class;let{scope:r,all:n=null}=t||{};return{style:s=>{let o=n;for(let a of s)for(let l of a.set){let h=i[l.id];if(h){o=o?o+" "+h:h;break}}return o},scope:r}}function j1(e,t){let i=null;for(let r of e){let n=r.style(t);n&&(i=i?i+" "+n:n)}return i}function Tc(e,t,i,r=0,n=e.length){let s=new D1(r,Array.isArray(t)?t:[t],i);s.highlightRange(e.cursor(),r,n,"",s.highlighters),s.flush(n)}var D1=class{constructor(e,t,i){this.at=e,this.highlighters=t,this.span=i,this.class=""}startSpan(e,t){t!=this.class&&(this.flush(e),e>this.at&&(this.at=e),this.class=t)}flush(e){e>this.at&&this.class&&this.span(this.at,e,this.class)}highlightRange(e,t,i,r,n){let{type:s,from:o,to:a}=e;if(o>=i||a<=t)return;s.isTop&&(n=this.highlighters.filter(d=>!d.scope||d.scope(s)));let l=r,h=_1(e)||An.empty,c=j1(n,h.tags);if(c&&(l&&(l+=" "),l+=c,h.mode==1&&(r+=(r?" ":"")+c)),this.startSpan(Math.max(t,o),l),h.opaque)return;let u=e.tree&&e.tree.prop(M.mounted);if(u&&u.overlay){let d=e.node.enter(u.overlay[0].from+o,1),f=this.highlighters.filter(O=>!O.scope||O.scope(u.tree.type)),p=e.firstChild();for(let O=0,g=o;;O++){let y=O<u.overlay.length?u.overlay[O]:null,b=y?y.from+o:a,S=Math.max(t,g),w=Math.min(i,b);if(S<w&&p)for(;e.from<w&&(this.highlightRange(e,S,w,r,n),this.startSpan(Math.min(w,e.to),l),!(e.to>=b||!e.nextSibling())););if(!y||b>i)break;g=y.to+o,g>t&&(this.highlightRange(d.cursor(),Math.max(t,y.from+o),Math.min(i,g),"",f),this.startSpan(Math.min(i,g),l))}p&&e.parent()}else if(e.firstChild()){u&&(r="");do if(!(e.to<=t)){if(e.from>=i)break;this.highlightRange(e,t,i,r,n),this.startSpan(Math.min(i,e.to),l)}while(e.nextSibling());e.parent()}}};function _1(e){let t=e.type.prop($c);for(;t&&t.context&&!e.matchContext(t.context);)t=t.next;return t||null}var Q=V.define,$n=Q(),jt=Q(),xc=Q(jt),Pc=Q(jt),Dt=Q(),Tn=Q(Dt),So=Q(Dt),vt=Q(),Oi=Q(vt),bt=Q(),wt=Q(),xo=Q(),dr=Q(xo),Cn=Q(),m={comment:$n,lineComment:Q($n),blockComment:Q($n),docComment:Q($n),name:jt,variableName:Q(jt),typeName:xc,tagName:Q(xc),propertyName:Pc,attributeName:Q(Pc),className:Q(jt),labelName:Q(jt),namespace:Q(jt),macroName:Q(jt),literal:Dt,string:Tn,docString:Q(Tn),character:Q(Tn),attributeValue:Q(Tn),number:So,integer:Q(So),float:Q(So),bool:Q(Dt),regexp:Q(Dt),escape:Q(Dt),color:Q(Dt),url:Q(Dt),keyword:bt,self:Q(bt),null:Q(bt),atom:Q(bt),unit:Q(bt),modifier:Q(bt),operatorKeyword:Q(bt),controlKeyword:Q(bt),definitionKeyword:Q(bt),moduleKeyword:Q(bt),operator:wt,derefOperator:Q(wt),arithmeticOperator:Q(wt),logicOperator:Q(wt),bitwiseOperator:Q(wt),compareOperator:Q(wt),updateOperator:Q(wt),definitionOperator:Q(wt),typeOperator:Q(wt),controlOperator:Q(wt),punctuation:xo,separator:Q(xo),bracket:dr,angleBracket:Q(dr),squareBracket:Q(dr),paren:Q(dr),brace:Q(dr),content:vt,heading:Oi,heading1:Q(Oi),heading2:Q(Oi),heading3:Q(Oi),heading4:Q(Oi),heading5:Q(Oi),heading6:Q(Oi),contentSeparator:Q(vt),list:Q(vt),quote:Q(vt),emphasis:Q(vt),strong:Q(vt),link:Q(vt),monospace:Q(vt),strikethrough:Q(vt),inserted:Q(),deleted:Q(),changed:Q(),invalid:Q(),meta:Cn,documentMeta:Q(Cn),annotation:Q(Cn),processingInstruction:Q(Cn),definition:V.defineModifier(),constant:V.defineModifier(),function:V.defineModifier(),standard:V.defineModifier(),local:V.defineModifier(),special:V.defineModifier()},cA=Po([{tag:m.link,class:"tok-link"},{tag:m.heading,class:"tok-heading"},{tag:m.emphasis,class:"tok-emphasis"},{tag:m.strong,class:"tok-strong"},{tag:m.keyword,class:"tok-keyword"},{tag:m.atom,class:"tok-atom"},{tag:m.bool,class:"tok-bool"},{tag:m.url,class:"tok-url"},{tag:m.labelName,class:"tok-labelName"},{tag:m.inserted,class:"tok-inserted"},{tag:m.deleted,class:"tok-deleted"},{tag:m.literal,class:"tok-literal"},{tag:m.string,class:"tok-string"},{tag:m.number,class:"tok-number"},{tag:[m.regexp,m.escape,m.special(m.string)],class:"tok-string2"},{tag:m.variableName,class:"tok-variableName"},{tag:m.local(m.variableName),class:"tok-variableName tok-local"},{tag:m.definition(m.variableName),class:"tok-variableName tok-definition"},{tag:m.special(m.variableName),class:"tok-variableName2"},{tag:m.definition(m.propertyName),class:"tok-propertyName tok-definition"},{tag:m.typeName,class:"tok-typeName"},{tag:m.namespace,class:"tok-namespace"},{tag:m.className,class:"tok-className"},{tag:m.macroName,class:"tok-macroName"},{tag:m.propertyName,class:"tok-propertyName"},{tag:m.operator,class:"tok-operator"},{tag:m.comment,class:"tok-comment"},{tag:m.meta,class:"tok-meta"},{tag:m.invalid,class:"tok-invalid"},{tag:m.punctuation,class:"tok-punctuation"}]);var Cc=class Nc{static create(t,i,r,n,s){let o=n+(n<<8)+t+(i<<4)|0;return new Nc(t,i,r,o,s,[],[])}constructor(t,i,r,n,s,o,a){this.type=t,this.value=i,this.from=r,this.hash=n,this.end=s,this.children=o,this.positions=a,this.hashProp=[[M.contextHash,n]]}addChild(t,i){t.prop(M.contextHash)!=this.hash&&(t=new L(t.type,t.children,t.positions,t.length,this.hashProp)),this.children.push(t),this.positions.push(i)}toTree(t,i=this.end){let r=this.children.length-1;return r>=0&&(i=Math.max(i,this.positions[r]+this.children[r].length+this.from)),new L(t.types[this.type],this.children,this.positions,i-this.from).balance({makeTree:(n,s,o)=>new L(le.none,n,s,o,this.hashProp)})}},P;(function(e){e[e.Document=1]="Document",e[e.CodeBlock=2]="CodeBlock",e[e.FencedCode=3]="FencedCode",e[e.Blockquote=4]="Blockquote",e[e.HorizontalRule=5]="HorizontalRule",e[e.BulletList=6]="BulletList",e[e.OrderedList=7]="OrderedList",e[e.ListItem=8]="ListItem",e[e.ATXHeading1=9]="ATXHeading1",e[e.ATXHeading2=10]="ATXHeading2",e[e.ATXHeading3=11]="ATXHeading3",e[e.ATXHeading4=12]="ATXHeading4",e[e.ATXHeading5=13]="ATXHeading5",e[e.ATXHeading6=14]="ATXHeading6",e[e.SetextHeading1=15]="SetextHeading1",e[e.SetextHeading2=16]="SetextHeading2",e[e.HTMLBlock=17]="HTMLBlock",e[e.LinkReference=18]="LinkReference",e[e.Paragraph=19]="Paragraph",e[e.CommentBlock=20]="CommentBlock",e[e.ProcessingInstructionBlock=21]="ProcessingInstructionBlock",e[e.Escape=22]="Escape",e[e.Entity=23]="Entity",e[e.HardBreak=24]="HardBreak",e[e.Emphasis=25]="Emphasis",e[e.StrongEmphasis=26]="StrongEmphasis",e[e.Link=27]="Link",e[e.Image=28]="Image",e[e.InlineCode=29]="InlineCode",e[e.HTMLTag=30]="HTMLTag",e[e.Comment=31]="Comment",e[e.ProcessingInstruction=32]="ProcessingInstruction",e[e.Autolink=33]="Autolink",e[e.HeaderMark=34]="HeaderMark",e[e.QuoteMark=35]="QuoteMark",e[e.ListMark=36]="ListMark",e[e.LinkMark=37]="LinkMark",e[e.EmphasisMark=38]="EmphasisMark",e[e.CodeMark=39]="CodeMark",e[e.CodeText=40]="CodeText",e[e.CodeInfo=41]="CodeInfo",e[e.LinkTitle=42]="LinkTitle",e[e.LinkLabel=43]="LinkLabel",e[e.URL=44]="URL"})(P||(P={}));var U1=class{constructor(e,t){this.start=e,this.content=t,this.marks=[],this.parsers=[]}},z1=class{constructor(){this.text="",this.baseIndent=0,this.basePos=0,this.depth=0,this.markers=[],this.pos=0,this.indent=0,this.next=-1}forward(){this.basePos>this.pos&&this.forwardInner()}forwardInner(){let e=this.skipSpace(this.basePos);this.indent=this.countIndent(e,this.pos,this.indent),this.pos=e,this.next=e==this.text.length?-1:this.text.charCodeAt(e)}skipSpace(e){return pr(this.text,e)}reset(e){for(this.text=e,this.baseIndent=this.basePos=this.pos=this.indent=0,this.forwardInner(),this.depth=1;this.markers.length;)this.markers.pop()}moveBase(e){this.basePos=e,this.baseIndent=this.countIndent(e,this.pos,this.indent)}moveBaseColumn(e){this.baseIndent=e,this.basePos=this.findColumn(e)}addMarker(e){this.markers.push(e)}countIndent(e,t=0,i=0){for(let r=t;r<e;r++)i+=this.text.charCodeAt(r)==9?4-i%4:1;return i}findColumn(e){let t=0;for(let i=0;t<this.text.length&&i<e;t++)i+=this.text.charCodeAt(t)==9?4-i%4:1;return t}scrub(){if(!this.baseIndent)return this.text;let e="";for(let t=0;t<this.basePos;t++)e+=" ";return e+this.text.slice(this.basePos)}};function Ac(e,t,i){if(i.pos==i.text.length||e!=t.block&&i.indent>=t.stack[i.depth+1].value+i.baseIndent)return!0;if(i.indent>=i.baseIndent+4)return!1;let r=(e.type==P.OrderedList?Xo:Ro)(i,t,!1);return r>0&&(e.type!=P.BulletList||Eo(i,t,!1)<0)&&i.text.charCodeAt(i.pos+r-1)==e.value}var jc={[P.Blockquote](e,t,i){return i.next!=62?!1:(i.markers.push(_(P.QuoteMark,t.lineStart+i.pos,t.lineStart+i.pos+1)),i.moveBase(i.pos+(rt(i.text.charCodeAt(i.pos+1))?2:1)),e.end=t.lineStart+i.text.length,!0)},[P.ListItem](e,t,i){return i.indent<i.baseIndent+e.value&&i.next>-1?!1:(i.moveBaseColumn(i.baseIndent+e.value),!0)},[P.OrderedList]:Ac,[P.BulletList]:Ac,[P.Document](){return!0}};function rt(e){return e==32||e==9||e==10||e==13}function pr(e,t=0){for(;t<e.length&&rt(e.charCodeAt(t));)t++;return t}function Zc(e,t,i){for(;t>i&&rt(e.charCodeAt(t-1));)t--;return t}function Dc(e){if(e.next!=96&&e.next!=126)return-1;let t=e.pos+1;for(;t<e.text.length&&e.text.charCodeAt(t)==e.next;)t++;if(t<e.pos+3)return-1;if(e.next==96){for(let i=t;i<e.text.length;i++)if(e.text.charCodeAt(i)==96)return-1}return t}function _c(e){return e.next!=62?-1:e.text.charCodeAt(e.pos+1)==32?2:1}function Eo(e,t,i){if(e.next!=42&&e.next!=45&&e.next!=95)return-1;let r=1;for(let n=e.pos+1;n<e.text.length;n++){let s=e.text.charCodeAt(n);if(s==e.next)r++;else if(!rt(s))return-1}return i&&e.next==45&&Bc(e)>-1&&e.depth==t.stack.length||r<3?-1:1}function Uc(e,t){for(let i=e.stack.length-1;i>=0;i--)if(e.stack[i].type==t)return!0;return!1}function Ro(e,t,i){return(e.next==45||e.next==43||e.next==42)&&(e.pos==e.text.length-1||rt(e.text.charCodeAt(e.pos+1)))&&(!i||Uc(t,P.BulletList)||e.skipSpace(e.pos+2)<e.text.length)?1:-1}function Xo(e,t,i){let r=e.pos,n=e.next;for(;n>=48&&n<=57;){if(r++,r==e.text.length)return-1;n=e.text.charCodeAt(r)}return r==e.pos||r>e.pos+9||n!=46&&n!=41||r<e.text.length-1&&!rt(e.text.charCodeAt(r+1))||i&&!Uc(t,P.OrderedList)&&(e.skipSpace(r+1)==e.text.length||r>e.pos+1||e.next!=49)?-1:r+1-e.pos}function zc(e){if(e.next!=35)return-1;let t=e.pos+1;for(;t<e.text.length&&e.text.charCodeAt(t)==35;)t++;if(t<e.text.length&&e.text.charCodeAt(t)!=32)return-1;let i=t-e.pos;return i>6?-1:i}function Bc(e){if(e.next!=45&&e.next!=61||e.indent>=e.baseIndent+4)return-1;let t=e.pos+1;for(;t<e.text.length&&e.text.charCodeAt(t)==e.next;)t++;let i=t;for(;t<e.text.length&&rt(e.text.charCodeAt(t));)t++;return t==e.text.length?i:-1}var $o=/^[ \t]*$/,Gc=/-->/,Fc=/\?>/,To=[[/^<(?:script|pre|style)(?:\s|>|$)/i,/<\/(?:script|pre|style)>/i],[/^\s*<!--/,Gc],[/^\s*<\?/,Fc],[/^\s*<![A-Z]/,/>/],[/^\s*<!\[CDATA\[/,/\]\]>/],[/^\s*<\/?(?:address|article|aside|base|basefont|blockquote|body|caption|center|col|colgroup|dd|details|dialog|dir|div|dl|dt|fieldset|figcaption|figure|footer|form|frame|frameset|h1|h2|h3|h4|h5|h6|head|header|hr|html|iframe|legend|li|link|main|menu|menuitem|nav|noframes|ol|optgroup|option|p|param|section|source|summary|table|tbody|td|tfoot|th|thead|title|tr|track|ul)(?:\s|\/?>|$)/i,$o],[/^\s*(?:<\/[a-z][\w-]*\s*>|<[a-z][\w-]*(\s+[a-z:_][\w-.]*(?:\s*=\s*(?:[^\s"'=<>`]+|'[^']*'|"[^"]*"))?)*\s*>)\s*$/i,$o]];function Hc(e,t,i){if(e.next!=60)return-1;let r=e.text.slice(e.pos);for(let n=0,s=To.length-(i?1:0);n<s;n++)if(To[n][0].test(r))return n;return-1}function Ec(e,t){let i=e.countIndent(t,e.pos,e.indent),r=e.countIndent(e.skipSpace(t),t,i);return r>=i+5?i+1:r}function mi(e,t,i){let r=e.length-1;r>=0&&e[r].to==t&&e[r].type==P.CodeText?e[r].to=i:e.push(_(P.CodeText,t,i))}var Zn={LinkReference:void 0,IndentedCode(e,t){let i=t.baseIndent+4;if(t.indent<i)return!1;let r=t.findColumn(i),n=e.lineStart+r,s=e.lineStart+t.text.length,o=[],a=[];for(mi(o,n,s);e.nextLine()&&t.depth>=e.stack.length;)if(t.pos==t.text.length){mi(a,e.lineStart-1,e.lineStart);for(let l of t.markers)a.push(l)}else{if(t.indent<i)break;{if(a.length){for(let h of a)h.type==P.CodeText?mi(o,h.from,h.to):o.push(h);a=[]}mi(o,e.lineStart-1,e.lineStart);for(let h of t.markers)o.push(h);s=e.lineStart+t.text.length;let l=e.lineStart+t.findColumn(t.baseIndent+4);l<s&&mi(o,l,s)}}return a.length&&(a=a.filter(l=>l.type!=P.CodeText),a.length&&(t.markers=a.concat(t.markers))),e.addNode(e.buffer.writeElements(o,-n).finish(P.CodeBlock,s-n),n),!0},FencedCode(e,t){let i=Dc(t);if(i<0)return!1;let r=e.lineStart+t.pos,n=t.next,s=i-t.pos,o=t.skipSpace(i),a=Zc(t.text,t.text.length,o),l=[_(P.CodeMark,r,r+s)];o<a&&l.push(_(P.CodeInfo,e.lineStart+o,e.lineStart+a));for(let h=!0;e.nextLine()&&t.depth>=e.stack.length;h=!1){let c=t.pos;if(t.indent-t.baseIndent<4)for(;c<t.text.length&&t.text.charCodeAt(c)==n;)c++;if(c-t.pos>=s&&t.skipSpace(c)==t.text.length){for(let u of t.markers)l.push(u);l.push(_(P.CodeMark,e.lineStart+t.pos,e.lineStart+c)),e.nextLine();break}else{h||mi(l,e.lineStart-1,e.lineStart);for(let f of t.markers)l.push(f);let u=e.lineStart+t.basePos,d=e.lineStart+t.text.length;u<d&&mi(l,u,d)}}return e.addNode(e.buffer.writeElements(l,-r).finish(P.FencedCode,e.prevLineEnd()-r),r),!0},Blockquote(e,t){let i=_c(t);return i<0?!1:(e.startContext(P.Blockquote,t.pos),e.addNode(P.QuoteMark,e.lineStart+t.pos,e.lineStart+t.pos+1),t.moveBase(t.pos+i),null)},HorizontalRule(e,t){if(Eo(t,e,!1)<0)return!1;let i=e.lineStart+t.pos;return e.nextLine(),e.addNode(P.HorizontalRule,i),!0},BulletList(e,t){let i=Ro(t,e,!1);if(i<0)return!1;e.block.type!=P.BulletList&&e.startContext(P.BulletList,t.basePos,t.next);let r=Ec(t,t.pos+1);return e.startContext(P.ListItem,t.basePos,r-t.baseIndent),e.addNode(P.ListMark,e.lineStart+t.pos,e.lineStart+t.pos+i),t.moveBaseColumn(r),null},OrderedList(e,t){let i=Xo(t,e,!1);if(i<0)return!1;e.block.type!=P.OrderedList&&e.startContext(P.OrderedList,t.basePos,t.text.charCodeAt(t.pos+i-1));let r=Ec(t,t.pos+i);return e.startContext(P.ListItem,t.basePos,r-t.baseIndent),e.addNode(P.ListMark,e.lineStart+t.pos,e.lineStart+t.pos+i),t.moveBaseColumn(r),null},ATXHeading(e,t){let i=zc(t);if(i<0)return!1;let r=t.pos,n=e.lineStart+r,s=Zc(t.text,t.text.length,r),o=s;for(;o>r&&t.text.charCodeAt(o-1)==t.next;)o--;(o==s||o==r||!rt(t.text.charCodeAt(o-1)))&&(o=t.text.length);let a=e.buffer.write(P.HeaderMark,0,i).writeElements(e.parser.parseInline(t.text.slice(r+i+1,o),n+i+1),-n);o<t.text.length&&a.write(P.HeaderMark,o-r,s-r);let l=a.finish(P.ATXHeading1-1+i,t.text.length-r);return e.nextLine(),e.addNode(l,n),!0},HTMLBlock(e,t){let i=Hc(t,e,!1);if(i<0)return!1;let r=e.lineStart+t.pos,n=To[i][1],s=[],o=n!=$o;for(;!n.test(t.text)&&e.nextLine();){if(t.depth<e.stack.length){o=!1;break}for(let h of t.markers)s.push(h)}o&&e.nextLine();let a=n==Gc?P.CommentBlock:n==Fc?P.ProcessingInstructionBlock:P.HTMLBlock,l=e.prevLineEnd();return e.addNode(e.buffer.writeElements(s,-r).finish(a,l-r),r),!0},SetextHeading:void 0},B1=class{constructor(e){this.stage=0,this.elts=[],this.pos=0,this.start=e.start,this.advance(e.content)}nextLine(e,t,i){if(this.stage==-1)return!1;let r=i.content+`
-`+t.scrub(),n=this.advance(r);return n>-1&&n<r.length?this.complete(e,i,n):!1}finish(e,t){return(this.stage==2||this.stage==3)&&pr(t.content,this.pos)==t.content.length?this.complete(e,t,t.content.length):!1}complete(e,t,i){return e.addLeafElement(t,_(P.LinkReference,this.start,this.start+i,this.elts)),!0}nextStage(e){return e?(this.pos=e.to-this.start,this.elts.push(e),this.stage++,!0):(e===!1&&(this.stage=-1),!1)}advance(e){for(;;){if(this.stage==-1)return-1;if(this.stage==0){if(!this.nextStage(au(e,this.pos,this.start,!0)))return-1;if(e.charCodeAt(this.pos)!=58)return this.stage=-1;this.elts.push(_(P.LinkMark,this.pos+this.start,this.pos+this.start+1)),this.pos++}else if(this.stage==1){if(!this.nextStage(su(e,pr(e,this.pos),this.start)))return-1}else if(this.stage==2){let t=pr(e,this.pos),i=0;if(t>this.pos){let r=ou(e,t,this.start);if(r){let n=ko(e,r.to-this.start);n>0&&(this.nextStage(r),i=n)}}return i||(i=ko(e,this.pos)),i>0&&i<e.length?i:-1}else return ko(e,this.pos)}}};function ko(e,t){for(;t<e.length;t++){let i=e.charCodeAt(t);if(i==10)break;if(!rt(i))return-1}return t}var G1=class{nextLine(e,t,i){let r=t.depth<e.stack.length?-1:Bc(t),n=t.next;if(r<0)return!1;let s=_(P.HeaderMark,e.lineStart+t.pos,e.lineStart+r);return e.nextLine(),e.addLeafElement(i,_(n==61?P.SetextHeading1:P.SetextHeading2,i.start,e.prevLineEnd(),[...e.parser.parseInline(i.content,i.start),s])),!0}finish(){return!1}},F1={LinkReference(e,t){return t.content.charCodeAt(0)==91?new B1(t):null},SetextHeading(){return new G1}},H1=[(e,t)=>zc(t)>=0,(e,t)=>Dc(t)>=0,(e,t)=>_c(t)>=0,(e,t)=>Ro(t,e,!0)>=0,(e,t)=>Xo(t,e,!0)>=0,(e,t)=>Eo(t,e,!0)>=0,(e,t)=>Hc(t,e,!0)>=0],K1={text:"",end:0},J1=class{constructor(e,t,i,r){this.parser=e,this.input=t,this.ranges=r,this.line=new z1,this.atEnd=!1,this.reusePlaceholders=new Map,this.stoppedAt=null,this.rangeI=0,this.to=r[r.length-1].to,this.lineStart=this.absoluteLineStart=this.absoluteLineEnd=r[0].from,this.block=Cc.create(P.Document,0,this.lineStart,0,0),this.stack=[this.block],this.fragments=i.length?new rb(i,t):null,this.readLine()}get parsedPos(){return this.absoluteLineStart}advance(){if(this.stoppedAt!=null&&this.absoluteLineStart>this.stoppedAt)return this.finish();let{line:e}=this;for(;;){for(let i=0;;){let r=e.depth<this.stack.length?this.stack[this.stack.length-1]:null;for(;i<e.markers.length&&(!r||e.markers[i].from<r.end);){let n=e.markers[i++];this.addNode(n.type,n.from,n.to)}if(!r)break;this.finishContext()}if(e.pos<e.text.length)break;if(!this.nextLine())return this.finish()}if(this.fragments&&this.reuseFragment(e.basePos))return null;e:for(;;){for(let i of this.parser.blockParsers)if(i){let r=i(this,e);if(r!=!1){if(r==!0)return null;e.forward();continue e}}break}let t=new U1(this.lineStart+e.pos,e.text.slice(e.pos));for(let i of this.parser.leafBlockParsers)if(i){let r=i(this,t);r&&t.parsers.push(r)}e:for(;this.nextLine()&&e.pos!=e.text.length;){if(e.indent<e.baseIndent+4){for(let i of this.parser.endLeafBlock)if(i(this,e,t))break e}for(let i of t.parsers)if(i.nextLine(this,e,t))return null;t.content+=`
-`+e.scrub();for(let i of e.markers)t.marks.push(i)}return this.finishLeaf(t),null}stopAt(e){if(this.stoppedAt!=null&&this.stoppedAt<e)throw new RangeError("Can't move stoppedAt forward");this.stoppedAt=e}reuseFragment(e){if(!this.fragments.moveTo(this.absoluteLineStart+e,this.absoluteLineStart)||!this.fragments.matches(this.block.hash))return!1;let t=this.fragments.takeNodes(this);return t?(this.absoluteLineStart+=t,this.lineStart=lu(this.absoluteLineStart,this.ranges),this.moveRangeI(),this.absoluteLineStart<this.to?(this.lineStart++,this.absoluteLineStart++,this.readLine()):(this.atEnd=!0,this.readLine()),!0):!1}get depth(){return this.stack.length}parentType(e=this.depth-1){return this.parser.nodeSet.types[this.stack[e].type]}nextLine(){return this.lineStart+=this.line.text.length,this.absoluteLineEnd>=this.to?(this.absoluteLineStart=this.absoluteLineEnd,this.atEnd=!0,this.readLine(),!1):(this.lineStart++,this.absoluteLineStart=this.absoluteLineEnd+1,this.moveRangeI(),this.readLine(),!0)}moveRangeI(){for(;this.rangeI<this.ranges.length-1&&this.absoluteLineStart>=this.ranges[this.rangeI].to;)this.rangeI++,this.absoluteLineStart=Math.max(this.absoluteLineStart,this.ranges[this.rangeI].from)}scanLine(e){let t=K1;if(t.end=e,e>=this.to)t.text="";else if(t.text=this.lineChunkAt(e),t.end+=t.text.length,this.ranges.length>1){let i=this.absoluteLineStart,r=this.rangeI;for(;this.ranges[r].to<t.end;){r++;let n=this.ranges[r].from,s=this.lineChunkAt(n);t.end=n+s.length,t.text=t.text.slice(0,this.ranges[r-1].to-i)+s,i=t.end-t.text.length}}return t}readLine(){let{line:e}=this,{text:t,end:i}=this.scanLine(this.absoluteLineStart);for(this.absoluteLineEnd=i,e.reset(t);e.depth<this.stack.length;e.depth++){let r=this.stack[e.depth],n=this.parser.skipContextMarkup[r.type];if(!n)throw new Error("Unhandled block context "+P[r.type]);if(!n(r,this,e))break;e.forward()}}lineChunkAt(e){let t=this.input.chunk(e),i;if(this.input.lineChunks)i=t==`
-`?"":t;else{let r=t.indexOf(`
-`);i=r<0?t:t.slice(0,r)}return e+i.length>this.to?i.slice(0,this.to-e):i}prevLineEnd(){return this.atEnd?this.lineStart:this.lineStart-1}startContext(e,t,i=0){this.block=Cc.create(e,i,this.lineStart+t,this.block.hash,this.lineStart+this.line.text.length),this.stack.push(this.block)}startComposite(e,t,i=0){this.startContext(this.parser.getNodeType(e),t,i)}addNode(e,t,i){typeof e=="number"&&(e=new L(this.parser.nodeSet.types[e],Ri,Ri,(i??this.prevLineEnd())-t)),this.block.addChild(e,t-this.block.from)}addElement(e){this.block.addChild(e.toTree(this.parser.nodeSet),e.from-this.block.from)}addLeafElement(e,t){this.addNode(this.buffer.writeElements(Zo(t.children,e.marks),-t.from).finish(t.type,t.to-t.from),t.from)}finishContext(){let e=this.stack.pop(),t=this.stack[this.stack.length-1];t.addChild(e.toTree(this.parser.nodeSet),e.from-t.from),this.block=t}finish(){for(;this.stack.length>1;)this.finishContext();return this.addGaps(this.block.toTree(this.parser.nodeSet,this.lineStart))}addGaps(e){return this.ranges.length>1?Kc(this.ranges,0,e.topNode,this.ranges[0].from,this.reusePlaceholders):e}finishLeaf(e){for(let i of e.parsers)if(i.finish(this,e))return;let t=Zo(this.parser.parseInline(e.content,e.start),e.marks);this.addNode(this.buffer.writeElements(t,-e.start).finish(P.Paragraph,e.content.length),e.start)}elt(e,t,i,r){return typeof e=="string"?_(this.parser.getNodeType(e),t,i,r):new iu(e,t)}get buffer(){return new tu(this.parser.nodeSet)}};function Kc(e,t,i,r,n){let s=e[t].to,o=[],a=[],l=i.from+r;function h(c,u){for(;u?c>=s:c>s;){let d=e[t+1].from-s;r+=d,c+=d,t++,s=e[t].to}}for(let c=i.firstChild;c;c=c.nextSibling){h(c.from+r,!0);let u=c.from+r,d,f=n.get(c.tree);f?d=f:c.to+r>s?(d=Kc(e,t,c,r,n),h(c.to+r,!1)):d=c.toTree(),o.push(d),a.push(u-l)}return h(i.to+r,!1),new L(i.type,o,a,i.to+r-l,i.tree?i.tree.propValues:void 0)}var Mo=class Jc extends pi{constructor(t,i,r,n,s,o,a,l,h){super(),this.nodeSet=t,this.blockParsers=i,this.leafBlockParsers=r,this.blockNames=n,this.endLeafBlock=s,this.skipContextMarkup=o,this.inlineParsers=a,this.inlineNames=l,this.wrappers=h,this.nodeTypes=Object.create(null);for(let c of t.types)this.nodeTypes[c.name]=c.id}createParse(t,i,r){let n=new J1(this,t,i,r);for(let s of this.wrappers)n=s(n,t,i,r);return n}configure(t){let i=Co(t);if(!i)return this;let{nodeSet:r,skipContextMarkup:n}=this,s=this.blockParsers.slice(),o=this.leafBlockParsers.slice(),a=this.blockNames.slice(),l=this.inlineParsers.slice(),h=this.inlineNames.slice(),c=this.endLeafBlock.slice(),u=this.wrappers;if(fr(i.defineNodes)){n=Object.assign({},n);let d=r.types.slice(),f;for(let p of i.defineNodes){let{name:O,block:g,composite:y,style:b}=typeof p=="string"?{name:p}:p;if(d.some(k=>k.name==O))continue;y&&(n[d.length]=(k,Z,T)=>y(Z,T,k.value));let S=d.length,w=y?["Block","BlockContext"]:g?S>=P.ATXHeading1&&S<=P.SetextHeading2?["Block","LeafBlock","Heading"]:["Block","LeafBlock"]:void 0;d.push(le.define({id:S,name:O,props:w&&[[M.group,w]]})),b&&(f||(f={}),Array.isArray(b)||b instanceof V?f[O]=b:Object.assign(f,b))}r=new fi(d),f&&(r=r.extend(Re(f)))}if(fr(i.props)&&(r=r.extend(...i.props)),fr(i.remove))for(let d of i.remove){let f=this.blockNames.indexOf(d),p=this.inlineNames.indexOf(d);f>-1&&(s[f]=o[f]=void 0),p>-1&&(l[p]=void 0)}if(fr(i.parseBlock))for(let d of i.parseBlock){let f=a.indexOf(d.name);if(f>-1)s[f]=d.parse,o[f]=d.leaf;else{let p=d.before?En(a,d.before):d.after?En(a,d.after)+1:a.length-1;s.splice(p,0,d.parse),o.splice(p,0,d.leaf),a.splice(p,0,d.name)}d.endLeaf&&c.push(d.endLeaf)}if(fr(i.parseInline))for(let d of i.parseInline){let f=h.indexOf(d.name);if(f>-1)l[f]=d.parse;else{let p=d.before?En(h,d.before):d.after?En(h,d.after)+1:h.length-1;l.splice(p,0,d.parse),h.splice(p,0,d.name)}}return i.wrap&&(u=u.concat(i.wrap)),new Jc(r,s,o,a,c,n,l,h,u)}getNodeType(t){let i=this.nodeTypes[t];if(i==null)throw new RangeError(`Unknown node type '${t}'`);return i}parseInline(t,i){let r=new tb(this,t,i);e:for(let n=i;n<r.end;){let s=r.char(n);for(let o of this.inlineParsers)if(o){let a=o(r,s,n);if(a>=0){n=a;continue e}}n++}return r.resolveMarkers(0)}};function fr(e){return e!=null&&e.length>0}function Co(e){if(!Array.isArray(e))return e;if(e.length==0)return null;let t=Co(e[0]);if(e.length==1)return t;let i=Co(e.slice(1));if(!i||!t)return t||i;let r=(o,a)=>(o||Ri).concat(a||Ri),n=t.wrap,s=i.wrap;return{props:r(t.props,i.props),defineNodes:r(t.defineNodes,i.defineNodes),parseBlock:r(t.parseBlock,i.parseBlock),parseInline:r(t.parseInline,i.parseInline),remove:r(t.remove,i.remove),wrap:n?s?(o,a,l,h)=>n(s(o,a,l,h),a,l,h):n:s}}function En(e,t){let i=e.indexOf(t);if(i<0)throw new RangeError(`Position specified relative to unknown parser ${t}`);return i}var eu=[le.none];for(let e=1,t;t=P[e];e++)eu[e]=le.define({id:e,name:t,props:e>=P.Escape?[]:[[M.group,e in jc?["Block","BlockContext"]:["Block","LeafBlock"]]],top:t=="Document"});var Ri=[],tu=class{constructor(e){this.nodeSet=e,this.content=[],this.nodes=[]}write(e,t,i,r=0){return this.content.push(e,t,i,4+r*4),this}writeElements(e,t=0){for(let i of e)i.writeTo(this,t);return this}finish(e,t){return L.build({buffer:this.content,nodeSet:this.nodeSet,reused:this.nodes,topID:e,length:t})}},mr=class{constructor(e,t,i,r=Ri){this.type=e,this.from=t,this.to=i,this.children=r}writeTo(e,t){let i=e.content.length;e.writeElements(this.children,t),e.content.push(this.type,this.from+t,this.to+t,e.content.length+4-i)}toTree(e){return new tu(e).writeElements(this.children,-this.from).finish(this.type,this.to-this.from)}},iu=class{constructor(e,t){this.tree=e,this.from=t}get to(){return this.from+this.tree.length}get type(){return this.tree.type.id}get children(){return Ri}writeTo(e,t){e.nodes.push(this.tree),e.content.push(e.nodes.length-1,this.from+t,this.to+t,-1)}toTree(){return this.tree}};function _(e,t,i,r){return new mr(e,t,i,r)}var ru={resolve:"Emphasis",mark:"EmphasisMark"},nu={resolve:"Emphasis",mark:"EmphasisMark"},Ei={},Ao={},it=class{constructor(e,t,i,r){this.type=e,this.from=t,this.to=i,this.side=r}},Rc="!\"#$%&'()*+,-./:;<=>?@[\\]^_`{|}~",gr=/[!"#$%&'()*+,\-.\/:;<=>?@\[\\\]^_`{|}~\xA1\u2010-\u2027]/;try{gr=new RegExp("[\\p{Pc}|\\p{Pd}|\\p{Pe}|\\p{Pf}|\\p{Pi}|\\p{Po}|\\p{Ps}]","u")}catch{}var Qo={Escape(e,t,i){if(t!=92||i==e.end-1)return-1;let r=e.char(i+1);for(let n=0;n<Rc.length;n++)if(Rc.charCodeAt(n)==r)return e.append(_(P.Escape,i,i+2));return-1},Entity(e,t,i){if(t!=38)return-1;let r=/^(?:#\d+|#x[a-f\d]+|\w+);/i.exec(e.slice(i+1,i+31));return r?e.append(_(P.Entity,i,i+1+r[0].length)):-1},InlineCode(e,t,i){if(t!=96||i&&e.char(i-1)==96)return-1;let r=i+1;for(;r<e.end&&e.char(r)==96;)r++;let n=r-i,s=0;for(;r<e.end;r++)if(e.char(r)==96){if(s++,s==n&&e.char(r+1)!=96)return e.append(_(P.InlineCode,i,r+1,[_(P.CodeMark,i,i+n),_(P.CodeMark,r+1-n,r+1)]))}else s=0;return-1},HTMLTag(e,t,i){if(t!=60||i==e.end-1)return-1;let r=e.slice(i+1,e.end),n=/^(?:[a-z][-\w+.]+:[^\s>]+|[a-z\d.!#$%&'*+/=?^_`{|}~-]+@[a-z\d](?:[a-z\d-]{0,61}[a-z\d])?(?:\.[a-z\d](?:[a-z\d-]{0,61}[a-z\d])?)*)>/i.exec(r);if(n)return e.append(_(P.Autolink,i,i+1+n[0].length,[_(P.LinkMark,i,i+1),_(P.URL,i+1,i+n[0].length),_(P.LinkMark,i+n[0].length,i+1+n[0].length)]));let s=/^!--[^>](?:-[^-]|[^-])*?-->/i.exec(r);if(s)return e.append(_(P.Comment,i,i+1+s[0].length));let o=/^\?[^]*?\?>/.exec(r);if(o)return e.append(_(P.ProcessingInstruction,i,i+1+o[0].length));let a=/^(?:![A-Z][^]*?>|!\[CDATA\[[^]*?\]\]>|\/\s*[a-zA-Z][\w-]*\s*>|\s*[a-zA-Z][\w-]*(\s+[a-zA-Z:_][\w-.:]*(?:\s*=\s*(?:[^\s"'=<>`]+|'[^']*'|"[^"]*"))?)*\s*(\/\s*)?>)/.exec(r);return a?e.append(_(P.HTMLTag,i,i+1+a[0].length)):-1},Emphasis(e,t,i){if(t!=95&&t!=42)return-1;let r=i+1;for(;e.char(r)==t;)r++;let n=e.slice(i-1,i),s=e.slice(r,r+1),o=gr.test(n),a=gr.test(s),l=/\s|^$/.test(n),h=/\s|^$/.test(s),c=!h&&(!a||l||o),u=!l&&(!o||h||a),d=c&&(t==42||!u||o),f=u&&(t==42||!c||a);return e.append(new it(t==95?ru:nu,i,r,(d?1:0)|(f?2:0)))},HardBreak(e,t,i){if(t==92&&e.char(i+1)==10)return e.append(_(P.HardBreak,i,i+2));if(t==32){let r=i+1;for(;e.char(r)==32;)r++;if(e.char(r)==10&&r>=i+2)return e.append(_(P.HardBreak,i,r+1))}return-1},Link(e,t,i){return t==91?e.append(new it(Ei,i,i+1,1)):-1},Image(e,t,i){return t==33&&e.char(i+1)==91?e.append(new it(Ao,i,i+2,1)):-1},LinkEnd(e,t,i){if(t!=93)return-1;for(let r=e.parts.length-1;r>=0;r--){let n=e.parts[r];if(n instanceof it&&(n.type==Ei||n.type==Ao)){if(!n.side||e.skipSpace(n.to)==i&&!/[(\[]/.test(e.slice(i+1,i+2)))return e.parts[r]=null,-1;let s=e.takeContent(r),o=e.parts[r]=eb(e,s,n.type==Ei?P.Link:P.Image,n.from,i+1);if(n.type==Ei)for(let a=0;a<r;a++){let l=e.parts[a];l instanceof it&&l.type==Ei&&(l.side=0)}return o.to}}return-1}};function eb(e,t,i,r,n){let{text:s}=e,o=e.char(n),a=n;if(t.unshift(_(P.LinkMark,r,r+(i==P.Image?2:1))),t.push(_(P.LinkMark,n-1,n)),o==40){let l=e.skipSpace(n+1),h=su(s,l-e.offset,e.offset),c;h&&(l=e.skipSpace(h.to),l!=h.to&&(c=ou(s,l-e.offset,e.offset),c&&(l=e.skipSpace(c.to)))),e.char(l)==41&&(t.push(_(P.LinkMark,n,n+1)),a=l+1,h&&t.push(h),c&&t.push(c),t.push(_(P.LinkMark,l,a)))}else if(o==91){let l=au(s,n-e.offset,e.offset,!1);l&&(t.push(l),a=l.to)}return _(i,r,a,t)}function su(e,t,i){if(e.charCodeAt(t)==60){for(let r=t+1;r<e.length;r++){let n=e.charCodeAt(r);if(n==62)return _(P.URL,t+i,r+1+i);if(n==60||n==10)return!1}return null}else{let r=0,n=t;for(let s=!1;n<e.length;n++){let o=e.charCodeAt(n);if(rt(o))break;if(s)s=!1;else if(o==40)r++;else if(o==41){if(!r)break;r--}else o==92&&(s=!0)}return n>t?_(P.URL,t+i,n+i):n==e.length?null:!1}}function ou(e,t,i){let r=e.charCodeAt(t);if(r!=39&&r!=34&&r!=40)return!1;let n=r==40?41:r;for(let s=t+1,o=!1;s<e.length;s++){let a=e.charCodeAt(s);if(o)o=!1;else{if(a==n)return _(P.LinkTitle,t+i,s+1+i);a==92&&(o=!0)}}return null}function au(e,t,i,r){for(let n=!1,s=t+1,o=Math.min(e.length,s+999);s<o;s++){let a=e.charCodeAt(s);if(n)n=!1;else{if(a==93)return r?!1:_(P.LinkLabel,t+i,s+1+i);if(r&&!rt(a)&&(r=!1),a==91)return!1;a==92&&(n=!0)}}return null}var tb=class{constructor(e,t,i){this.parser=e,this.text=t,this.offset=i,this.parts=[]}char(e){return e>=this.end?-1:this.text.charCodeAt(e-this.offset)}get end(){return this.offset+this.text.length}slice(e,t){return this.text.slice(e-this.offset,t-this.offset)}append(e){return this.parts.push(e),e.to}addDelimiter(e,t,i,r,n){return this.append(new it(e,t,i,(r?1:0)|(n?2:0)))}get hasOpenLink(){for(let e=this.parts.length-1;e>=0;e--){let t=this.parts[e];if(t instanceof it&&(t.type==Ei||t.type==Ao))return!0}return!1}addElement(e){return this.append(e)}resolveMarkers(e){for(let i=e;i<this.parts.length;i++){let r=this.parts[i];if(!(r instanceof it&&r.type.resolve&&r.side&2))continue;let n=r.type==ru||r.type==nu,s=r.to-r.from,o,a=i-1;for(;a>=e;a--){let f=this.parts[a];if(f instanceof it&&f.side&1&&f.type==r.type&&!(n&&(r.side&1||f.side&2)&&(f.to-f.from+s)%3==0&&((f.to-f.from)%3||s%3))){o=f;break}}if(!o)continue;let l=r.type.resolve,h=[],c=o.from,u=r.to;if(n){let f=Math.min(2,o.to-o.from,s);c=o.to-f,u=r.from+f,l=f==1?"Emphasis":"StrongEmphasis"}o.type.mark&&h.push(this.elt(o.type.mark,c,o.to));for(let f=a+1;f<i;f++)this.parts[f]instanceof mr&&h.push(this.parts[f]),this.parts[f]=null;r.type.mark&&h.push(this.elt(r.type.mark,r.from,u));let d=this.elt(l,c,u,h);this.parts[a]=n&&o.from!=c?new it(o.type,o.from,c,o.side):null,(this.parts[i]=n&&r.to!=u?new it(r.type,u,r.to,r.side):null)?this.parts.splice(i,0,d):this.parts[i]=d}let t=[];for(let i=e;i<this.parts.length;i++){let r=this.parts[i];r instanceof mr&&t.push(r)}return t}findOpeningDelimiter(e){for(let t=this.parts.length-1;t>=0;t--){let i=this.parts[t];if(i instanceof it&&i.type==e)return t}return null}takeContent(e){let t=this.resolveMarkers(e);return this.parts.length=e,t}skipSpace(e){return pr(this.text,e-this.offset)+this.offset}elt(e,t,i,r){return typeof e=="string"?_(this.parser.getNodeType(e),t,i,r):new iu(e,t)}};function Zo(e,t){if(!t.length)return e;if(!e.length)return t;let i=e.slice(),r=0;for(let n of t){for(;r<i.length&&i[r].to<n.to;)r++;if(r<i.length&&i[r].from<n.from){let s=i[r];s instanceof mr&&(i[r]=new mr(s.type,s.from,s.to,Zo(s.children,[n])))}else i.splice(r++,0,n)}return i}var ib=[P.CodeBlock,P.ListItem,P.OrderedList,P.BulletList],rb=class{constructor(e,t){this.fragments=e,this.input=t,this.i=0,this.fragment=null,this.fragmentEnd=-1,this.cursor=null,e.length&&(this.fragment=e[this.i++])}nextFragment(){this.fragment=this.i<this.fragments.length?this.fragments[this.i++]:null,this.cursor=null,this.fragmentEnd=-1}moveTo(e,t){for(;this.fragment&&this.fragment.to<=e;)this.nextFragment();if(!this.fragment||this.fragment.from>(e?e-1:0))return!1;if(this.fragmentEnd<0){let n=this.fragment.to;for(;n>0&&this.input.read(n-1,n)!=`
-`;)n--;this.fragmentEnd=n?n-1:0}let i=this.cursor;i||(i=this.cursor=this.fragment.tree.cursor(),i.firstChild());let r=e+this.fragment.offset;for(;i.to<=r;)if(!i.parent())return!1;for(;;){if(i.from>=r)return this.fragment.from<=t;if(!i.childAfter(r))return!1}}matches(e){let t=this.cursor.tree;return t&&t.prop(M.contextHash)==e}takeNodes(e){let t=this.cursor,i=this.fragment.offset,r=this.fragmentEnd-(this.fragment.openEnd?1:0),n=e.absoluteLineStart,s=n,o=e.block.children.length,a=s,l=o;for(;;){if(t.to-i>r){if(t.type.isAnonymous&&t.firstChild())continue;break}let h=lu(t.from-i,e.ranges);if(t.to-i<=e.ranges[e.rangeI].to)e.addNode(t.tree,h);else{let c=new L(e.parser.nodeSet.types[P.Paragraph],[],[],0,e.block.hashProp);e.reusePlaceholders.set(c,t.tree),e.addNode(c,h)}if(t.type.is("Block")&&(ib.indexOf(t.type.id)<0?(s=t.to-i,o=e.block.children.length):(s=a,o=l,a=t.to-i,l=e.block.children.length)),!t.nextSibling())break}for(;e.block.children.length>o;)e.block.children.pop(),e.block.positions.pop();return s-n}};function lu(e,t){let i=e;for(let r=1;r<t.length;r++){let n=t[r-1].to,s=t[r].from;n<e&&(i-=s-n)}return i}var nb=Re({"Blockquote/...":m.quote,HorizontalRule:m.contentSeparator,"ATXHeading1/... SetextHeading1/...":m.heading1,"ATXHeading2/... SetextHeading2/...":m.heading2,"ATXHeading3/...":m.heading3,"ATXHeading4/...":m.heading4,"ATXHeading5/...":m.heading5,"ATXHeading6/...":m.heading6,"Comment CommentBlock":m.comment,Escape:m.escape,Entity:m.character,"Emphasis/...":m.emphasis,"StrongEmphasis/...":m.strong,"Link/... Image/...":m.link,"OrderedList/... BulletList/...":m.list,"BlockQuote/...":m.quote,"InlineCode CodeText":m.monospace,"URL Autolink":m.url,"HeaderMark HardBreak QuoteMark ListMark LinkMark EmphasisMark CodeMark":m.processingInstruction,"CodeInfo LinkLabel":m.labelName,LinkTitle:m.string,Paragraph:m.content}),hu=new Mo(new fi(eu).extend(nb),Object.keys(Zn).map(e=>Zn[e]),Object.keys(Zn).map(e=>F1[e]),Object.keys(Zn),H1,jc,Object.keys(Qo).map(e=>Qo[e]),Object.keys(Qo),[]);function sb(e,t,i){let r=[];for(let n=e.firstChild,s=t;;n=n.nextSibling){let o=n?n.from:i;if(o>s&&r.push({from:s,to:o}),!n)break;s=n.to}return r}function cu(e){let{codeParser:t,htmlParser:i}=e;return{wrap:Qn((r,n)=>{let s=r.type.id;if(t&&(s==P.CodeBlock||s==P.FencedCode)){let o="";if(s==P.FencedCode){let l=r.node.getChild(P.CodeInfo);l&&(o=n.read(l.from,l.to))}let a=t(o);if(a)return{parser:a,overlay:l=>l.type.id==P.CodeText}}else if(i&&(s==P.HTMLBlock||s==P.HTMLTag))return{parser:i,overlay:sb(r.node,r.from,r.to)};return null})}}var ob={resolve:"Strikethrough",mark:"StrikethroughMark"},Wo={defineNodes:[{name:"Strikethrough",style:{"Strikethrough/...":m.strikethrough}},{name:"StrikethroughMark",style:m.processingInstruction}],parseInline:[{name:"Strikethrough",parse(e,t,i){if(t!=126||e.char(i+1)!=126||e.char(i+2)==126)return-1;let r=e.slice(i-1,i),n=e.slice(i+2,i+3),s=/\s|^$/.test(r),o=/\s|^$/.test(n),a=gr.test(r),l=gr.test(n);return e.addDelimiter(ob,i,i+2,!o&&(!l||s||a),!s&&(!a||o||l))},after:"Emphasis"}]};function Or(e,t,i=0,r,n=0){let s=0,o=!0,a=-1,l=-1,h=!1,c=()=>{r.push(e.elt("TableCell",n+a,n+l,e.parser.parseInline(t.slice(a,l),n+a)))};for(let u=i;u<t.length;u++){let d=t.charCodeAt(u);d==124&&!h?((!o||a>-1)&&s++,o=!1,r&&(a>-1&&c(),r.push(e.elt("TableDelimiter",u+n,u+n+1))),a=l=-1):(h||d!=32&&d!=9)&&(a<0&&(a=u),l=u+1),h=!h&&d==92}return a>-1&&(s++,r&&c()),s}function Xc(e,t){for(let i=t;i<e.length;i++){let r=e.charCodeAt(i);if(r==124)return!0;r==92&&i++}return!1}var uu=/^\|?(\s*:?-+:?\s*\|)+(\s*:?-+:?\s*)?$/,Mc=class{constructor(){this.rows=null}nextLine(e,t,i){if(this.rows==null){this.rows=!1;let r;if((t.next==45||t.next==58||t.next==124)&&uu.test(r=t.text.slice(t.pos))){let n=[];Or(e,i.content,0,n,i.start)==Or(e,r,t.pos)&&(this.rows=[e.elt("TableHeader",i.start,i.start+i.content.length,n),e.elt("TableDelimiter",e.lineStart+t.pos,e.lineStart+t.text.length)])}}else if(this.rows){let r=[];Or(e,t.text,t.pos,r,e.lineStart),this.rows.push(e.elt("TableRow",e.lineStart+t.pos,e.lineStart+t.text.length,r))}return!1}finish(e,t){return this.rows?(e.addLeafElement(t,e.elt("Table",t.start,t.start+t.content.length,this.rows)),!0):!1}},ab={defineNodes:[{name:"Table",block:!0},{name:"TableHeader",style:{"TableHeader/...":m.heading}},"TableRow",{name:"TableCell",style:m.content},{name:"TableDelimiter",style:m.processingInstruction}],parseBlock:[{name:"Table",leaf(e,t){return Xc(t.content,0)?new Mc:null},endLeaf(e,t,i){if(i.parsers.some(n=>n instanceof Mc)||!Xc(t.text,t.basePos))return!1;let r=e.scanLine(e.absoluteLineEnd+1).text;return uu.test(r)&&Or(e,t.text,t.basePos)==Or(e,r,t.basePos)},before:"SetextHeading"}]},lb=class{nextLine(){return!1}finish(e,t){return e.addLeafElement(t,e.elt("Task",t.start,t.start+t.content.length,[e.elt("TaskMarker",t.start,t.start+3),...e.parser.parseInline(t.content.slice(3),t.start+3)])),!0}},hb={defineNodes:[{name:"Task",block:!0,style:m.list},{name:"TaskMarker",style:m.atom}],parseBlock:[{name:"TaskList",leaf(e,t){return/^\[[ xX]\][ \t]/.test(t.content)&&e.parentType().name=="ListItem"?new lb:null},after:"SetextHeading"}]},Wc=/(www\.)|(https?:\/\/)|([\w.+-]+@)|(mailto:|xmpp:)/gy,qc=/[\w-]+(\.[\w-]+)+(\/[^\s<]*)?/gy,cb=/[\w-]+\.[\w-]+($|\/)/,Yc=/[\w.+-]+@[\w-]+(\.[\w.-]+)+/gy,Ic=/\/[a-zA-Z\d@.]+/gy;function Lc(e,t,i,r){let n=0;for(let s=t;s<i;s++)e[s]==r&&n++;return n}function ub(e,t){qc.lastIndex=t;let i=qc.exec(e);if(!i||cb.exec(i[0])[0].indexOf("_")>-1)return-1;let r=t+i[0].length;for(;;){let n=e[r-1],s;if(/[?!.,:*_~]/.test(n)||n==")"&&Lc(e,t,r,")")>Lc(e,t,r,"("))r--;else if(n==";"&&(s=/&(?:#\d+|#x[a-f\d]+|\w+);$/.exec(e.slice(t,r))))r=t+s.index;else break}return r}function Vc(e,t){Yc.lastIndex=t;let i=Yc.exec(e);if(!i)return-1;let r=i[0][i[0].length-1];return r=="_"||r=="-"?-1:t+i[0].length-(r=="."?1:0)}var db={parseInline:[{name:"Autolink",parse(e,t,i){let r=i-e.offset;Wc.lastIndex=r;let n=Wc.exec(e.text),s=-1;if(!n)return-1;if(n[1]||n[2]){if(s=ub(e.text,r+n[0].length),s>-1&&e.hasOpenLink){let o=/([^\[\]]|\[[^\]]*\])*/.exec(e.text.slice(r,s));s=r+o[0].length}}else n[3]?s=Vc(e.text,r):(s=Vc(e.text,r+n[0].length),s>-1&&n[0]=="xmpp:"&&(Ic.lastIndex=s,n=Ic.exec(e.text),n&&(s=n.index+n[0].length)));return s<0?-1:(e.addElement(e.elt("URL",i,s+e.offset)),s+e.offset)}}]},du=[ab,hb,Wo,db];function fu(e,t,i){return(r,n,s)=>{if(n!=e||r.char(s+1)==e)return-1;let o=[r.elt(i,s,s+1)];for(let a=s+1;a<r.end;a++){let l=r.char(a);if(l==e)return r.addElement(r.elt(t,s,a+1,o.concat(r.elt(i,a,a+1))));if(l==92&&o.push(r.elt("Escape",a,a+++2)),rt(l))break}return-1}}var Rn={defineNodes:[{name:"Superscript",style:m.special(m.content)},{name:"SuperscriptMark",style:m.processingInstruction}],parseInline:[{name:"Superscript",parse:fu(94,"Superscript","SuperscriptMark")}]},Xn={defineNodes:[{name:"Subscript",style:m.special(m.content)},{name:"SubscriptMark",style:m.processingInstruction}],parseInline:[{name:"Subscript",parse:fu(126,"Subscript","SubscriptMark")}]},pu={defineNodes:[{name:"Emoji",style:m.character}],parseInline:[{name:"Emoji",parse(e,t,i){let r;return t!=58||!(r=/^[a-zA-Z_0-9]+:/.exec(e.slice(i+1,e.end)))?-1:e.addElement(e.elt("Emoji",i,i+1+r[0].length))}}]};var G=class Pu{lineAt(t){if(t<0||t>this.length)throw new RangeError(`Invalid position ${t} in document of length ${this.length}`);return this.lineInner(t,!1,1,0)}line(t){if(t<1||t>this.lines)throw new RangeError(`Invalid line number ${t} in ${this.lines}-line document`);return this.lineInner(t,!0,1,0)}replace(t,i,r){[t,i]=qi(this,t,i);let n=[];return this.decompose(0,t,n,2),r.length&&r.decompose(0,r.length,n,3),this.decompose(i,this.length,n,1),Yn.from(n,this.length-(i-t)+r.length)}append(t){return this.replace(this.length,this.length,t)}slice(t,i=this.length){[t,i]=qi(this,t,i);let r=[];return this.decompose(t,i,r,0),Yn.from(r,i-t)}eq(t){if(t==this)return!0;if(t.length!=this.length||t.lines!=this.lines)return!1;let i=this.scanIdentical(t,1),r=this.length-this.scanIdentical(t,-1),n=new vr(this),s=new vr(t);for(let o=i,a=i;;){if(n.next(o),s.next(o),o=0,n.lineBreak!=s.lineBreak||n.done!=s.done||n.value!=s.value)return!1;if(a+=n.value.length,n.done||a>=r)return!0}}iter(t=1){return new vr(this,t)}iterRange(t,i=this.length){return new ku(this,t,i)}iterLines(t,i){let r;if(t==null)r=this.iter();else{i==null&&(i=this.lines+1);let n=this.line(t).from;r=this.iterRange(n,Math.max(n,i==this.lines+1?this.length:i<=1?0:this.line(i-1).to))}return new Qu(r)}toString(){return this.sliceString(0)}toJSON(){let t=[];return this.flatten(t),t}constructor(){}static of(t){if(t.length==0)throw new RangeError("A document must have at least one line");return t.length==1&&!t[0]?Pu.empty:t.length<=32?new lt(t):Yn.from(lt.split(t,[]))}},lt=class St extends G{constructor(t,i=fb(t)){super(),this.text=t,this.length=i}get lines(){return this.text.length}get children(){return null}lineInner(t,i,r,n){for(let s=0;;s++){let o=this.text[s],a=n+o.length;if((i?r:a)>=t)return new pb(n,a,r,o);n=a+1,r++}}decompose(t,i,r,n){let s=t<=0&&i>=this.length?this:new St(Ou(this.text,t,i),Math.min(i,this.length)-Math.max(0,t));if(n&1){let o=r.pop(),a=In(s.text,o.text.slice(),0,s.length);if(a.length<=32)r.push(new St(a,o.length+s.length));else{let l=a.length>>1;r.push(new St(a.slice(0,l)),new St(a.slice(l)))}}else r.push(s)}replace(t,i,r){if(!(r instanceof St))return super.replace(t,i,r);[t,i]=qi(this,t,i);let n=In(this.text,In(r.text,Ou(this.text,0,t)),i),s=this.length+r.length-(i-t);return n.length<=32?new St(n,s):Yn.from(St.split(n,[]),s)}sliceString(t,i=this.length,r=`
-`){[t,i]=qi(this,t,i);let n="";for(let s=0,o=0;s<=i&&o<this.text.length;o++){let a=this.text[o],l=s+a.length;s>t&&o&&(n+=r),t<l&&i>s&&(n+=a.slice(Math.max(0,t-s),i-s)),s=l+1}return n}flatten(t){for(let i of this.text)t.push(i)}scanIdentical(){return 0}static split(t,i){let r=[],n=-1;for(let s of t)r.push(s),n+=s.length+1,r.length==32&&(i.push(new St(r,n)),r=[],n=-1);return n>-1&&i.push(new St(r,n)),i}},Yn=class Xi extends G{constructor(t,i){super(),this.children=t,this.length=i,this.lines=0;for(let r of t)this.lines+=r.lines}lineInner(t,i,r,n){for(let s=0;;s++){let o=this.children[s],a=n+o.length,l=r+o.lines-1;if((i?l:a)>=t)return o.lineInner(t,i,r,n);n=a+1,r=l+1}}decompose(t,i,r,n){for(let s=0,o=0;o<=i&&s<this.children.length;s++){let a=this.children[s],l=o+a.length;if(t<=l&&i>=o){let h=n&((o<=t?1:0)|(l>=i?2:0));o>=t&&l<=i&&!h?r.push(a):a.decompose(t-o,i-o,r,h)}o=l+1}}replace(t,i,r){if([t,i]=qi(this,t,i),r.lines<this.lines)for(let n=0,s=0;n<this.children.length;n++){let o=this.children[n],a=s+o.length;if(t>=s&&i<=a){let l=o.replace(t-s,i-s,r),h=this.lines-o.lines+l.lines;if(l.lines<h>>4&&l.lines>h>>6){let c=this.children.slice();return c[n]=l,new Xi(c,this.length-(i-t)+r.length)}return super.replace(s,a,l)}s=a+1}return super.replace(t,i,r)}sliceString(t,i=this.length,r=`
-`){[t,i]=qi(this,t,i);let n="";for(let s=0,o=0;s<this.children.length&&o<=i;s++){let a=this.children[s],l=o+a.length;o>t&&s&&(n+=r),t<l&&i>o&&(n+=a.sliceString(t-o,i-o,r)),o=l+1}return n}flatten(t){for(let i of this.children)i.flatten(t)}scanIdentical(t,i){if(!(t instanceof Xi))return 0;let r=0,[n,s,o,a]=i>0?[0,0,this.children.length,t.children.length]:[this.children.length-1,t.children.length-1,-1,-1];for(;;n+=i,s+=i){if(n==o||s==a)return r;let l=this.children[n],h=t.children[s];if(l!=h)return r+l.scanIdentical(h,i);r+=l.length+1}}static from(t,i=t.reduce((r,n)=>r+n.length+1,-1)){let r=0;for(let f of t)r+=f.lines;if(r<32){let f=[];for(let p of t)p.flatten(f);return new lt(f,i)}let n=Math.max(32,r>>5),s=n<<1,o=n>>1,a=[],l=0,h=-1,c=[];function u(f){let p;if(f.lines>s&&f instanceof Xi)for(let O of f.children)u(O);else f.lines>o&&(l>o||!l)?(d(),a.push(f)):f instanceof lt&&l&&(p=c[c.length-1])instanceof lt&&f.lines+p.lines<=32?(l+=f.lines,h+=f.length+1,c[c.length-1]=new lt(p.text.concat(f.text),p.length+1+f.length)):(l+f.lines>n&&d(),l+=f.lines,h+=f.length+1,c.push(f))}function d(){l!=0&&(a.push(c.length==1?c[0]:Xi.from(c,h)),h=-1,l=c.length=0)}for(let f of t)u(f);return d(),a.length==1?a[0]:new Xi(a,i)}};G.empty=new lt([""],0);function fb(e){let t=-1;for(let i of e)t+=i.length+1;return t}function In(e,t,i=0,r=1e9){for(let n=0,s=0,o=!0;s<e.length&&n<=r;s++){let a=e[s],l=n+a.length;l>=i&&(l>r&&(a=a.slice(0,r-n)),n<i&&(a=a.slice(i-n)),o?(t[t.length-1]+=a,o=!1):t.push(a)),n=l+1}return t}function Ou(e,t,i){return In(e,[""],t,i)}var vr=class{constructor(e,t=1){this.dir=t,this.done=!1,this.lineBreak=!1,this.value="",this.nodes=[e],this.offsets=[t>0?1:(e instanceof lt?e.text.length:e.children.length)<<1]}nextInner(e,t){for(this.done=this.lineBreak=!1;;){let i=this.nodes.length-1,r=this.nodes[i],n=this.offsets[i],s=n>>1,o=r instanceof lt?r.text.length:r.children.length;if(s==(t>0?o:0)){if(i==0)return this.done=!0,this.value="",this;t>0&&this.offsets[i-1]++,this.nodes.pop(),this.offsets.pop()}else if((n&1)==(t>0?0:1)){if(this.offsets[i]+=t,e==0)return this.lineBreak=!0,this.value=`
-`,this;e--}else if(r instanceof lt){let a=r.text[s+(t<0?-1:0)];if(this.offsets[i]+=t,a.length>Math.max(0,e))return this.value=e==0?a:t>0?a.slice(e):a.slice(0,a.length-e),this;e-=a.length}else{let a=r.children[s+(t<0?-1:0)];e>a.length?(e-=a.length,this.offsets[i]+=t):(t<0&&this.offsets[i]--,this.nodes.push(a),this.offsets.push(t>0?1:(a instanceof lt?a.text.length:a.children.length)<<1))}}}next(e=0){return e<0&&(this.nextInner(-e,-this.dir),e=this.value.length),this.nextInner(e,this.dir)}},ku=class{constructor(e,t,i){this.value="",this.done=!1,this.cursor=new vr(e,t>i?-1:1),this.pos=t>i?e.length:0,this.from=Math.min(t,i),this.to=Math.max(t,i)}nextInner(e,t){if(t<0?this.pos<=this.from:this.pos>=this.to)return this.value="",this.done=!0,this;e+=Math.max(0,t<0?this.pos-this.to:this.from-this.pos);let i=t<0?this.pos-this.from:this.to-this.pos;e>i&&(e=i),i-=e;let{value:r}=this.cursor.next(e);return this.pos+=(r.length+e)*t,this.value=r.length<=i?r:t<0?r.slice(r.length-i):r.slice(0,i),this.done=!this.value,this}next(e=0){return e<0?e=Math.max(e,this.from-this.pos):e>0&&(e=Math.min(e,this.to-this.pos)),this.nextInner(e,this.cursor.dir)}get lineBreak(){return this.cursor.lineBreak&&this.value!=""}},Qu=class{constructor(e){this.inner=e,this.afterBreak=!0,this.value="",this.done=!1}next(e=0){let{done:t,lineBreak:i,value:r}=this.inner.next(e);return t&&this.afterBreak?(this.value="",this.afterBreak=!1):t?(this.done=!0,this.value=""):i?this.afterBreak?this.value="":(this.afterBreak=!0,this.next()):(this.value=r,this.afterBreak=!1),this}get lineBreak(){return!1}};typeof Symbol<"u"&&(G.prototype[Symbol.iterator]=function(){return this.iter()},vr.prototype[Symbol.iterator]=ku.prototype[Symbol.iterator]=Qu.prototype[Symbol.iterator]=function(){return this});var pb=class{constructor(e,t,i,r){this.from=e,this.to=t,this.number=i,this.text=r}get length(){return this.to-this.from}};function qi(e,t,i){return t=Math.max(0,Math.min(e.length,t)),[t,Math.max(t,Math.min(e.length,i))]}var Mi="lc,34,7n,7,7b,19,,,,2,,2,,,20,b,1c,l,g,,2t,7,2,6,2,2,,4,z,,u,r,2j,b,1m,9,9,,o,4,,9,,3,,5,17,3,3b,f,,w,1j,,,,4,8,4,,3,7,a,2,t,,1m,,,,2,4,8,,9,,a,2,q,,2,2,1l,,4,2,4,2,2,3,3,,u,2,3,,b,2,1l,,4,5,,2,4,,k,2,m,6,,,1m,,,2,,4,8,,7,3,a,2,u,,1n,,,,c,,9,,14,,3,,1l,3,5,3,,4,7,2,b,2,t,,1m,,2,,2,,3,,5,2,7,2,b,2,s,2,1l,2,,,2,4,8,,9,,a,2,t,,20,,4,,2,3,,,8,,29,,2,7,c,8,2q,,2,9,b,6,22,2,r,,,,,,1j,e,,5,,2,5,b,,10,9,,2u,4,,6,,2,2,2,p,2,4,3,g,4,d,,2,2,6,,f,,jj,3,qa,3,t,3,t,2,u,2,1s,2,,7,8,,2,b,9,,19,3,3b,2,y,,3a,3,4,2,9,,6,3,63,2,2,,1m,,,7,,,,,2,8,6,a,2,,1c,h,1r,4,1c,7,,,5,,14,9,c,2,w,4,2,2,,3,1k,,,2,3,,,3,1m,8,2,2,48,3,,d,,7,4,,6,,3,2,5i,1m,,5,ek,,5f,x,2da,3,3x,,2o,w,fe,6,2x,2,n9w,4,,a,w,2,28,2,7k,,3,,4,,p,2,5,,47,2,q,i,d,,12,8,p,b,1a,3,1c,,2,4,2,2,13,,1v,6,2,2,2,2,c,,8,,1b,,1f,,,3,2,2,5,2,,,16,2,8,,6m,,2,,4,,fn4,,kh,g,g,g,a6,2,gt,,6a,,45,5,1ae,3,,2,5,4,14,3,4,,4l,2,fx,4,ar,2,49,b,4w,,1i,f,1k,3,1d,4,2,2,1x,3,10,5,,8,1q,,c,2,1g,9,a,4,2,,2n,3,2,,,2,6,,4g,,3,8,l,2,1l,2,,,,,m,,e,7,3,5,5f,8,2,3,,,n,,29,,2,6,,,2,,,2,,2,6j,,2,4,6,2,,2,r,2,2d,8,2,,,2,2y,,,,2,6,,,2t,3,2,4,,5,77,9,,2,6t,,a,2,,,4,,40,4,2,2,4,,w,a,14,6,2,4,8,,9,6,2,3,1a,d,,2,ba,7,,6,,,2a,m,2,7,,2,,2,3e,6,3,,,2,,7,,,20,2,3,,,,9n,2,f0b,5,1n,7,t4,,1r,4,29,,f5k,2,43q,,,3,4,5,8,8,2,7,u,4,44,3,1iz,1j,4,1e,8,,e,,m,5,,f,11s,7,,h,2,7,,2,,5,79,7,c5,4,15s,7,31,7,240,5,gx7k,2o,3k,6o".split(",").map(e=>e?parseInt(e,36):1);for(let e=1;e<Mi.length;e++)Mi[e]+=Mi[e-1];function Ob(e){for(let t=1;t<Mi.length;t+=2)if(Mi[t]>e)return Mi[t-1]<=e;return!1}function mu(e){return e>=127462&&e<=127487}var gu=8205;function ht(e,t,i=!0,r=!0){return(i?$u:mb)(e,t,r)}function $u(e,t,i){if(t==e.length)return t;t&&Tu(e.charCodeAt(t))&&Cu(e.charCodeAt(t-1))&&t--;let r=Qe(e,t);for(t+=nt(r);t<e.length;){let n=Qe(e,t);if(r==gu||n==gu||i&&Ob(n))t+=nt(n),r=n;else if(mu(n)){let s=0,o=t-2;for(;o>=0&&mu(Qe(e,o));)s++,o-=2;if(s%2==0)break;t+=2}else break}return t}function mb(e,t,i){for(;t>0;){let r=$u(e,t-2,i);if(r<t)return r;t--}return 0}function Tu(e){return e>=56320&&e<57344}function Cu(e){return e>=55296&&e<56320}function Qe(e,t){let i=e.charCodeAt(t);if(!Cu(i)||t+1==e.length)return i;let r=e.charCodeAt(t+1);return Tu(r)?(i-55296<<10)+(r-56320)+65536:i}function Ho(e){return e<=65535?String.fromCharCode(e):(e-=65536,String.fromCharCode((e>>10)+55296,(e&1023)+56320))}function nt(e){return e<65536?1:2}var Yo=/\r\n?|\n/,ge=function(e){return e[e.Simple=0]="Simple",e[e.TrackDel=1]="TrackDel",e[e.TrackBefore=2]="TrackBefore",e[e.TrackAfter=3]="TrackAfter",e}(ge||(ge={})),Sr=class Ln{constructor(t){this.sections=t}get length(){let t=0;for(let i=0;i<this.sections.length;i+=2)t+=this.sections[i];return t}get newLength(){let t=0;for(let i=0;i<this.sections.length;i+=2){let r=this.sections[i+1];t+=r<0?this.sections[i]:r}return t}get empty(){return this.sections.length==0||this.sections.length==2&&this.sections[1]<0}iterGaps(t){for(let i=0,r=0,n=0;i<this.sections.length;){let s=this.sections[i++],o=this.sections[i++];o<0?(t(r,n,s),n+=s):n+=o,r+=s}}iterChangedRanges(t,i=!1){Io(this,t,i)}get invertedDesc(){let t=[];for(let i=0;i<this.sections.length;){let r=this.sections[i++],n=this.sections[i++];n<0?t.push(r,n):t.push(n,r)}return new Ln(t)}composeDesc(t){return this.empty?t:t.empty?this:Au(this,t)}mapDesc(t,i=!1){return t.empty?this:Lo(this,t,i)}mapPos(t,i=-1,r=ge.Simple){let n=0,s=0;for(let o=0;o<this.sections.length;){let a=this.sections[o++],l=this.sections[o++],h=n+a;if(l<0){if(h>t)return s+(t-n);s+=a}else{if(r!=ge.Simple&&h>=t&&(r==ge.TrackDel&&n<t&&h>t||r==ge.TrackBefore&&n<t||r==ge.TrackAfter&&h>t))return null;if(h>t||h==t&&i<0&&!a)return t==n||i<0?s:s+l;s+=l}n=h}if(t>n)throw new RangeError(`Position ${t} is out of range for changeset of length ${n}`);return s}touchesRange(t,i=t){for(let r=0,n=0;r<this.sections.length&&n<=i;){let s=this.sections[r++],o=this.sections[r++],a=n+s;if(o>=0&&n<=i&&a>=t)return n<t&&a>i?"cover":!0;n=a}return!1}toString(){let t="";for(let i=0;i<this.sections.length;){let r=this.sections[i++],n=this.sections[i++];t+=(t?" ":"")+r+(n>=0?":"+n:"")}return t}toJSON(){return this.sections}static fromJSON(t){if(!Array.isArray(t)||t.length%2||t.some(i=>typeof i!="number"))throw new RangeError("Invalid JSON representation of ChangeDesc");return new Ln(t)}static create(t){return new Ln(t)}},ct=class _t extends Sr{constructor(t,i){super(t),this.inserted=i}apply(t){if(this.length!=t.length)throw new RangeError("Applying change set to a document with the wrong length");return Io(this,(i,r,n,s,o)=>t=t.replace(n,n+(r-i),o),!1),t}mapDesc(t,i=!1){return Lo(this,t,i,!0)}invert(t){let i=this.sections.slice(),r=[];for(let n=0,s=0;n<i.length;n+=2){let o=i[n],a=i[n+1];if(a>=0){i[n]=a,i[n+1]=o;let l=n>>1;for(;r.length<l;)r.push(G.empty);r.push(o?t.slice(s,s+o):G.empty)}s+=o}return new _t(i,r)}compose(t){return this.empty?t:t.empty?this:Au(this,t,!0)}map(t,i=!1){return t.empty?this:Lo(this,t,i,!0)}iterChanges(t,i=!1){Io(this,t,i)}get desc(){return Sr.create(this.sections)}filter(t){let i=[],r=[],n=[],s=new Pr(this);e:for(let o=0,a=0;;){let l=o==t.length?1e9:t[o++];for(;a<l||a==l&&s.len==0;){if(s.done)break e;let c=Math.min(s.len,l-a);we(n,c,-1);let u=s.ins==-1?-1:s.off==0?s.ins:0;we(i,c,u),u>0&&Ut(r,i,s.text),s.forward(c),a+=c}let h=t[o++];for(;a<h;){if(s.done)break e;let c=Math.min(s.len,h-a);we(i,c,-1),we(n,c,s.ins==-1?-1:s.off==0?s.ins:0),s.forward(c),a+=c}}return{changes:new _t(i,r),filtered:Sr.create(n)}}toJSON(){let t=[];for(let i=0;i<this.sections.length;i+=2){let r=this.sections[i],n=this.sections[i+1];n<0?t.push(r):n==0?t.push([r]):t.push([r].concat(this.inserted[i>>1].toJSON()))}return t}static of(t,i,r){let n=[],s=[],o=0,a=null;function l(c=!1){if(!c&&!n.length)return;o<i&&we(n,i-o,-1);let u=new _t(n,s);a=a?a.compose(u.map(a)):u,n=[],s=[],o=0}function h(c){if(Array.isArray(c))for(let u of c)h(u);else if(c instanceof _t){if(c.length!=i)throw new RangeError(`Mismatched change set length (got ${c.length}, expected ${i})`);l(),a=a?a.compose(c.map(a)):c}else{let{from:u,to:d=u,insert:f}=c;if(u>d||u<0||d>i)throw new RangeError(`Invalid change range ${u} to ${d} (in doc of length ${i})`);let p=f?typeof f=="string"?G.of(f.split(r||Yo)):f:G.empty,O=p.length;if(u==d&&O==0)return;u<o&&l(),u>o&&we(n,u-o,-1),we(n,d-u,O),Ut(s,n,p),o=d}}return h(t),l(!a),a}static empty(t){return new _t(t?[t,-1]:[],[])}static fromJSON(t){if(!Array.isArray(t))throw new RangeError("Invalid JSON representation of ChangeSet");let i=[],r=[];for(let n=0;n<t.length;n++){let s=t[n];if(typeof s=="number")i.push(s,-1);else{if(!Array.isArray(s)||typeof s[0]!="number"||s.some((o,a)=>a&&typeof o!="string"))throw new RangeError("Invalid JSON representation of ChangeSet");if(s.length==1)i.push(s[0],0);else{for(;r.length<n;)r.push(G.empty);r[n]=G.of(s.slice(1)),i.push(s[0],r[n].length)}}}return new _t(i,r)}static createSet(t,i){return new _t(t,i)}};function we(e,t,i,r=!1){if(t==0&&i<=0)return;let n=e.length-2;n>=0&&i<=0&&i==e[n+1]?e[n]+=t:t==0&&e[n]==0?e[n+1]+=i:r?(e[n]+=t,e[n+1]+=i):e.push(t,i)}function Ut(e,t,i){if(i.length==0)return;let r=t.length-2>>1;if(r<e.length)e[e.length-1]=e[e.length-1].append(i);else{for(;e.length<r;)e.push(G.empty);e.push(i)}}function Io(e,t,i){let r=e.inserted;for(let n=0,s=0,o=0;o<e.sections.length;){let a=e.sections[o++],l=e.sections[o++];if(l<0)n+=a,s+=a;else{let h=n,c=s,u=G.empty;for(;h+=a,c+=l,l&&r&&(u=u.append(r[o-2>>1])),!(i||o==e.sections.length||e.sections[o+1]<0);)a=e.sections[o++],l=e.sections[o++];t(n,h,s,c,u),n=h,s=c}}}function Lo(e,t,i,r=!1){let n=[],s=r?[]:null,o=new Pr(e),a=new Pr(t);for(let l=-1;;)if(o.ins==-1&&a.ins==-1){let h=Math.min(o.len,a.len);we(n,h,-1),o.forward(h),a.forward(h)}else if(a.ins>=0&&(o.ins<0||l==o.i||o.off==0&&(a.len<o.len||a.len==o.len&&!i))){let h=a.len;for(we(n,a.ins,-1);h;){let c=Math.min(o.len,h);o.ins>=0&&l<o.i&&o.len<=c&&(we(n,0,o.ins),s&&Ut(s,n,o.text),l=o.i),o.forward(c),h-=c}a.next()}else if(o.ins>=0){let h=0,c=o.len;for(;c;)if(a.ins==-1){let u=Math.min(c,a.len);h+=u,c-=u,a.forward(u)}else if(a.ins==0&&a.len<c)c-=a.len,a.next();else break;we(n,h,l<o.i?o.ins:0),s&&l<o.i&&Ut(s,n,o.text),l=o.i,o.forward(o.len-c)}else{if(o.done&&a.done)return s?ct.createSet(n,s):Sr.create(n);throw new Error("Mismatched change set lengths")}}function Au(e,t,i=!1){let r=[],n=i?[]:null,s=new Pr(e),o=new Pr(t);for(let a=!1;;){if(s.done&&o.done)return n?ct.createSet(r,n):Sr.create(r);if(s.ins==0)we(r,s.len,0,a),s.next();else if(o.len==0&&!o.done)we(r,0,o.ins,a),n&&Ut(n,r,o.text),o.next();else{if(s.done||o.done)throw new Error("Mismatched change set lengths");{let l=Math.min(s.len2,o.len),h=r.length;if(s.ins==-1){let c=o.ins==-1?-1:o.off?0:o.ins;we(r,l,c,a),n&&c&&Ut(n,r,o.text)}else o.ins==-1?(we(r,s.off?0:s.len,l,a),n&&Ut(n,r,s.textBit(l))):(we(r,s.off?0:s.len,o.off?0:o.ins,a),n&&!o.off&&Ut(n,r,o.text));a=(s.ins>l||o.ins>=0&&o.len>l)&&(a||r.length>h),s.forward2(l),o.forward(l)}}}}var Pr=class{constructor(e){this.set=e,this.i=0,this.next()}next(){let{sections:e}=this.set;this.i<e.length?(this.len=e[this.i++],this.ins=e[this.i++]):(this.len=0,this.ins=-2),this.off=0}get done(){return this.ins==-2}get len2(){return this.ins<0?this.len:this.ins}get text(){let{inserted:e}=this.set,t=this.i-2>>1;return t>=e.length?G.empty:e[t]}textBit(e){let{inserted:t}=this.set,i=this.i-2>>1;return i>=t.length&&!e?G.empty:t[i].slice(this.off,e==null?void 0:this.off+e)}forward(e){e==this.len?this.next():(this.len-=e,this.off+=e)}forward2(e){this.ins==-1?this.forward(e):e==this.ins?this.next():(this.ins-=e,this.off+=e)}},Mn=class Vo{constructor(t,i,r){this.from=t,this.to=i,this.flags=r}get anchor(){return this.flags&32?this.to:this.from}get head(){return this.flags&32?this.from:this.to}get empty(){return this.from==this.to}get assoc(){return this.flags&8?-1:this.flags&16?1:0}get bidiLevel(){let t=this.flags&7;return t==7?null:t}get goalColumn(){let t=this.flags>>6;return t==16777215?void 0:t}map(t,i=-1){let r,n;return this.empty?r=n=t.mapPos(this.from,i):(r=t.mapPos(this.from,1),n=t.mapPos(this.to,-1)),r==this.from&&n==this.to?this:new Vo(r,n,this.flags)}extend(t,i=t){if(t<=this.anchor&&i>=this.anchor)return $.range(t,i);let r=Math.abs(t-this.anchor)>Math.abs(i-this.anchor)?t:i;return $.range(this.anchor,r)}eq(t,i=!1){return this.anchor==t.anchor&&this.head==t.head&&(!i||!this.empty||this.assoc==t.assoc)}toJSON(){return{anchor:this.anchor,head:this.head}}static fromJSON(t){if(!t||typeof t.anchor!="number"||typeof t.head!="number")throw new RangeError("Invalid JSON representation for SelectionRange");return $.range(t.anchor,t.head)}static create(t,i,r){return new Vo(t,i,r)}},$=class De{constructor(t,i){this.ranges=t,this.mainIndex=i}map(t,i=-1){return t.empty?this:De.create(this.ranges.map(r=>r.map(t,i)),this.mainIndex)}eq(t,i=!1){if(this.ranges.length!=t.ranges.length||this.mainIndex!=t.mainIndex)return!1;for(let r=0;r<this.ranges.length;r++)if(!this.ranges[r].eq(t.ranges[r],i))return!1;return!0}get main(){return this.ranges[this.mainIndex]}asSingle(){return this.ranges.length==1?this:new De([this.main],0)}addRange(t,i=!0){return De.create([t].concat(this.ranges),i?0:this.mainIndex+1)}replaceRange(t,i=this.mainIndex){let r=this.ranges.slice();return r[i]=t,De.create(r,this.mainIndex)}toJSON(){return{ranges:this.ranges.map(t=>t.toJSON()),main:this.mainIndex}}static fromJSON(t){if(!t||!Array.isArray(t.ranges)||typeof t.main!="number"||t.main>=t.ranges.length)throw new RangeError("Invalid JSON representation for EditorSelection");return new De(t.ranges.map(i=>Mn.fromJSON(i)),t.main)}static single(t,i=t){return new De([De.range(t,i)],0)}static create(t,i=0){if(t.length==0)throw new RangeError("A selection needs at least one range");for(let r=0,n=0;n<t.length;n++){let s=t[n];if(s.empty?s.from<=r:s.from<r)return De.normalized(t.slice(),i);r=s.to}return new De(t,i)}static cursor(t,i=0,r,n){return Mn.create(t,t,(i==0?0:i<0?8:16)|(r==null?7:Math.min(6,r))|(n??16777215)<<6)}static range(t,i,r,n){let s=(r??16777215)<<6|(n==null?7:Math.min(6,n));return i<t?Mn.create(i,t,48|s):Mn.create(t,i,(i>t?8:0)|s)}static normalized(t,i=0){let r=t[i];t.sort((n,s)=>n.from-s.from),i=t.indexOf(r);for(let n=1;n<t.length;n++){let s=t[n],o=t[n-1];if(s.empty?s.from<=o.to:s.from<o.to){let a=o.from,l=Math.max(s.to,o.to);n<=i&&i--,t.splice(--n,2,s.anchor>s.head?De.range(l,a):De.range(a,l))}}return new De(t,i)}};function Zu(e,t){for(let i of e.ranges)if(i.to>t)throw new RangeError("Selection points outside of document")}var Ko=0,E=class Eu{constructor(t,i,r,n,s){this.combine=t,this.compareInput=i,this.compare=r,this.isStatic=n,this.id=Ko++,this.default=t([]),this.extensions=typeof s=="function"?s(this):s}get reader(){return this}static define(t={}){return new Eu(t.combine||(i=>i),t.compareInput||((i,r)=>i===r),t.compare||(t.combine?(i,r)=>i===r:Jo),!!t.static,t.enables)}of(t){return new Vn([],this,0,t)}compute(t,i){if(this.isStatic)throw new Error("Can't compute a static facet");return new Vn(t,this,1,i)}computeN(t,i){if(this.isStatic)throw new Error("Can't compute a static facet");return new Vn(t,this,2,i)}from(t,i){return i||(i=r=>r),this.compute([t],r=>i(r.field(t)))}};function Jo(e,t){return e==t||e.length==t.length&&e.every((i,r)=>i===t[r])}var Vn=class{constructor(e,t,i,r){this.dependencies=e,this.facet=t,this.type=i,this.value=r,this.id=Ko++}dynamicSlot(e){var t;let i=this.value,r=this.facet.compareInput,n=this.id,s=e[n]>>1,o=this.type==2,a=!1,l=!1,h=[];for(let c of this.dependencies)c=="doc"?a=!0:c=="selection"?l=!0:((t=e[c.id])!==null&&t!==void 0?t:1)&1||h.push(e[c.id]);return{create(c){return c.values[s]=i(c),1},update(c,u){if(a&&u.docChanged||l&&(u.docChanged||u.selection)||No(c,h)){let d=i(c);if(o?!yu(d,c.values[s],r):!r(d,c.values[s]))return c.values[s]=d,1}return 0},reconfigure:(c,u)=>{let d,f=u.config.address[n];if(f!=null){let p=Nn(u,f);if(this.dependencies.every(O=>O instanceof E?u.facet(O)===c.facet(O):O instanceof We?u.field(O,!1)==c.field(O,!1):!0)||(o?yu(d=i(c),p,r):r(d=i(c),p)))return c.values[s]=p,0}else d=i(c);return c.values[s]=d,1}}}};function yu(e,t,i){if(e.length!=t.length)return!1;for(let r=0;r<e.length;r++)if(!i(e[r],t[r]))return!1;return!0}function No(e,t){let i=!1;for(let r of t)xr(e,r)&1&&(i=!0);return i}function gb(e,t,i){let r=i.map(l=>e[l.id]),n=i.map(l=>l.type),s=r.filter(l=>!(l&1)),o=e[t.id]>>1;function a(l){let h=[];for(let c=0;c<r.length;c++){let u=Nn(l,r[c]);if(n[c]==2)for(let d of u)h.push(d);else h.push(u)}return t.combine(h)}return{create(l){for(let h of r)xr(l,h);return l.values[o]=a(l),1},update(l,h){if(!No(l,s))return 0;let c=a(l);return t.compare(c,l.values[o])?0:(l.values[o]=c,1)},reconfigure(l,h){let c=No(l,r),u=h.config.facets[t.id],d=h.facet(t);if(u&&!c&&Jo(i,u))return l.values[o]=d,0;let f=a(l);return t.compare(f,d)?(l.values[o]=d,0):(l.values[o]=f,1)}}}var bu=E.define({static:!0}),We=class Ru{constructor(t,i,r,n,s){this.id=t,this.createF=i,this.updateF=r,this.compareF=n,this.spec=s,this.provides=void 0}static define(t){let i=new Ru(Ko++,t.create,t.update,t.compare||((r,n)=>r===n),t);return t.provide&&(i.provides=t.provide(i)),i}create(t){return(t.facet(bu).find(r=>r.field==this)?.create||this.createF)(t)}slot(t){let i=t[this.id]>>1;return{create:r=>(r.values[i]=this.create(r),1),update:(r,n)=>{let s=r.values[i],o=this.updateF(s,n);return this.compareF(s,o)?0:(r.values[i]=o,1)},reconfigure:(r,n)=>n.config.address[this.id]!=null?(r.values[i]=n.field(this),0):(r.values[i]=this.create(r),1)}}init(t){return[this,bu.of({field:this,create:t})]}get extension(){return this}},gi={lowest:4,low:3,default:2,high:1,highest:0};function yr(e){return t=>new Xu(t,e)}var _e={highest:yr(gi.highest),high:yr(gi.high),default:yr(gi.default),low:yr(gi.low),lowest:yr(gi.lowest)},Xu=class{constructor(e,t){this.inner=e,this.prec=t}},Mu=class Wu{of(t){return new jo(this,t)}reconfigure(t){return Wu.reconfigure.of({compartment:this,extension:t})}get(t){return t.config.compartments.get(this)}},jo=class{constructor(e,t){this.compartment=e,this.inner=t}},wu=class qu{constructor(t,i,r,n,s,o){for(this.base=t,this.compartments=i,this.dynamicSlots=r,this.address=n,this.staticValues=s,this.facets=o,this.statusTemplate=[];this.statusTemplate.length<r.length;)this.statusTemplate.push(0)}staticFacet(t){let i=this.address[t.id];return i==null?t.default:this.staticValues[i>>1]}static resolve(t,i,r){let n=[],s=Object.create(null),o=new Map;for(let d of yb(t,i,o))d instanceof We?n.push(d):(s[d.facet.id]||(s[d.facet.id]=[])).push(d);let a=Object.create(null),l=[],h=[];for(let d of n)a[d.id]=h.length<<1,h.push(f=>d.slot(f));let c=r?.config.facets;for(let d in s){let f=s[d],p=f[0].facet,O=c&&c[d]||[];if(f.every(g=>g.type==0))if(a[p.id]=l.length<<1|1,Jo(O,f))l.push(r.facet(p));else{let g=p.combine(f.map(y=>y.value));l.push(r&&p.compare(g,r.facet(p))?r.facet(p):g)}else{for(let g of f)g.type==0?(a[g.id]=l.length<<1|1,l.push(g.value)):(a[g.id]=h.length<<1,h.push(y=>g.dynamicSlot(y)));a[p.id]=h.length<<1,h.push(g=>gb(g,p,f))}}let u=h.map(d=>d(a));return new qu(t,o,u,a,l,s)}};function yb(e,t,i){let r=[[],[],[],[],[]],n=new Map;function s(o,a){let l=n.get(o);if(l!=null){if(l<=a)return;let h=r[l].indexOf(o);h>-1&&r[l].splice(h,1),o instanceof jo&&i.delete(o.compartment)}if(n.set(o,a),Array.isArray(o))for(let h of o)s(h,a);else if(o instanceof jo){if(i.has(o.compartment))throw new RangeError("Duplicate use of compartment in extensions");let h=t.get(o.compartment)||o.inner;i.set(o.compartment,h),s(h,a)}else if(o instanceof Xu)s(o.inner,o.prec);else if(o instanceof We)r[a].push(o),o.provides&&s(o.provides,a);else if(o instanceof Vn)r[a].push(o),o.facet.extensions&&s(o.facet.extensions,gi.default);else{let h=o.extension;if(!h)throw new Error(`Unrecognized extension value in extension set (${o}). This sometimes happens because multiple instances of @codemirror/state are loaded, breaking instanceof checks.`);s(h,a)}}return s(e,gi.default),r.reduce((o,a)=>o.concat(a))}function xr(e,t){if(t&1)return 2;let i=t>>1,r=e.status[i];if(r==4)throw new Error("Cyclic dependency between fields and/or facets");if(r&2)return r;e.status[i]=4;let n=e.computeSlot(e,e.config.dynamicSlots[i]);return e.status[i]=2|n}function Nn(e,t){return t&1?e.config.staticValues[t>>1]:e.values[t>>1]}var Yu=E.define(),Do=E.define({combine:e=>e.some(t=>t),static:!0}),Iu=E.define({combine:e=>e.length?e[0]:void 0,static:!0}),Lu=E.define(),Vu=E.define(),Nu=E.define(),ju=E.define({combine:e=>e.length?e[0]:!1}),Rt=class{constructor(e,t){this.type=e,this.value=t}static define(){return new bb}},bb=class{of(e){return new Rt(this,e)}},wb=class{constructor(e){this.map=e}of(e){return new z(this,e)}},z=class Du{constructor(t,i){this.type=t,this.value=i}map(t){let i=this.type.map(this.value,t);return i===void 0?void 0:i==this.value?this:new Du(this.type,i)}is(t){return this.type==t}static define(t={}){return new wb(t.map||(i=>i))}static mapEffects(t,i){if(!t.length)return t;let r=[];for(let n of t){let s=n.map(i);s&&r.push(s)}return r}};z.reconfigure=z.define();z.appendConfig=z.define();var Me=class wr{constructor(t,i,r,n,s,o){this.startState=t,this.changes=i,this.selection=r,this.effects=n,this.annotations=s,this.scrollIntoView=o,this._doc=null,this._state=null,r&&Zu(r,i.newLength),s.some(a=>a.type==wr.time)||(this.annotations=s.concat(wr.time.of(Date.now())))}static create(t,i,r,n,s,o){return new wr(t,i,r,n,s,o)}get newDoc(){return this._doc||(this._doc=this.changes.apply(this.startState.doc))}get newSelection(){return this.selection||this.startState.selection.map(this.changes)}get state(){return this._state||this.startState.applyTransaction(this),this._state}annotation(t){for(let i of this.annotations)if(i.type==t)return i.value}get docChanged(){return!this.changes.empty}get reconfigured(){return this.startState.config!=this.state.config}isUserEvent(t){let i=this.annotation(wr.userEvent);return!!(i&&(i==t||i.length>t.length&&i.slice(0,t.length)==t&&i[t.length]=="."))}};Me.time=Rt.define();Me.userEvent=Rt.define();Me.addToHistory=Rt.define();Me.remote=Rt.define();function vb(e,t){let i=[];for(let r=0,n=0;;){let s,o;if(r<e.length&&(n==t.length||t[n]>=e[r]))s=e[r++],o=e[r++];else if(n<t.length)s=t[n++],o=t[n++];else return i;!i.length||i[i.length-1]<s?i.push(s,o):i[i.length-1]<o&&(i[i.length-1]=o)}}function _u(e,t,i){var r;let n,s,o;return i?(n=t.changes,s=ct.empty(t.changes.length),o=e.changes.compose(t.changes)):(n=t.changes.map(e.changes),s=e.changes.mapDesc(t.changes,!0),o=e.changes.compose(n)),{changes:o,selection:t.selection?t.selection.map(s):(r=e.selection)===null||r===void 0?void 0:r.map(n),effects:z.mapEffects(e.effects,n).concat(z.mapEffects(t.effects,s)),annotations:e.annotations.length?e.annotations.concat(t.annotations):t.annotations,scrollIntoView:e.scrollIntoView||t.scrollIntoView}}function _o(e,t,i){let r=t.selection,n=Wi(t.annotations);return t.userEvent&&(n=n.concat(Me.userEvent.of(t.userEvent))),{changes:t.changes instanceof ct?t.changes:ct.of(t.changes||[],i,e.facet(Iu)),selection:r&&(r instanceof $?r:$.single(r.anchor,r.head)),effects:Wi(t.effects),annotations:n,scrollIntoView:!!t.scrollIntoView}}function Uu(e,t,i){let r=_o(e,t.length?t[0]:{},e.doc.length);t.length&&t[0].filter===!1&&(i=!1);for(let s=1;s<t.length;s++){t[s].filter===!1&&(i=!1);let o=!!t[s].sequential;r=_u(r,_o(e,t[s],o?r.changes.newLength:e.doc.length),o)}let n=Me.create(e,r.changes,r.selection,r.effects,r.annotations,r.scrollIntoView);return xb(i?Sb(n):n)}function Sb(e){let t=e.startState,i=!0;for(let n of t.facet(Lu)){let s=n(e);if(s===!1){i=!1;break}Array.isArray(s)&&(i=i===!0?s:vb(i,s))}if(i!==!0){let n,s;if(i===!1)s=e.changes.invertedDesc,n=ct.empty(t.doc.length);else{let o=e.changes.filter(i);n=o.changes,s=o.filtered.mapDesc(o.changes).invertedDesc}e=Me.create(t,n,e.selection&&e.selection.map(s),z.mapEffects(e.effects,s),e.annotations,e.scrollIntoView)}let r=t.facet(Vu);for(let n=r.length-1;n>=0;n--){let s=r[n](e);s instanceof Me?e=s:Array.isArray(s)&&s.length==1&&s[0]instanceof Me?e=s[0]:e=Uu(t,Wi(s),!1)}return e}function xb(e){let t=e.startState,i=t.facet(Nu),r=e;for(let n=i.length-1;n>=0;n--){let s=i[n](e);s&&Object.keys(s).length&&(r=_u(r,_o(t,s,e.changes.newLength),!0))}return r==e?e:Me.create(t,e.changes,e.selection,r.effects,r.annotations,r.scrollIntoView)}var Pb=[];function Wi(e){return e==null?Pb:Array.isArray(e)?e:[e]}var Xe=function(e){return e[e.Word=0]="Word",e[e.Space=1]="Space",e[e.Other=2]="Other",e}(Xe||(Xe={})),kb=/[\u00df\u0587\u0590-\u05f4\u0600-\u06ff\u3040-\u309f\u30a0-\u30ff\u3400-\u4db5\u4e00-\u9fcc\uac00-\ud7af]/,Uo;try{Uo=new RegExp("[\\p{Alphabetic}\\p{Number}_]","u")}catch{}function Qb(e){if(Uo)return Uo.test(e);for(let t=0;t<e.length;t++){let i=e[t];if(/\w/.test(i)||i>"\x80"&&(i.toUpperCase()!=i.toLowerCase()||kb.test(i)))return!0}return!1}function $b(e){return t=>{if(!/\S/.test(t))return Xe.Space;if(Qb(t))return Xe.Word;for(let i=0;i<e.length;i++)if(t.indexOf(e[i])>-1)return Xe.Word;return Xe.Other}}var he=class at{constructor(t,i,r,n,s,o){this.config=t,this.doc=i,this.selection=r,this.values=n,this.status=t.statusTemplate.slice(),this.computeSlot=s,o&&(o._state=this);for(let a=0;a<this.config.dynamicSlots.length;a++)xr(this,a<<1);this.computeSlot=null}field(t,i=!0){let r=this.config.address[t.id];if(r==null){if(i)throw new RangeError("Field is not present in this state");return}return xr(this,r),Nn(this,r)}update(...t){return Uu(this,t,!0)}applyTransaction(t){let i=this.config,{base:r,compartments:n}=i;for(let a of t.effects)a.is(Mu.reconfigure)?(i&&(n=new Map,i.compartments.forEach((l,h)=>n.set(h,l)),i=null),n.set(a.value.compartment,a.value.extension)):a.is(z.reconfigure)?(i=null,r=a.value):a.is(z.appendConfig)&&(i=null,r=Wi(r).concat(a.value));let s;i?s=t.startState.values.slice():(i=wu.resolve(r,n,this),s=new at(i,this.doc,this.selection,i.dynamicSlots.map(()=>null),(a,l)=>l.reconfigure(a,this),null).values);let o=t.startState.facet(Do)?t.newSelection:t.newSelection.asSingle();new at(i,t.newDoc,o,s,(a,l)=>l.update(a,t),t)}replaceSelection(t){return typeof t=="string"&&(t=this.toText(t)),this.changeByRange(i=>({changes:{from:i.from,to:i.to,insert:t},range:$.cursor(i.from+t.length)}))}changeByRange(t){let i=this.selection,r=t(i.ranges[0]),n=this.changes(r.changes),s=[r.range],o=Wi(r.effects);for(let a=1;a<i.ranges.length;a++){let l=t(i.ranges[a]),h=this.changes(l.changes),c=h.map(n);for(let d=0;d<a;d++)s[d]=s[d].map(c);let u=n.mapDesc(h,!0);s.push(l.range.map(u)),n=n.compose(c),o=z.mapEffects(o,c).concat(z.mapEffects(Wi(l.effects),u))}return{changes:n,selection:$.create(s,i.mainIndex),effects:o}}changes(t=[]){return t instanceof ct?t:ct.of(t,this.doc.length,this.facet(at.lineSeparator))}toText(t){return G.of(t.split(this.facet(at.lineSeparator)||Yo))}sliceDoc(t=0,i=this.doc.length){return this.doc.sliceString(t,i,this.lineBreak)}facet(t){let i=this.config.address[t.id];return i==null?t.default:(xr(this,i),Nn(this,i))}toJSON(t){let i={doc:this.sliceDoc(),selection:this.selection.toJSON()};if(t)for(let r in t){let n=t[r];n instanceof We&&this.config.address[n.id]!=null&&(i[r]=n.spec.toJSON(this.field(t[r]),this))}return i}static fromJSON(t,i={},r){if(!t||typeof t.doc!="string")throw new RangeError("Invalid JSON representation for EditorState");let n=[];if(r){for(let s in r)if(Object.prototype.hasOwnProperty.call(t,s)){let o=r[s],a=t[s];n.push(o.init(l=>o.spec.fromJSON(a,l)))}}return at.create({doc:t.doc,selection:$.fromJSON(t.selection),extensions:i.extensions?n.concat([i.extensions]):n})}static create(t={}){let i=wu.resolve(t.extensions||[],new Map),r=t.doc instanceof G?t.doc:G.of((t.doc||"").split(i.staticFacet(at.lineSeparator)||Yo)),n=t.selection?t.selection instanceof $?t.selection:$.single(t.selection.anchor,t.selection.head):$.single(0);return Zu(n,r.length),i.staticFacet(Do)||(n=n.asSingle()),new at(i,r,n,i.dynamicSlots.map(()=>null),(s,o)=>o.create(s),null)}get tabSize(){return this.facet(at.tabSize)}get lineBreak(){return this.facet(at.lineSeparator)||`
-`}get readOnly(){return this.facet(ju)}phrase(t,...i){for(let r of this.facet(at.phrases))if(Object.prototype.hasOwnProperty.call(r,t)){t=r[t];break}return i.length&&(t=t.replace(/\$(\$|\d*)/g,(r,n)=>{if(n=="$")return"$";let s=+(n||1);return!s||s>i.length?r:i[s-1]})),t}languageDataAt(t,i,r=-1){let n=[];for(let s of this.facet(Yu))for(let o of s(this,i,r))Object.prototype.hasOwnProperty.call(o,t)&&n.push(o[t]);return n}charCategorizer(t){return $b(this.languageDataAt("wordChars",t).join(""))}wordAt(t){let{text:i,from:r,length:n}=this.doc.lineAt(t),s=this.charCategorizer(t),o=t-r,a=t-r;for(;o>0;){let l=ht(i,o,!1);if(s(i.slice(l,o))!=Xe.Word)break;o=l}for(;a<n;){let l=ht(i,a);if(s(i.slice(a,l))!=Xe.Word)break;a=l}return o==a?null:$.range(o+r,a+r)}};he.allowMultipleSelections=Do;he.tabSize=E.define({combine:e=>e.length?e[0]:4});he.lineSeparator=Iu;he.readOnly=ju;he.phrases=E.define({compare(e,t){let i=Object.keys(e),r=Object.keys(t);return i.length==r.length&&i.every(n=>e[n]==t[n])}});he.languageData=Yu;he.changeFilter=Lu;he.transactionFilter=Vu;he.transactionExtender=Nu;Mu.reconfigure=z.define();function Xt(e,t,i={}){let r={};for(let n of e)for(let s of Object.keys(n)){let o=n[s],a=r[s];if(a===void 0)r[s]=o;else if(!(a===o||o===void 0))if(Object.hasOwnProperty.call(i,s))r[s]=i[s](a,o);else throw new Error("Config merge conflict for field "+s)}for(let n in t)r[n]===void 0&&(r[n]=t[n]);return r}var Et=class{eq(e){return this==e}range(e,t=e){return zo.create(e,t,this)}};Et.prototype.startSide=Et.prototype.endSide=0;Et.prototype.point=!1;Et.prototype.mapMode=ge.TrackDel;var zo=class zu{constructor(t,i,r){this.from=t,this.to=i,this.value=r}static create(t,i,r){return new zu(t,i,r)}};function Bo(e,t){return e.from-t.from||e.value.startSide-t.value.startSide}var Tb=class Bu{constructor(t,i,r,n){this.from=t,this.to=i,this.value=r,this.maxPoint=n}get length(){return this.to[this.to.length-1]}findIndex(t,i,r,n=0){let s=r?this.to:this.from;for(let o=n,a=s.length;;){if(o==a)return o;let l=o+a>>1,h=s[l]-t||(r?this.value[l].endSide:this.value[l].startSide)-i;if(l==o)return h>=0?o:a;h>=0?a=l:o=l+1}}between(t,i,r,n){for(let s=this.findIndex(i,-1e9,!0),o=this.findIndex(r,1e9,!1,s);s<o;s++)if(n(this.from[s]+t,this.to[s]+t,this.value[s])===!1)return!1}map(t,i){let r=[],n=[],s=[],o=-1,a=-1;for(let l=0;l<this.value.length;l++){let h=this.value[l],c=this.from[l]+t,u=this.to[l]+t,d,f;if(c==u){let p=i.mapPos(c,h.startSide,h.mapMode);if(p==null||(d=f=p,h.startSide!=h.endSide&&(f=i.mapPos(c,h.endSide),f<d)))continue}else if(d=i.mapPos(c,h.startSide),f=i.mapPos(u,h.endSide),d>f||d==f&&h.startSide>0&&h.endSide<=0)continue;(f-d||h.endSide-h.startSide)<0||(o<0&&(o=d),h.point&&(a=Math.max(a,f-d)),r.push(h),n.push(d-o),s.push(f-o))}return{mapped:r.length?new Bu(n,s,r,a):null,pos:o}}},ie=class Zt{constructor(t,i,r,n){this.chunkPos=t,this.chunk=i,this.nextLayer=r,this.maxPoint=n}static create(t,i,r,n){return new Zt(t,i,r,n)}get length(){let t=this.chunk.length-1;return t<0?0:Math.max(this.chunkEnd(t),this.nextLayer.length)}get size(){if(this.isEmpty)return 0;let t=this.nextLayer.size;for(let i of this.chunk)t+=i.value.length;return t}chunkEnd(t){return this.chunkPos[t]+this.chunk[t].length}update(t){let{add:i=[],sort:r=!1,filterFrom:n=0,filterTo:s=this.length}=t,o=t.filter;if(i.length==0&&!o)return this;if(r&&(i=i.slice().sort(Bo)),this.isEmpty)return i.length?Zt.of(i):this;let a=new Fu(this,null,-1).goto(0),l=0,h=[],c=new yi;for(;a.value||l<i.length;)if(l<i.length&&(a.from-i[l].from||a.startSide-i[l].value.startSide)>=0){let u=i[l++];c.addInner(u.from,u.to,u.value)||h.push(u)}else a.rangeIndex==1&&a.chunkIndex<this.chunk.length&&(l==i.length||this.chunkEnd(a.chunkIndex)<i[l].from)&&(!o||n>this.chunkEnd(a.chunkIndex)||s<this.chunkPos[a.chunkIndex])&&c.addChunk(this.chunkPos[a.chunkIndex],this.chunk[a.chunkIndex])?a.nextChunk():((!o||n>a.to||s<a.from||o(a.from,a.to,a.value))&&(c.addInner(a.from,a.to,a.value)||h.push(zo.create(a.from,a.to,a.value))),a.next());return c.finishInner(this.nextLayer.isEmpty&&!h.length?Zt.empty:this.nextLayer.update({add:h,filter:o,filterFrom:n,filterTo:s}))}map(t){if(t.empty||this.isEmpty)return this;let i=[],r=[],n=-1;for(let o=0;o<this.chunk.length;o++){let a=this.chunkPos[o],l=this.chunk[o],h=t.touchesRange(a,a+l.length);if(h===!1)n=Math.max(n,l.maxPoint),i.push(l),r.push(t.mapPos(a));else if(h===!0){let{mapped:c,pos:u}=l.map(a,t);c&&(n=Math.max(n,c.maxPoint),i.push(c),r.push(u))}}let s=this.nextLayer.map(t);return i.length==0?s:new Zt(r,i,s||Zt.empty,n)}between(t,i,r){if(!this.isEmpty){for(let n=0;n<this.chunk.length;n++){let s=this.chunkPos[n],o=this.chunk[n];if(i>=s&&t<=s+o.length&&o.between(s,t-s,i-s,r)===!1)return}this.nextLayer.between(t,i,r)}}iter(t=0){return Go.from([this]).goto(t)}get isEmpty(){return this.nextLayer==this}static iter(t,i=0){return Go.from(t).goto(i)}static compare(t,i,r,n,s=-1){let o=t.filter(u=>u.maxPoint>0||!u.isEmpty&&u.maxPoint>=s),a=i.filter(u=>u.maxPoint>0||!u.isEmpty&&u.maxPoint>=s),l=vu(o,a,r),h=new br(o,l,s),c=new br(a,l,s);r.iterGaps((u,d,f)=>Su(h,u,c,d,f,n)),r.empty&&r.length==0&&Su(h,0,c,0,0,n)}static eq(t,i,r=0,n){n==null&&(n=999999999);let s=t.filter(c=>!c.isEmpty&&i.indexOf(c)<0),o=i.filter(c=>!c.isEmpty&&t.indexOf(c)<0);if(s.length!=o.length)return!1;if(!s.length)return!0;let a=vu(s,o),l=new br(s,a,0).goto(r),h=new br(o,a,0).goto(r);for(;;){if(l.to!=h.to||!Fo(l.active,h.active)||l.point&&(!h.point||!l.point.eq(h.point)))return!1;if(l.to>n)return!0;l.next(),h.next()}}static spans(t,i,r,n,s=-1){let o=new br(t,null,s).goto(i),a=i,l=o.openStart;for(;;){let h=Math.min(o.to,r);if(o.point){let c=o.activeForPoint(o.to),u=o.pointFrom<i?c.length+1:o.point.startSide<0?c.length:Math.min(c.length,l);n.point(a,h,o.point,c,u,o.pointRank),l=Math.min(o.openEnd(h),c.length)}else h>a&&(n.span(a,h,o.active,l),l=o.openEnd(h));if(o.to>r)return l+(o.point&&o.to>r?1:0);a=o.to,o.next()}}static of(t,i=!1){let r=new yi;for(let n of t instanceof zo?[t]:i?Cb(t):t)r.add(n.from,n.to,n.value);return r.finish()}static join(t){if(!t.length)return Zt.empty;let i=t[t.length-1];for(let r=t.length-2;r>=0;r--)for(let n=t[r];n!=Zt.empty;n=n.nextLayer)i=new Zt(n.chunkPos,n.chunk,i,Math.max(n.maxPoint,i.maxPoint));return i}};ie.empty=new ie([],[],null,-1);function Cb(e){if(e.length>1)for(let t=e[0],i=1;i<e.length;i++){let r=e[i];if(Bo(t,r)>0)return e.slice().sort(Bo);t=r}return e}ie.empty.nextLayer=ie.empty;var yi=class Gu{finishChunk(t){this.chunks.push(new Tb(this.from,this.to,this.value,this.maxPoint)),this.chunkPos.push(this.chunkStart),this.chunkStart=-1,this.setMaxPoint=Math.max(this.setMaxPoint,this.maxPoint),this.maxPoint=-1,t&&(this.from=[],this.to=[],this.value=[])}constructor(){this.chunks=[],this.chunkPos=[],this.chunkStart=-1,this.last=null,this.lastFrom=-1e9,this.lastTo=-1e9,this.from=[],this.to=[],this.value=[],this.maxPoint=-1,this.setMaxPoint=-1,this.nextLayer=null}add(t,i,r){this.addInner(t,i,r)||(this.nextLayer||(this.nextLayer=new Gu)).add(t,i,r)}addInner(t,i,r){let n=t-this.lastTo||r.startSide-this.last.endSide;if(n<=0&&(t-this.lastFrom||r.startSide-this.last.startSide)<0)throw new Error("Ranges must be added sorted by `from` position and `startSide`");return n<0?!1:(this.from.length==250&&this.finishChunk(!0),this.chunkStart<0&&(this.chunkStart=t),this.from.push(t-this.chunkStart),this.to.push(i-this.chunkStart),this.last=r,this.lastFrom=t,this.lastTo=i,this.value.push(r),r.point&&(this.maxPoint=Math.max(this.maxPoint,i-t)),!0)}addChunk(t,i){if((t-this.lastTo||i.value[0].startSide-this.last.endSide)<0)return!1;this.from.length&&this.finishChunk(!0),this.setMaxPoint=Math.max(this.setMaxPoint,i.maxPoint),this.chunks.push(i),this.chunkPos.push(t);let r=i.value.length-1;return this.last=i.value[r],this.lastFrom=i.from[r]+t,this.lastTo=i.to[r]+t,!0}finish(){return this.finishInner(ie.empty)}finishInner(t){if(this.from.length&&this.finishChunk(!1),this.chunks.length==0)return t;let i=ie.create(this.chunkPos,this.chunks,this.nextLayer?this.nextLayer.finishInner(t):t,this.setMaxPoint);return this.from=null,i}};function vu(e,t,i){let r=new Map;for(let s of e)for(let o=0;o<s.chunk.length;o++)s.chunk[o].maxPoint<=0&&r.set(s.chunk[o],s.chunkPos[o]);let n=new Set;for(let s of t)for(let o=0;o<s.chunk.length;o++){let a=r.get(s.chunk[o]);a!=null&&(i?i.mapPos(a):a)==s.chunkPos[o]&&!i?.touchesRange(a,a+s.chunk[o].length)&&n.add(s.chunk[o])}return n}var Fu=class{constructor(e,t,i,r=0){this.layer=e,this.skip=t,this.minPoint=i,this.rank=r}get startSide(){return this.value?this.value.startSide:0}get endSide(){return this.value?this.value.endSide:0}goto(e,t=-1e9){return this.chunkIndex=this.rangeIndex=0,this.gotoInner(e,t,!1),this}gotoInner(e,t,i){for(;this.chunkIndex<this.layer.chunk.length;){let r=this.layer.chunk[this.chunkIndex];if(!(this.skip&&this.skip.has(r)||this.layer.chunkEnd(this.chunkIndex)<e||r.maxPoint<this.minPoint))break;this.chunkIndex++,i=!1}if(this.chunkIndex<this.layer.chunk.length){let r=this.layer.chunk[this.chunkIndex].findIndex(e-this.layer.chunkPos[this.chunkIndex],t,!0);(!i||this.rangeIndex<r)&&this.setRangeIndex(r)}this.next()}forward(e,t){(this.to-e||this.endSide-t)<0&&this.gotoInner(e,t,!0)}next(){for(;;)if(this.chunkIndex==this.layer.chunk.length){this.from=this.to=1e9,this.value=null;break}else{let e=this.layer.chunkPos[this.chunkIndex],t=this.layer.chunk[this.chunkIndex],i=e+t.from[this.rangeIndex];if(this.from=i,this.to=e+t.to[this.rangeIndex],this.value=t.value[this.rangeIndex],this.setRangeIndex(this.rangeIndex+1),this.minPoint<0||this.value.point&&this.to-this.from>=this.minPoint)break}}setRangeIndex(e){if(e==this.layer.chunk[this.chunkIndex].value.length){if(this.chunkIndex++,this.skip)for(;this.chunkIndex<this.layer.chunk.length&&this.skip.has(this.layer.chunk[this.chunkIndex]);)this.chunkIndex++;this.rangeIndex=0}else this.rangeIndex=e}nextChunk(){this.chunkIndex++,this.rangeIndex=0,this.next()}compare(e){return this.from-e.from||this.startSide-e.startSide||this.rank-e.rank||this.to-e.to||this.endSide-e.endSide}},Go=class Hu{constructor(t){this.heap=t}static from(t,i=null,r=-1){let n=[];for(let s=0;s<t.length;s++)for(let o=t[s];!o.isEmpty;o=o.nextLayer)o.maxPoint>=r&&n.push(new Fu(o,i,r,s));return n.length==1?n[0]:new Hu(n)}get startSide(){return this.value?this.value.startSide:0}goto(t,i=-1e9){for(let r of this.heap)r.goto(t,i);for(let r=this.heap.length>>1;r>=0;r--)qo(this.heap,r);return this.next(),this}forward(t,i){for(let r of this.heap)r.forward(t,i);for(let r=this.heap.length>>1;r>=0;r--)qo(this.heap,r);(this.to-t||this.value.endSide-i)<0&&this.next()}next(){if(this.heap.length==0)this.from=this.to=1e9,this.value=null,this.rank=-1;else{let t=this.heap[0];this.from=t.from,this.to=t.to,this.value=t.value,this.rank=t.rank,t.value&&t.next(),qo(this.heap,0)}}};function qo(e,t){for(let i=e[t];;){let r=(t<<1)+1;if(r>=e.length)break;let n=e[r];if(r+1<e.length&&n.compare(e[r+1])>=0&&(n=e[r+1],r++),i.compare(n)<0)break;e[r]=i,e[t]=n,t=r}}var br=class{constructor(e,t,i){this.minPoint=i,this.active=[],this.activeTo=[],this.activeRank=[],this.minActive=-1,this.point=null,this.pointFrom=0,this.pointRank=0,this.to=-1e9,this.endSide=0,this.openStart=-1,this.cursor=Go.from(e,t,i)}goto(e,t=-1e9){return this.cursor.goto(e,t),this.active.length=this.activeTo.length=this.activeRank.length=0,this.minActive=-1,this.to=e,this.endSide=t,this.openStart=-1,this.next(),this}forward(e,t){for(;this.minActive>-1&&(this.activeTo[this.minActive]-e||this.active[this.minActive].endSide-t)<0;)this.removeActive(this.minActive);this.cursor.forward(e,t)}removeActive(e){Wn(this.active,e),Wn(this.activeTo,e),Wn(this.activeRank,e),this.minActive=xu(this.active,this.activeTo)}addActive(e){let t=0,{value:i,to:r,rank:n}=this.cursor;for(;t<this.activeRank.length&&(n-this.activeRank[t]||r-this.activeTo[t])>0;)t++;qn(this.active,t,i),qn(this.activeTo,t,r),qn(this.activeRank,t,n),e&&qn(e,t,this.cursor.from),this.minActive=xu(this.active,this.activeTo)}next(){let e=this.to,t=this.point;this.point=null;let i=this.openStart<0?[]:null;for(;;){let r=this.minActive;if(r>-1&&(this.activeTo[r]-this.cursor.from||this.active[r].endSide-this.cursor.startSide)<0){if(this.activeTo[r]>e){this.to=this.activeTo[r],this.endSide=this.active[r].endSide;break}this.removeActive(r),i&&Wn(i,r)}else if(this.cursor.value)if(this.cursor.from>e){this.to=this.cursor.from,this.endSide=this.cursor.startSide;break}else{let n=this.cursor.value;if(!n.point)this.addActive(i),this.cursor.next();else if(t&&this.cursor.to==this.to&&this.cursor.from<this.cursor.to)this.cursor.next();else{this.point=n,this.pointFrom=this.cursor.from,this.pointRank=this.cursor.rank,this.to=this.cursor.to,this.endSide=n.endSide,this.cursor.next(),this.forward(this.to,this.endSide);break}}else{this.to=this.endSide=1e9;break}}if(i){this.openStart=0;for(let r=i.length-1;r>=0&&i[r]<e;r--)this.openStart++}}activeForPoint(e){if(!this.active.length)return this.active;let t=[];for(let i=this.active.length-1;i>=0&&!(this.activeRank[i]<this.pointRank);i--)(this.activeTo[i]>e||this.activeTo[i]==e&&this.active[i].endSide>=this.point.endSide)&&t.push(this.active[i]);return t.reverse()}openEnd(e){let t=0;for(let i=this.activeTo.length-1;i>=0&&this.activeTo[i]>e;i--)t++;return t}};function Su(e,t,i,r,n,s){e.goto(t),i.goto(r);let o=r+n,a=r,l=r-t;for(;;){let h=e.to+l-i.to||e.endSide-i.endSide,c=h<0?e.to+l:i.to,u=Math.min(c,o);if(e.point||i.point?e.point&&i.point&&(e.point==i.point||e.point.eq(i.point))&&Fo(e.activeForPoint(e.to),i.activeForPoint(i.to))||s.comparePoint(a,u,e.point,i.point):u>a&&!Fo(e.active,i.active)&&s.compareRange(a,u,e.active,i.active),c>o)break;a=c,h<=0&&e.next(),h>=0&&i.next()}}function Fo(e,t){if(e.length!=t.length)return!1;for(let i=0;i<e.length;i++)if(e[i]!=t[i]&&!e[i].eq(t[i]))return!1;return!0}function Wn(e,t){for(let i=t,r=e.length-1;i<r;i++)e[i]=e[i+1];e.pop()}function qn(e,t,i){for(let r=e.length-1;r>=t;r--)e[r+1]=e[r];e[t]=i}function xu(e,t){let i=-1,r=1e9;for(let n=0;n<t.length;n++)(t[n]-r||e[n].endSide-e[i].endSide)<0&&(i=n,r=t[n]);return i}function zt(e,t,i=e.length){let r=0;for(let n=0;n<i;)e.charCodeAt(n)==9?(r+=t-r%t,n++):(r++,n=ht(e,n));return r}function Ku(e,t,i,r){for(let n=0,s=0;;){if(s>=t)return n;if(n==e.length)break;s+=e.charCodeAt(n)==9?i-s%i:1,n=ht(e,n)}return r===!0?-1:e.length}var Mt={8:"Backspace",9:"Tab",10:"Enter",12:"NumLock",13:"Enter",16:"Shift",17:"Control",18:"Alt",20:"CapsLock",27:"Escape",32:" ",33:"PageUp",34:"PageDown",35:"End",36:"Home",37:"ArrowLeft",38:"ArrowUp",39:"ArrowRight",40:"ArrowDown",44:"PrintScreen",45:"Insert",46:"Delete",59:";",61:"=",91:"Meta",92:"Meta",106:"*",107:"+",108:",",109:"-",110:".",111:"/",144:"NumLock",145:"ScrollLock",160:"Shift",161:"Shift",162:"Control",163:"Control",164:"Alt",165:"Alt",173:"-",186:";",187:"=",188:",",189:"-",190:".",191:"/",192:"`",219:"[",220:"\\",221:"]",222:"'"},Yi={48:")",49:"!",50:"@",51:"#",52:"$",53:"%",54:"^",55:"&",56:"*",57:"(",59:":",61:"+",173:"_",186:":",187:"+",188:"<",189:"_",190:">",191:"?",192:"~",219:"{",220:"|",221:"}",222:'"'},Ab=typeof navigator<"u"&&/Mac/.test(navigator.platform),Zb=typeof navigator<"u"&&/MSIE \d|Trident\/(?:[7-9]|\d{2,})\..*rv:(\d+)/.exec(navigator.userAgent);for(ue=0;ue<10;ue++)Mt[48+ue]=Mt[96+ue]=String(ue);var ue;for(ue=1;ue<=24;ue++)Mt[ue+111]="F"+ue;var ue;for(ue=65;ue<=90;ue++)Mt[ue]=String.fromCharCode(ue+32),Yi[ue]=String.fromCharCode(ue);var ue;for(jn in Mt)Yi.hasOwnProperty(jn)||(Yi[jn]=Mt[jn]);var jn;function Ju(e){var t=Ab&&e.metaKey&&e.shiftKey&&!e.ctrlKey&&!e.altKey||Zb&&e.shiftKey&&e.key&&e.key.length==1||e.key=="Unidentified",i=!t&&e.key||(e.shiftKey?Yi:Mt)[e.keyCode]||e.key||"Unidentified";return i=="Esc"&&(i="Escape"),i=="Del"&&(i="Delete"),i=="Left"&&(i="ArrowLeft"),i=="Up"&&(i="ArrowUp"),i=="Right"&&(i="ArrowRight"),i=="Down"&&(i="ArrowDown"),i}var ea="\u037C",ed=typeof Symbol>"u"?"__"+ea:Symbol.for(ea),ta=typeof Symbol>"u"?"__styleSet"+Math.floor(Math.random()*1e8):Symbol("styleSet"),td=typeof globalThis<"u"?globalThis:typeof window<"u"?window:{},xt=class{constructor(e,t){this.rules=[];let{finish:i}=t||{};function r(s){return/^@/.test(s)?[s]:s.split(/,\s*/)}function n(s,o,a,l){let h=[],c=/^@(\w+)\b/.exec(s[0]),u=c&&c[1]=="keyframes";if(c&&o==null)return a.push(s[0]+";");for(let d in o){let f=o[d];if(/&/.test(d))n(d.split(/,\s*/).map(p=>s.map(O=>p.replace(/&/,O))).reduce((p,O)=>p.concat(O)),f,a);else if(f&&typeof f=="object"){if(!c)throw new RangeError("The value of a property ("+d+") should be a primitive value.");n(r(d),f,h,u)}else f!=null&&h.push(d.replace(/_.*/,"").replace(/[A-Z]/g,p=>"-"+p.toLowerCase())+": "+f+";")}(h.length||u)&&a.push((i&&!c&&!l?s.map(i):s).join(", ")+" {"+h.join(" ")+"}")}for(let s in e)n(r(s),e[s],this.rules)}getRules(){return this.rules.join(`
-`)}static newName(){let e=td[ed]||1;return td[ed]=e+1,ea+e.toString(36)}static mount(e,t,i){let r=e[ta],n=i&&i.nonce;r?n&&r.setNonce(n):r=new Eb(e,n),r.mount(Array.isArray(t)?t:[t],e)}},id=new Map,Eb=class{constructor(e,t){let i=e.ownerDocument||e,r=i.defaultView;if(!e.head&&e.adoptedStyleSheets&&r.CSSStyleSheet){let n=id.get(i);if(n)return e[ta]=n;this.sheet=new r.CSSStyleSheet,id.set(i,this)}else this.styleTag=i.createElement("style"),t&&this.styleTag.setAttribute("nonce",t);this.modules=[],e[ta]=this}mount(e,t){let i=this.sheet,r=0,n=0;for(let s=0;s<e.length;s++){let o=e[s],a=this.modules.indexOf(o);if(a<n&&a>-1&&(this.modules.splice(a,1),n--,a=-1),a==-1){if(this.modules.splice(n++,0,o),i)for(let l=0;l<o.rules.length;l++)i.insertRule(o.rules[l],r++)}else{for(;n<a;)r+=this.modules[n++].rules.length;r+=o.rules.length,n++}}if(i)t.adoptedStyleSheets.indexOf(this.sheet)<0&&(t.adoptedStyleSheets=[this.sheet,...t.adoptedStyleSheets]);else{let s="";for(let a=0;a<this.modules.length;a++)s+=this.modules[a].getRules()+`
-`;this.styleTag.textContent=s;let o=t.head||t;this.styleTag.parentNode!=o&&o.insertBefore(this.styleTag,o.firstChild)}}setNonce(e){this.styleTag&&this.styleTag.getAttribute("nonce")!=e&&this.styleTag.setAttribute("nonce",e)}};function ds(e){let t;return e.nodeType==11?t=e.getSelection?e:e.ownerDocument:t=e,t.getSelection()}function pa(e,t){return t?e==t||e.contains(t.nodeType!=1?t.parentNode:t):!1}function Rb(e){let t=e.activeElement;for(;t&&t.shadowRoot;)t=t.shadowRoot.activeElement;return t}function ts(e,t){if(!t.anchorNode)return!1;try{return pa(e,t.anchorNode)}catch{return!1}}function Rr(e){return e.nodeType==3?wi(e,0,e.nodeValue.length).getClientRects():e.nodeType==1?e.getClientRects():[]}function Er(e,t,i,r){return i?rd(e,t,i,r,-1)||rd(e,t,i,r,1):!1}function bi(e){for(var t=0;;t++)if(e=e.previousSibling,!e)return t}function fs(e){return e.nodeType==1&&/^(DIV|P|LI|UL|OL|BLOCKQUOTE|DD|DT|H\d|SECTION|PRE)$/.test(e.nodeName)}function rd(e,t,i,r,n){for(;;){if(e==i&&t==r)return!0;if(t==(n<0?0:Wt(e))){if(e.nodeName=="DIV")return!1;let s=e.parentNode;if(!s||s.nodeType!=1)return!1;t=bi(e)+(n<0?0:1),e=s}else if(e.nodeType==1){if(e=e.childNodes[t+(n<0?-1:0)],e.nodeType==1&&e.contentEditable=="false")return!1;t=n<0?Wt(e):0}else return!1}}function Wt(e){return e.nodeType==3?e.nodeValue.length:e.childNodes.length}function _a(e,t){let i=t?e.left:e.right;return{left:i,right:i,top:e.top,bottom:e.bottom}}function Xb(e){let t=e.visualViewport;return t?{left:0,right:t.width,top:0,bottom:t.height}:{left:0,right:e.innerWidth,top:0,bottom:e.innerHeight}}function Hd(e,t){let i=t.width/e.offsetWidth,r=t.height/e.offsetHeight;return(i>.995&&i<1.005||!isFinite(i)||Math.abs(t.width-e.offsetWidth)<1)&&(i=1),(r>.995&&r<1.005||!isFinite(r)||Math.abs(t.height-e.offsetHeight)<1)&&(r=1),{scaleX:i,scaleY:r}}function Mb(e,t,i,r,n,s,o,a){let l=e.ownerDocument,h=l.defaultView||window;for(let c=e,u=!1;c&&!u;)if(c.nodeType==1){let d,f=c==l.body,p=1,O=1;if(f)d=Xb(h);else{if(/^(fixed|sticky)$/.test(getComputedStyle(c).position)&&(u=!0),c.scrollHeight<=c.clientHeight&&c.scrollWidth<=c.clientWidth){c=c.assignedSlot||c.parentNode;continue}let b=c.getBoundingClientRect();({scaleX:p,scaleY:O}=Hd(c,b)),d={left:b.left,right:b.left+c.clientWidth*p,top:b.top,bottom:b.top+c.clientHeight*O}}let g=0,y=0;if(n=="nearest")t.top<d.top?(y=-(d.top-t.top+o),i>0&&t.bottom>d.bottom+y&&(y=t.bottom-d.bottom+y+o)):t.bottom>d.bottom&&(y=t.bottom-d.bottom+o,i<0&&t.top-y<d.top&&(y=-(d.top+y-t.top+o)));else{let b=t.bottom-t.top,S=d.bottom-d.top;y=(n=="center"&&b<=S?t.top+b/2-S/2:n=="start"||n=="center"&&i<0?t.top-o:t.bottom-S+o)-d.top}if(r=="nearest"?t.left<d.left?(g=-(d.left-t.left+s),i>0&&t.right>d.right+g&&(g=t.right-d.right+g+s)):t.right>d.right&&(g=t.right-d.right+s,i<0&&t.left<d.left+g&&(g=-(d.left+g-t.left+s))):g=(r=="center"?t.left+(t.right-t.left)/2-(d.right-d.left)/2:r=="start"==a?t.left-s:t.right-(d.right-d.left)+s)-d.left,g||y)if(f)h.scrollBy(g,y);else{let b=0,S=0;if(y){let w=c.scrollTop;c.scrollTop+=y/O,S=(c.scrollTop-w)*O}if(g){let w=c.scrollLeft;c.scrollLeft+=g/p,b=(c.scrollLeft-w)*p}t={left:t.left-b,top:t.top-S,right:t.right-b,bottom:t.bottom-S},b&&Math.abs(b-g)<1&&(r="nearest"),S&&Math.abs(S-y)<1&&(n="nearest")}if(f)break;c=c.assignedSlot||c.parentNode}else if(c.nodeType==11)c=c.host;else break}function Wb(e){let t=e.ownerDocument;for(let i=e.parentNode;i&&i!=t.body;)if(i.nodeType==1){if(i.scrollHeight>i.clientHeight||i.scrollWidth>i.clientWidth)return i;i=i.assignedSlot||i.parentNode}else if(i.nodeType==11)i=i.host;else break;return null}var qb=class{constructor(){this.anchorNode=null,this.anchorOffset=0,this.focusNode=null,this.focusOffset=0}eq(e){return this.anchorNode==e.anchorNode&&this.anchorOffset==e.anchorOffset&&this.focusNode==e.focusNode&&this.focusOffset==e.focusOffset}setRange(e){let{anchorNode:t,focusNode:i}=e;this.set(t,Math.min(e.anchorOffset,t?Wt(t):0),i,Math.min(e.focusOffset,i?Wt(i):0))}set(e,t,i,r){this.anchorNode=e,this.anchorOffset=t,this.focusNode=i,this.focusOffset=r}},Ii=null;function Kd(e){if(e.setActive)return e.setActive();if(Ii)return e.focus(Ii);let t=[];for(let i=e;i&&(t.push(i,i.scrollTop,i.scrollLeft),i!=i.ownerDocument);i=i.parentNode);if(e.focus(Ii==null?{get preventScroll(){return Ii={preventScroll:!0},!0}}:void 0),!Ii){Ii=!1;for(let i=0;i<t.length;){let r=t[i++],n=t[i++],s=t[i++];r.scrollTop!=n&&(r.scrollTop=n),r.scrollLeft!=s&&(r.scrollLeft=s)}}}var nd;function wi(e,t,i=t){let r=nd||(nd=document.createRange());return r.setEnd(e,i),r.setStart(e,t),r}function Li(e,t,i,r){let n={key:t,code:t,keyCode:i,which:i,cancelable:!0};r&&({altKey:n.altKey,ctrlKey:n.ctrlKey,shiftKey:n.shiftKey,metaKey:n.metaKey}=r);let s=new KeyboardEvent("keydown",n);s.synthetic=!0,e.dispatchEvent(s);let o=new KeyboardEvent("keyup",n);return o.synthetic=!0,e.dispatchEvent(o),s.defaultPrevented||o.defaultPrevented}function Yb(e){for(;e;){if(e&&(e.nodeType==9||e.nodeType==11&&e.host))return e;e=e.assignedSlot||e.parentNode}return null}function Jd(e){for(;e.attributes.length;)e.removeAttributeNode(e.attributes[0])}function Ib(e,t){let i=t.focusNode,r=t.focusOffset;if(!i||t.anchorNode!=i||t.anchorOffset!=r)return!1;for(r=Math.min(r,Wt(i));;)if(r){if(i.nodeType!=1)return!1;let n=i.childNodes[r-1];n.contentEditable=="false"?r--:(i=n,r=Wt(i))}else{if(i==e)return!0;r=bi(i),i=i.parentNode}}function ef(e){return e.scrollTop>Math.max(1,e.scrollHeight-e.clientHeight-4)}function tf(e,t){for(let i=e,r=t;;){if(i.nodeType==3&&r>0)return{node:i,offset:r};if(i.nodeType==1&&r>0){if(i.contentEditable=="false")return null;i=i.childNodes[r-1],r=Wt(i)}else if(i.parentNode&&!fs(i))r=bi(i),i=i.parentNode;else return null}}function rf(e,t){for(let i=e,r=t;;){if(i.nodeType==3&&r<i.nodeValue.length)return{node:i,offset:r};if(i.nodeType==1&&r<i.childNodes.length){if(i.contentEditable=="false")return null;i=i.childNodes[r],r=0}else if(i.parentNode&&!fs(i))r=bi(i)+1,i=i.parentNode;else return null}}var Ue=class Oa{constructor(t,i,r=!0){this.node=t,this.offset=i,this.precise=r}static before(t,i){return new Oa(t.parentNode,bi(t),i)}static after(t,i){return new Oa(t.parentNode,bi(t)+1,i)}},Ua=[],ne=class ma{constructor(){this.parent=null,this.dom=null,this.flags=2}get overrideDOMText(){return null}get posAtStart(){return this.parent?this.parent.posBefore(this):0}get posAtEnd(){return this.posAtStart+this.length}posBefore(t){let i=this.posAtStart;for(let r of this.children){if(r==t)return i;i+=r.length+r.breakAfter}throw new RangeError("Invalid child in posBefore")}posAfter(t){return this.posBefore(t)+t.length}sync(t,i){if(this.flags&2){let r=this.dom,n=null,s;for(let o of this.children){if(o.flags&7){if(!o.dom&&(s=n?n.nextSibling:r.firstChild)){let a=ma.get(s);(!a||!a.parent&&a.canReuseDOM(o))&&o.reuseDOM(s)}o.sync(t,i),o.flags&=-8}if(s=n?n.nextSibling:r.firstChild,i&&!i.written&&i.node==r&&s!=o.dom&&(i.written=!0),o.dom.parentNode==r)for(;s&&s!=o.dom;)s=sd(s);else r.insertBefore(o.dom,s);n=o.dom}for(s=n?n.nextSibling:r.firstChild,s&&i&&i.node==r&&(i.written=!0);s;)s=sd(s)}else if(this.flags&1)for(let r of this.children)r.flags&7&&(r.sync(t,i),r.flags&=-8)}reuseDOM(t){}localPosFromDOM(t,i){let r;if(t==this.dom)r=this.dom.childNodes[i];else{let n=Wt(t)==0?0:i==0?-1:1;for(;;){let s=t.parentNode;if(s==this.dom)break;n==0&&s.firstChild!=s.lastChild&&(t==s.firstChild?n=-1:n=1),t=s}n<0?r=t:r=t.nextSibling}if(r==this.dom.firstChild)return 0;for(;r&&!ma.get(r);)r=r.nextSibling;if(!r)return this.length;for(let n=0,s=0;;n++){let o=this.children[n];if(o.dom==r)return s;s+=o.length+o.breakAfter}}domBoundsAround(t,i,r=0){let n=-1,s=-1,o=-1,a=-1;for(let l=0,h=r,c=r;l<this.children.length;l++){let u=this.children[l],d=h+u.length;if(h<t&&d>i)return u.domBoundsAround(t,i,h);if(d>=t&&n==-1&&(n=l,s=h),h>i&&u.dom.parentNode==this.dom){o=l,a=c;break}c=d,h=d+u.breakAfter}return{from:s,to:a<0?r+this.length:a,startDOM:(n?this.children[n-1].dom.nextSibling:null)||this.dom.firstChild,endDOM:o<this.children.length&&o>=0?this.children[o].dom:null}}markDirty(t=!1){this.flags|=2,this.markParentsDirty(t)}markParentsDirty(t){for(let i=this.parent;i;i=i.parent){if(t&&(i.flags|=2),i.flags&1)return;i.flags|=1,t=!1}}setParent(t){this.parent!=t&&(this.parent=t,this.flags&7&&this.markParentsDirty(!0))}setDOM(t){this.dom!=t&&(this.dom&&(this.dom.cmView=null),this.dom=t,t.cmView=this)}get rootView(){for(let t=this;;){let i=t.parent;if(!i)return t;t=i}}replaceChildren(t,i,r=Ua){this.markDirty();for(let n=t;n<i;n++){let s=this.children[n];s.parent==this&&r.indexOf(s)<0&&s.destroy()}this.children.splice(t,i-t,...r);for(let n=0;n<r.length;n++)r[n].setParent(this)}ignoreMutation(t){return!1}ignoreEvent(t){return!1}childCursor(t=this.length){return new nf(this.children,t,this.children.length)}childPos(t,i=1){return this.childCursor().findPos(t,i)}toString(){let t=this.constructor.name.replace("View","");return t+(this.children.length?"("+this.children.join()+")":this.length?"["+(t=="Text"?this.text:this.length)+"]":"")+(this.breakAfter?"#":"")}static get(t){return t.cmView}get isEditable(){return!0}get isWidget(){return!1}get isHidden(){return!1}merge(t,i,r,n,s,o){return!1}become(t){return!1}canReuseDOM(t){return t.constructor==this.constructor&&!((this.flags|t.flags)&8)}getSide(){return 0}destroy(){for(let t of this.children)t.parent==this&&t.destroy();this.parent=null}};ne.prototype.breakAfter=0;function sd(e){let t=e.nextSibling;return e.parentNode.removeChild(e),t}var nf=class{constructor(e,t,i){this.children=e,this.pos=t,this.i=i,this.off=0}findPos(e,t=1){for(;;){if(e>this.pos||e==this.pos&&(t>0||this.i==0||this.children[this.i-1].breakAfter))return this.off=e-this.pos,this;let i=this.children[--this.i];this.pos-=i.length+i.breakAfter}}};function sf(e,t,i,r,n,s,o,a,l){let{children:h}=e,c=h.length?h[t]:null,u=s.length?s[s.length-1]:null,d=u?u.breakAfter:o;if(!(t==r&&c&&!o&&!d&&s.length<2&&c.merge(i,n,s.length?u:null,i==0,a,l))){if(r<h.length){let f=h[r];f&&(n<f.length||f.breakAfter&&u?.breakAfter)?(t==r&&(f=f.split(n),n=0),!d&&u&&f.merge(0,n,u,!0,0,l)?s[s.length-1]=f:((n||f.children.length&&!f.children[0].length)&&f.merge(0,n,null,!1,0,l),s.push(f))):f?.breakAfter&&(u?u.breakAfter=1:o=1),r++}for(c&&(c.breakAfter=o,i>0&&(!o&&s.length&&c.merge(i,c.length,s[0],!1,a,0)?c.breakAfter=s.shift().breakAfter:(i<c.length||c.children.length&&c.children[c.children.length-1].length==0)&&c.merge(i,c.length,null,!1,a,0),t++));t<r&&s.length;)if(h[r-1].become(s[s.length-1]))r--,s.pop(),l=s.length?0:a;else if(h[t].become(s[0]))t++,s.shift(),a=s.length?0:l;else break;!s.length&&t&&r<h.length&&!h[t-1].breakAfter&&h[r].merge(0,0,h[t-1],!1,a,l)&&t--,(t<r||s.length)&&e.replaceChildren(t,r,s)}}function of(e,t,i,r,n,s){let o=e.childCursor(),{i:a,off:l}=o.findPos(i,1),{i:h,off:c}=o.findPos(t,-1),u=t-i;for(let d of r)u+=d.length;e.length+=u,sf(e,h,c,a,l,r,0,n,s)}var ze=typeof navigator<"u"?navigator:{userAgent:"",vendor:"",platform:""},ga=typeof document<"u"?document:{documentElement:{style:{}}},ya=/Edge\/(\d+)/.exec(ze.userAgent),af=/MSIE \d/.test(ze.userAgent),ba=/Trident\/(?:[7-9]|\d{2,})\..*rv:(\d+)/.exec(ze.userAgent),Os=!!(af||ba||ya),od=!Os&&/gecko\/(\d+)/i.test(ze.userAgent),ia=!Os&&/Chrome\/(\d+)/.exec(ze.userAgent),ad="webkitFontSmoothing"in ga.documentElement.style,lf=!Os&&/Apple Computer/.test(ze.vendor),ld=lf&&(/Mobile\/\w+/.test(ze.userAgent)||ze.maxTouchPoints>2),A={mac:ld||/Mac/.test(ze.platform),windows:/Win/.test(ze.platform),linux:/Linux|X11/.test(ze.platform),ie:Os,ie_version:af?ga.documentMode||6:ba?+ba[1]:ya?+ya[1]:0,gecko:od,gecko_version:od?+(/Firefox\/(\d+)/.exec(ze.userAgent)||[0,0])[1]:0,chrome:!!ia,chrome_version:ia?+ia[1]:0,ios:ld,android:/Android\b/.test(ze.userAgent),webkit:ad,safari:lf,webkit_version:ad?+(/\bAppleWebKit\/(\d+)/.exec(navigator.userAgent)||[0,0])[1]:0,tabSize:ga.documentElement.style.tabSize!=null?"tab-size":"-moz-tab-size"},Lb=256,Kt=class wa extends ne{constructor(t){super(),this.text=t}get length(){return this.text.length}createDOM(t){this.setDOM(t||document.createTextNode(this.text))}sync(t,i){this.dom||this.createDOM(),this.dom.nodeValue!=this.text&&(i&&i.node==this.dom&&(i.written=!0),this.dom.nodeValue=this.text)}reuseDOM(t){t.nodeType==3&&this.createDOM(t)}merge(t,i,r){return this.flags&8||r&&(!(r instanceof wa)||this.length-(i-t)+r.length>Lb||r.flags&8)?!1:(this.text=this.text.slice(0,t)+(r?r.text:"")+this.text.slice(i),this.markDirty(),!0)}split(t){let i=new wa(this.text.slice(t));return this.text=this.text.slice(0,t),this.markDirty(),i.flags|=this.flags&8,i}localPosFromDOM(t,i){return t==this.dom?i:i?this.text.length:0}domAtPos(t){return new Ue(this.dom,t)}domBoundsAround(t,i,r){return{from:r,to:r+this.length,startDOM:this.dom,endDOM:this.dom.nextSibling}}coordsAt(t,i){return Vb(this.dom,t,i)}},Ni=class va extends ne{constructor(t,i=[],r=0){super(),this.mark=t,this.children=i,this.length=r;for(let n of i)n.setParent(this)}setAttrs(t){if(Jd(t),this.mark.class&&(t.className=this.mark.class),this.mark.attrs)for(let i in this.mark.attrs)t.setAttribute(i,this.mark.attrs[i]);return t}canReuseDOM(t){return super.canReuseDOM(t)&&!((this.flags|t.flags)&8)}reuseDOM(t){t.nodeName==this.mark.tagName.toUpperCase()&&(this.setDOM(t),this.flags|=6)}sync(t,i){this.dom?this.flags&4&&this.setAttrs(this.dom):this.setDOM(this.setAttrs(document.createElement(this.mark.tagName))),super.sync(t,i)}merge(t,i,r,n,s,o){return r&&(!(r instanceof va&&r.mark.eq(this.mark))||t&&s<=0||i<this.length&&o<=0)?!1:(of(this,t,i,r?r.children.slice():[],s-1,o-1),this.markDirty(),!0)}split(t){let i=[],r=0,n=-1,s=0;for(let a of this.children){let l=r+a.length;l>t&&i.push(r<t?a.split(t-r):a),n<0&&r>=t&&(n=s),r=l,s++}let o=this.length-t;return this.length=t,n>-1&&(this.children.length=n,this.markDirty()),new va(this.mark,i,o)}domAtPos(t){return cf(this,t)}coordsAt(t,i){return df(this,t,i)}};function Vb(e,t,i){let r=e.nodeValue.length;t>r&&(t=r);let n=t,s=t,o=0;t==0&&i<0||t==r&&i>=0?A.chrome||A.gecko||(t?(n--,o=1):s<r&&(s++,o=-1)):i<0?n--:s<r&&s++;let a=wi(e,n,s).getClientRects();if(!a.length)return null;let l=a[(o?o<0:i>=0)?0:a.length-1];return A.safari&&!o&&l.width==0&&(l=Array.prototype.find.call(a,h=>h.width)||l),o?_a(l,o<0):l||null}var hf=class Qr extends ne{static create(t,i,r){return new Qr(t,i,r)}constructor(t,i,r){super(),this.widget=t,this.length=i,this.side=r,this.prevWidget=null}split(t){let i=Qr.create(this.widget,this.length-t,this.side);return this.length-=t,i}sync(t){(!this.dom||!this.widget.updateDOM(this.dom,t))&&(this.dom&&this.prevWidget&&this.prevWidget.destroy(this.dom),this.prevWidget=null,this.setDOM(this.widget.toDOM(t)),this.widget.editable||(this.dom.contentEditable="false"))}getSide(){return this.side}merge(t,i,r,n,s,o){return r&&(!(r instanceof Qr)||!this.widget.compare(r.widget)||t>0&&s<=0||i<this.length&&o<=0)?!1:(this.length=t+(r?r.length:0)+(this.length-i),!0)}become(t){return t instanceof Qr&&t.side==this.side&&this.widget.constructor==t.widget.constructor?(this.widget.compare(t.widget)||this.markDirty(!0),this.dom&&!this.prevWidget&&(this.prevWidget=this.widget),this.widget=t.widget,this.length=t.length,!0):!1}ignoreMutation(){return!0}ignoreEvent(t){return this.widget.ignoreEvent(t)}get overrideDOMText(){if(this.length==0)return G.empty;let t=this;for(;t.parent;)t=t.parent;let{view:i}=t,r=i&&i.state.doc,n=this.posAtStart;return r?r.slice(n,n+this.length):G.empty}domAtPos(t){return(this.length?t==0:this.side>0)?Ue.before(this.dom):Ue.after(this.dom,t==this.length)}domBoundsAround(){return null}coordsAt(t,i){let r=this.widget.coordsAt(this.dom,t,i);if(r)return r;let n=this.dom.getClientRects(),s=null;if(!n.length)return null;let o=this.side?this.side<0:t>0;for(let a=o?n.length-1:0;s=n[a],!(t>0?a==0:a==n.length-1||s.top<s.bottom);a+=o?-1:1);return _a(s,!o)}get isEditable(){return!1}get isWidget(){return!0}get isHidden(){return this.widget.isHidden}destroy(){super.destroy(),this.dom&&this.widget.destroy(this.dom)}},Sa=class xa extends ne{constructor(t){super(),this.side=t}get length(){return 0}merge(){return!1}become(t){return t instanceof xa&&t.side==this.side}split(){return new xa(this.side)}sync(){if(!this.dom){let t=document.createElement("img");t.className="cm-widgetBuffer",t.setAttribute("aria-hidden","true"),this.setDOM(t)}}getSide(){return this.side}domAtPos(t){return this.side>0?Ue.before(this.dom):Ue.after(this.dom)}localPosFromDOM(){return 0}domBoundsAround(){return null}coordsAt(t){return this.dom.getBoundingClientRect()}get overrideDOMText(){return G.empty}get isHidden(){return!0}};Kt.prototype.children=hf.prototype.children=Sa.prototype.children=Ua;function cf(e,t){let i=e.dom,{children:r}=e,n=0;for(let s=0;n<r.length;n++){let o=r[n],a=s+o.length;if(!(a==s&&o.getSide()<=0)){if(t>s&&t<a&&o.dom.parentNode==i)return o.domAtPos(t-s);if(t<=s)break;s=a}}for(let s=n;s>0;s--){let o=r[s-1];if(o.dom.parentNode==i)return o.domAtPos(o.length)}for(let s=n;s<r.length;s++){let o=r[s];if(o.dom.parentNode==i)return o.domAtPos(0)}return new Ue(i,0)}function uf(e,t,i){let r,{children:n}=e;i>0&&t instanceof Ni&&n.length&&(r=n[n.length-1])instanceof Ni&&r.mark.eq(t.mark)?uf(r,t.children[0],i-1):(n.push(t),t.setParent(e)),e.length+=t.length}function df(e,t,i){let r=null,n=-1,s=null,o=-1;function a(h,c){for(let u=0,d=0;u<h.children.length&&d<=c;u++){let f=h.children[u],p=d+f.length;p>=c&&(f.children.length?a(f,c-d):(!s||s.isHidden&&i>0)&&(p>c||d==p&&f.getSide()>0)?(s=f,o=c-d):(d<c||d==p&&f.getSide()<0&&!f.isHidden)&&(r=f,n=c-d)),d=p}}a(e,t);let l=(i<0?r:s)||r||s;return l?l.coordsAt(Math.max(0,l==r?n:o),i):Nb(e)}function Nb(e){let t=e.dom.lastChild;if(!t)return e.dom.getBoundingClientRect();let i=Rr(t);return i[i.length-1]||null}function Pa(e,t){for(let i in e)i=="class"&&t.class?t.class+=" "+e.class:i=="style"&&t.style?t.style+=";"+e.style:t[i]=e[i];return t}var hd=Object.create(null);function za(e,t,i){if(e==t)return!0;e||(e=hd),t||(t=hd);let r=Object.keys(e),n=Object.keys(t);if(r.length-(i&&r.indexOf(i)>-1?1:0)!=n.length-(i&&n.indexOf(i)>-1?1:0))return!1;for(let s of r)if(s!=i&&(n.indexOf(s)==-1||e[s]!==t[s]))return!1;return!0}function ka(e,t,i){let r=!1;if(t)for(let n in t)i&&n in i||(r=!0,n=="style"?e.style.cssText="":e.removeAttribute(n));if(i)for(let n in i)t&&t[n]==i[n]||(r=!0,n=="style"?e.style.cssText=i[n]:e.setAttribute(n,i[n]));return r}function jb(e){let t=Object.create(null);for(let i=0;i<e.attributes.length;i++){let r=e.attributes[i];t[r.name]=r.value}return t}var $e=class is extends ne{constructor(){super(...arguments),this.children=[],this.length=0,this.prevAttrs=void 0,this.attrs=null,this.breakAfter=0}merge(t,i,r,n,s,o){if(r){if(!(r instanceof is))return!1;this.dom||r.transferDOM(this)}return n&&this.setDeco(r?r.attrs:null),of(this,t,i,r?r.children.slice():[],s,o),!0}split(t){let i=new is;if(i.breakAfter=this.breakAfter,this.length==0)return i;let{i:r,off:n}=this.childPos(t);n&&(i.append(this.children[r].split(n),0),this.children[r].merge(n,this.children[r].length,null,!1,0,0),r++);for(let s=r;s<this.children.length;s++)i.append(this.children[s],0);for(;r>0&&this.children[r-1].length==0;)this.children[--r].destroy();return this.children.length=r,this.markDirty(),this.length=t,i}transferDOM(t){this.dom&&(this.markDirty(),t.setDOM(this.dom),t.prevAttrs=this.prevAttrs===void 0?this.attrs:this.prevAttrs,this.prevAttrs=void 0,this.dom=null)}setDeco(t){za(this.attrs,t)||(this.dom&&(this.prevAttrs=this.attrs,this.markDirty()),this.attrs=t)}append(t,i){uf(this,t,i)}addLineDeco(t){let i=t.spec.attributes,r=t.spec.class;i&&(this.attrs=Pa(i,this.attrs||{})),r&&(this.attrs=Pa({class:r},this.attrs||{}))}domAtPos(t){return cf(this,t)}reuseDOM(t){t.nodeName=="DIV"&&(this.setDOM(t),this.flags|=6)}sync(t,i){var r;this.dom?this.flags&4&&(Jd(this.dom),this.dom.className="cm-line",this.prevAttrs=this.attrs?null:void 0):(this.setDOM(document.createElement("div")),this.dom.className="cm-line",this.prevAttrs=this.attrs?null:void 0),this.prevAttrs!==void 0&&(ka(this.dom,this.prevAttrs,this.attrs),this.dom.classList.add("cm-line"),this.prevAttrs=void 0),super.sync(t,i);let n=this.dom.lastChild;for(;n&&ne.get(n)instanceof Ni;)n=n.lastChild;if(!n||!this.length||n.nodeName!="BR"&&((r=ne.get(n))===null||r===void 0?void 0:r.isEditable)==!1&&(!A.ios||!this.children.some(s=>s instanceof Kt))){let s=document.createElement("BR");s.cmIgnore=!0,this.dom.appendChild(s)}}measureTextSize(){if(this.children.length==0||this.length>20)return null;let t=0,i;for(let r of this.children){if(!(r instanceof Kt)||/[^ -~]/.test(r.text))return null;let n=Rr(r.dom);if(n.length!=1)return null;t+=n[0].width,i=n[0].height}return t?{lineHeight:this.dom.getBoundingClientRect().height,charWidth:t/this.length,textHeight:i}:null}coordsAt(t,i){let r=df(this,t,i);if(!this.children.length&&r&&this.parent){let{heightOracle:n}=this.parent.view.viewState,s=r.bottom-r.top;if(Math.abs(s-n.lineHeight)<2&&n.textHeight<s){let o=(s-n.textHeight)/2;return{top:r.top+o,bottom:r.bottom-o,left:r.left,right:r.left}}}return r}become(t){return!1}covers(){return!0}static find(t,i){for(let r=0,n=0;r<t.children.length;r++){let s=t.children[r],o=n+s.length;if(o>=i){if(s instanceof is)return s;if(o>i)break}n=o+s.breakAfter}return null}},rs=class ns extends ne{constructor(t,i,r){super(),this.widget=t,this.length=i,this.deco=r,this.breakAfter=0,this.prevWidget=null}merge(t,i,r,n,s,o){return r&&(!(r instanceof ns)||!this.widget.compare(r.widget)||t>0&&s<=0||i<this.length&&o<=0)?!1:(this.length=t+(r?r.length:0)+(this.length-i),!0)}domAtPos(t){return t==0?Ue.before(this.dom):Ue.after(this.dom,t==this.length)}split(t){let i=this.length-t;this.length=t;let r=new ns(this.widget,i,this.deco);return r.breakAfter=this.breakAfter,r}get children(){return Ua}sync(t){(!this.dom||!this.widget.updateDOM(this.dom,t))&&(this.dom&&this.prevWidget&&this.prevWidget.destroy(this.dom),this.prevWidget=null,this.setDOM(this.widget.toDOM(t)),this.widget.editable||(this.dom.contentEditable="false"))}get overrideDOMText(){return this.parent?this.parent.view.state.doc.slice(this.posAtStart,this.posAtEnd):G.empty}domBoundsAround(){return null}become(t){return t instanceof ns&&t.widget.constructor==this.widget.constructor?(t.widget.compare(this.widget)||this.markDirty(!0),this.dom&&!this.prevWidget&&(this.prevWidget=this.widget),this.widget=t.widget,this.length=t.length,this.deco=t.deco,this.breakAfter=t.breakAfter,!0):!1}ignoreMutation(){return!0}ignoreEvent(t){return this.widget.ignoreEvent(t)}get isEditable(){return!1}get isWidget(){return!0}coordsAt(t,i){return this.widget.coordsAt(this.dom,t,i)}destroy(){super.destroy(),this.dom&&this.widget.destroy(this.dom)}covers(t){let{startSide:i,endSide:r}=this.deco;return i==r?!1:t<0?i<0:r>0}},Jt=class{eq(e){return!1}updateDOM(e,t){return!1}compare(e){return this==e||this.constructor==e.constructor&&this.eq(e)}get estimatedHeight(){return-1}get lineBreaks(){return 0}ignoreEvent(e){return!0}coordsAt(e,t,i){return null}get isHidden(){return!1}get editable(){return!1}destroy(e){}},Ce=function(e){return e[e.Text=0]="Text",e[e.WidgetBefore=1]="WidgetBefore",e[e.WidgetAfter=2]="WidgetAfter",e[e.WidgetRange=3]="WidgetRange",e}(Ce||(Ce={})),j=class extends Et{constructor(e,t,i,r){super(),this.startSide=e,this.endSide=t,this.widget=i,this.spec=r}get heightRelevant(){return!1}static mark(e){return new Ba(e)}static widget(e){let t=Math.max(-1e4,Math.min(1e4,e.side||0)),i=!!e.block;return t+=i&&!e.inlineOrder?t>0?3e8:-4e8:t>0?1e8:-1e8,new ji(e,t,t,i,e.widget||null,!1)}static replace(e){let t=!!e.block,i,r;if(e.isBlockGap)i=-5e8,r=4e8;else{let{start:n,end:s}=mf(e,t);i=(n?t?-3e8:-1:5e8)-1,r=(s?t?2e8:1:-6e8)+1}return new ji(e,i,r,t,e.widget||null,!0)}static line(e){return new Ga(e)}static set(e,t=!1){return ie.of(e,t)}hasHeight(){return this.widget?this.widget.estimatedHeight>-1:!1}};j.none=ie.empty;var Ba=class ff extends j{constructor(t){let{start:i,end:r}=mf(t);super(i?-1:5e8,r?1:-6e8,null,t),this.tagName=t.tagName||"span",this.class=t.class||"",this.attrs=t.attributes||null}eq(t){var i,r;return this==t||t instanceof ff&&this.tagName==t.tagName&&(this.class||((i=this.attrs)===null||i===void 0?void 0:i.class))==(t.class||((r=t.attrs)===null||r===void 0?void 0:r.class))&&za(this.attrs,t.attrs,"class")}range(t,i=t){if(t>=i)throw new RangeError("Mark decorations may not be empty");return super.range(t,i)}};Ba.prototype.point=!1;var Ga=class pf extends j{constructor(t){super(-2e8,-2e8,null,t)}eq(t){return t instanceof pf&&this.spec.class==t.spec.class&&za(this.spec.attributes,t.spec.attributes)}range(t,i=t){if(i!=t)throw new RangeError("Line decoration ranges must be zero-length");return super.range(t,i)}};Ga.prototype.mapMode=ge.TrackBefore;Ga.prototype.point=!0;var ji=class Of extends j{constructor(t,i,r,n,s,o){super(i,r,s,t),this.block=n,this.isReplace=o,this.mapMode=n?i<=0?ge.TrackBefore:ge.TrackAfter:ge.TrackDel}get type(){return this.startSide!=this.endSide?Ce.WidgetRange:this.startSide<=0?Ce.WidgetBefore:Ce.WidgetAfter}get heightRelevant(){return this.block||!!this.widget&&(this.widget.estimatedHeight>=5||this.widget.lineBreaks>0)}eq(t){return t instanceof Of&&Db(this.widget,t.widget)&&this.block==t.block&&this.startSide==t.startSide&&this.endSide==t.endSide}range(t,i=t){if(this.isReplace&&(t>i||t==i&&this.startSide>0&&this.endSide<=0))throw new RangeError("Invalid range for replacement decoration");if(!this.isReplace&&i!=t)throw new RangeError("Widget decorations can only have zero-length ranges");return super.range(t,i)}};ji.prototype.point=!0;function mf(e,t=!1){let{inclusiveStart:i,inclusiveEnd:r}=e;return i==null&&(i=e.inclusive),r==null&&(r=e.inclusive),{start:i??t,end:r??t}}function Db(e,t){return e==t||!!(e&&t&&e.compare(t))}function Qa(e,t,i,r=0){let n=i.length-1;n>=0&&i[n]+r>=e?i[n]=Math.max(i[n],t):i.push(e,t)}var ra=class gf{constructor(t,i,r,n){this.doc=t,this.pos=i,this.end=r,this.disallowBlockEffectsFor=n,this.content=[],this.curLine=null,this.breakAtStart=0,this.pendingBuffer=0,this.bufferMarks=[],this.atCursorPos=!0,this.openStart=-1,this.openEnd=-1,this.text="",this.textOff=0,this.cursor=t.iter(),this.skip=i}posCovered(){if(this.content.length==0)return!this.breakAtStart&&this.doc.lineAt(this.pos).from!=this.pos;let t=this.content[this.content.length-1];return!(t.breakAfter||t instanceof rs&&t.deco.endSide<0)}getLine(){return this.curLine||(this.content.push(this.curLine=new $e),this.atCursorPos=!0),this.curLine}flushBuffer(t=this.bufferMarks){this.pendingBuffer&&(this.curLine.append(Dn(new Sa(-1),t),t.length),this.pendingBuffer=0)}addBlockWidget(t){this.flushBuffer(),this.curLine=null,this.content.push(t)}finish(t){this.pendingBuffer&&t<=this.bufferMarks.length?this.flushBuffer():this.pendingBuffer=0,!this.posCovered()&&!(t&&this.content.length&&this.content[this.content.length-1]instanceof rs)&&this.getLine()}buildText(t,i,r){for(;t>0;){if(this.textOff==this.text.length){let{value:s,lineBreak:o,done:a}=this.cursor.next(this.skip);if(this.skip=0,a)throw new Error("Ran out of text content when drawing inline views");if(o){this.posCovered()||this.getLine(),this.content.length?this.content[this.content.length-1].breakAfter=1:this.breakAtStart=1,this.flushBuffer(),this.curLine=null,this.atCursorPos=!0,t--;continue}else this.text=s,this.textOff=0}let n=Math.min(this.text.length-this.textOff,t,512);this.flushBuffer(i.slice(i.length-r)),this.getLine().append(Dn(new Kt(this.text.slice(this.textOff,this.textOff+n)),i),r),this.atCursorPos=!0,this.textOff+=n,t-=n,r=0}}span(t,i,r,n){this.buildText(i-t,r,n),this.pos=i,this.openStart<0&&(this.openStart=n)}point(t,i,r,n,s,o){if(this.disallowBlockEffectsFor[o]&&r instanceof ji){if(r.block)throw new RangeError("Block decorations may not be specified via plugins");if(i>this.doc.lineAt(this.pos).to)throw new RangeError("Decorations that replace line breaks may not be specified via plugins")}let a=i-t;if(r instanceof ji)if(r.block)r.startSide>0&&!this.posCovered()&&this.getLine(),this.addBlockWidget(new rs(r.widget||Di.block,a,r));else{let l=hf.create(r.widget||Di.inline,a,a?0:r.startSide),h=this.atCursorPos&&!l.isEditable&&s<=n.length&&(t<i||r.startSide>0),c=!l.isEditable&&(t<i||s>n.length||r.startSide<=0),u=this.getLine();this.pendingBuffer==2&&!h&&!l.isEditable&&(this.pendingBuffer=0),this.flushBuffer(n),h&&(u.append(Dn(new Sa(1),n),s),s=n.length+Math.max(0,s-n.length)),u.append(Dn(l,n),s),this.atCursorPos=c,this.pendingBuffer=c?t<i||s>n.length?1:2:0,this.pendingBuffer&&(this.bufferMarks=n.slice())}else this.doc.lineAt(this.pos).from==this.pos&&this.getLine().addLineDeco(r);a&&(this.textOff+a<=this.text.length?this.textOff+=a:(this.skip+=a-(this.text.length-this.textOff),this.text="",this.textOff=0),this.pos=i),this.openStart<0&&(this.openStart=s)}static build(t,i,r,n,s){let o=new gf(t,i,r,s);return o.openEnd=ie.spans(n,i,r,o),o.openStart<0&&(o.openStart=o.openEnd),o.finish(o.openEnd),o}};function Dn(e,t){for(let i of t)e=new Ni(i,[e],e.length);return e}var Di=class extends Jt{constructor(e){super(),this.tag=e}eq(e){return e.tag==this.tag}toDOM(){return document.createElement(this.tag)}updateDOM(e){return e.nodeName.toLowerCase()==this.tag}get isHidden(){return!0}};Di.inline=new Di("span");Di.block=new Di("div");var ee=function(e){return e[e.LTR=0]="LTR",e[e.RTL=1]="RTL",e}(ee||(ee={})),vi=ee.LTR,Fa=ee.RTL;function yf(e){let t=[];for(let i=0;i<e.length;i++)t.push(1<<+e[i]);return t}var _b=yf("88888888888888888888888888888888888666888888787833333333337888888000000000000000000000000008888880000000000000000000000000088888888888888888888888888888888888887866668888088888663380888308888800000000000000000000000800000000000000000000000000000008"),Ub=yf("4444448826627288999999999992222222222222222222222222222222222222222222222229999999999999999999994444444444644222822222222222222222222222222222222222222222222222222222222222222222222222222222222222222222222222222222999999949999999229989999223333333333"),$a=Object.create(null),Pt=[];for(let e of["()","[]","{}"]){let t=e.charCodeAt(0),i=e.charCodeAt(1);$a[t]=i,$a[i]=-t}function bf(e){return e<=247?_b[e]:1424<=e&&e<=1524?2:1536<=e&&e<=1785?Ub[e-1536]:1774<=e&&e<=2220?4:8192<=e&&e<=8204?256:64336<=e&&e<=65023?4:1}var zb=/[\u0590-\u05f4\u0600-\u06ff\u0700-\u08ac\ufb50-\ufdff]/,Ft=class{get dir(){return this.level%2?Fa:vi}constructor(e,t,i){this.from=e,this.to=t,this.level=i}side(e,t){return this.dir==t==e?this.to:this.from}forward(e,t){return e==(this.dir==t)}static find(e,t,i,r){let n=-1;for(let s=0;s<e.length;s++){let o=e[s];if(o.from<=t&&o.to>=t){if(o.level==i)return s;(n<0||(r!=0?r<0?o.from<t:o.to>t:e[n].level>o.level))&&(n=s)}}if(n<0)throw new RangeError("Index out of range");return n}};function wf(e,t){if(e.length!=t.length)return!1;for(let i=0;i<e.length;i++){let r=e[i],n=t[i];if(r.from!=n.from||r.to!=n.to||r.direction!=n.direction||!wf(r.inner,n.inner))return!1}return!0}var J=[];function Bb(e,t,i,r,n){for(let s=0;s<=r.length;s++){let o=s?r[s-1].to:t,a=s<r.length?r[s].from:i,l=s?256:n;for(let h=o,c=l,u=l;h<a;h++){let d=bf(e.charCodeAt(h));d==512?d=c:d==8&&u==4&&(d=16),J[h]=d==4?2:d,d&7&&(u=d),c=d}for(let h=o,c=l,u=l;h<a;h++){let d=J[h];if(d==128)h<a-1&&c==J[h+1]&&c&24?d=J[h]=c:J[h]=256;else if(d==64){let f=h+1;for(;f<a&&J[f]==64;)f++;let p=h&&c==8||f<i&&J[f]==8?u==1?1:8:256;for(let O=h;O<f;O++)J[O]=p;h=f-1}else d==8&&u==1&&(J[h]=1);c=d,d&7&&(u=d)}}}function Gb(e,t,i,r,n){let s=n==1?2:1;for(let o=0,a=0,l=0;o<=r.length;o++){let h=o?r[o-1].to:t,c=o<r.length?r[o].from:i;for(let u=h,d,f,p;u<c;u++)if(f=$a[d=e.charCodeAt(u)])if(f<0){for(let O=a-3;O>=0;O-=3)if(Pt[O+1]==-f){let g=Pt[O+2],y=g&2?n:g&4?g&1?s:n:0;y&&(J[u]=J[Pt[O]]=y),a=O;break}}else{if(Pt.length==189)break;Pt[a++]=u,Pt[a++]=d,Pt[a++]=l}else if((p=J[u])==2||p==1){let O=p==n;l=O?0:1;for(let g=a-3;g>=0;g-=3){let y=Pt[g+2];if(y&2)break;if(O)Pt[g+2]|=2;else{if(y&4)break;Pt[g+2]|=4}}}}}function Fb(e,t,i,r){for(let n=0,s=r;n<=i.length;n++){let o=n?i[n-1].to:e,a=n<i.length?i[n].from:t;for(let l=o;l<a;){let h=J[l];if(h==256){let c=l+1;for(;;)if(c==a){if(n==i.length)break;c=i[n++].to,a=n<i.length?i[n].from:t}else if(J[c]==256)c++;else break;let u=s==1,d=(c<t?J[c]:r)==1,f=u==d?u?1:2:r;for(let p=c,O=n,g=O?i[O-1].to:e;p>l;)p==g&&(p=i[--O].from,g=O?i[O-1].to:e),J[--p]=f;l=c}else s=h,l++}}}function Ta(e,t,i,r,n,s,o){let a=r%2?2:1;if(r%2==n%2)for(let l=t,h=0;l<i;){let c=!0,u=!1;if(h==s.length||l<s[h].from){let O=J[l];O!=a&&(c=!1,u=O==16)}let d=!c&&a==1?[]:null,f=c?r:r+1,p=l;e:for(;;)if(h<s.length&&p==s[h].from){if(u)break e;let O=s[h];if(!c)for(let g=O.to,y=h+1;;){if(g==i)break e;if(y<s.length&&s[y].from==g)g=s[y++].to;else{if(J[g]==a)break e;break}}if(h++,d)d.push(O);else{O.from>l&&o.push(new Ft(l,O.from,f));let g=O.direction==vi!=!(f%2);Ca(e,g?r+1:r,n,O.inner,O.from,O.to,o),l=O.to}p=O.to}else{if(p==i||(c?J[p]!=a:J[p]==a))break;p++}d?Ta(e,l,p,r+1,n,d,o):l<p&&o.push(new Ft(l,p,f)),l=p}else for(let l=i,h=s.length;l>t;){let c=!0,u=!1;if(!h||l>s[h-1].to){let O=J[l-1];O!=a&&(c=!1,u=O==16)}let d=!c&&a==1?[]:null,f=c?r:r+1,p=l;e:for(;;)if(h&&p==s[h-1].to){if(u)break e;let O=s[--h];if(!c)for(let g=O.from,y=h;;){if(g==t)break e;if(y&&s[y-1].to==g)g=s[--y].from;else{if(J[g-1]==a)break e;break}}if(d)d.push(O);else{O.to<l&&o.push(new Ft(O.to,l,f));let g=O.direction==vi!=!(f%2);Ca(e,g?r+1:r,n,O.inner,O.from,O.to,o),l=O.from}p=O.from}else{if(p==t||(c?J[p-1]!=a:J[p-1]==a))break;p--}d?Ta(e,p,l,r+1,n,d,o):p<l&&o.push(new Ft(p,l,f)),l=p}}function Ca(e,t,i,r,n,s,o){let a=t%2?2:1;Bb(e,n,s,r,a),Gb(e,n,s,r,a),Fb(n,s,r,a),Ta(e,n,s,t,i,r,o)}function Hb(e,t,i){if(!e)return[new Ft(0,0,t==Fa?1:0)];if(t==vi&&!i.length&&!zb.test(e))return vf(e.length);if(i.length)for(;e.length>J.length;)J[J.length]=256;let r=[],n=t==vi?0:1;return Ca(e,n,n,i,0,e.length,r),r}function vf(e){return[new Ft(0,e,0)]}var Sf="";function Kb(e,t,i,r,n){var s;let o=r.head-e.from,a=Ft.find(t,o,(s=r.bidiLevel)!==null&&s!==void 0?s:-1,r.assoc),l=t[a],h=l.side(n,i);if(o==h){let d=a+=n?1:-1;if(d<0||d>=t.length)return null;l=t[a=d],o=l.side(!n,i),h=l.side(n,i)}let c=ht(e.text,o,l.forward(n,i));(c<l.from||c>l.to)&&(c=h),Sf=e.text.slice(Math.min(o,c),Math.max(o,c));let u=a==(n?t.length-1:0)?null:t[a+(n?1:-1)];return u&&c==h&&u.level+(n?0:1)<l.level?$.cursor(u.side(!n,i)+e.from,u.forward(n,i)?1:-1,u.level):$.cursor(c+e.from,l.forward(n,i)?-1:1,l.level)}function Jb(e,t,i){for(let r=t;r<i;r++){let n=bf(e.charCodeAt(r));if(n==1)return vi;if(n==2||n==4)return Fa}return vi}var xf=E.define(),Pf=E.define(),kf=E.define(),Qf=E.define(),Aa=E.define(),$f=E.define(),Tf=E.define(),Cf=E.define({combine:e=>e.some(t=>t)}),ew=E.define({combine:e=>e.some(t=>t)}),Af=E.define(),na=class Za{constructor(t,i="nearest",r="nearest",n=5,s=5,o=!1){this.range=t,this.y=i,this.x=r,this.yMargin=n,this.xMargin=s,this.isSnapshot=o}map(t){return t.empty?this:new Za(this.range.map(t),this.y,this.x,this.yMargin,this.xMargin,this.isSnapshot)}clip(t){return this.range.to<=t.doc.length?this:new Za($.cursor(t.doc.length),this.y,this.x,this.yMargin,this.xMargin,this.isSnapshot)}},_n=z.define({map:(e,t)=>e.map(t)});function Te(e,t,i){let r=e.facet(Qf);r.length?r[0](t):window.onerror?window.onerror(String(t),i,void 0,void 0,t):i?console.error(i+":",t):console.error(t)}var ms=E.define({combine:e=>e.length?e[0]:!0}),tw=0,$r=E.define(),ve=class Ea{constructor(t,i,r,n,s){this.id=t,this.create=i,this.domEventHandlers=r,this.domEventObservers=n,this.extension=s(this)}static define(t,i){let{eventHandlers:r,eventObservers:n,provide:s,decorations:o}=i||{};return new Ea(tw++,t,r,n,a=>{let l=[$r.of(a)];return o&&l.push(Xr.of(h=>{let c=h.plugin(a);return c?o(c):j.none})),s&&l.push(s(a)),l})}static fromClass(t,i){return Ea.define(r=>new t(r),i)}},sa=class{constructor(e){this.spec=e,this.mustUpdate=null,this.value=null}update(e){if(this.value){if(this.mustUpdate){let t=this.mustUpdate;if(this.mustUpdate=null,this.value.update)try{this.value.update(t)}catch(i){if(Te(t.state,i,"CodeMirror plugin crashed"),this.value.destroy)try{this.value.destroy()}catch{}this.deactivate()}}}else if(this.spec)try{this.value=this.spec.create(e)}catch(t){Te(e.state,t,"CodeMirror plugin crashed"),this.deactivate()}return this}destroy(e){var t;if(!((t=this.value)===null||t===void 0)&&t.destroy)try{this.value.destroy()}catch(i){Te(e.state,i,"CodeMirror plugin crashed")}}deactivate(){this.spec=this.value=null}},Zf=E.define(),Ha=E.define(),Xr=E.define(),Ef=E.define(),Ka=E.define(),Rf=E.define();function cd(e,t){let i=e.state.facet(Rf);if(!i.length)return i;let r=i.map(s=>s instanceof Function?s(e):s),n=[];return ie.spans(r,t.from,t.to,{point(){},span(s,o,a,l){let h=s-t.from,c=o-t.from,u=n;for(let d=a.length-1;d>=0;d--,l--){let f=a[d].spec.bidiIsolate,p;if(f==null&&(f=Jb(t.text,h,c)),l>0&&u.length&&(p=u[u.length-1]).to==h&&p.direction==f)p.to=c,u=p.inner;else{let O={from:h,to:c,direction:f,inner:[]};u.push(O),u=O.inner}}}}),n}var Xf=E.define();function Mf(e){let t=0,i=0,r=0,n=0;for(let s of e.state.facet(Xf)){let o=s(e);o&&(o.left!=null&&(t=Math.max(t,o.left)),o.right!=null&&(i=Math.max(i,o.right)),o.top!=null&&(r=Math.max(r,o.top)),o.bottom!=null&&(n=Math.max(n,o.bottom)))}return{left:t,right:i,top:r,bottom:n}}var Tr=E.define(),Ht=class ss{constructor(t,i,r,n){this.fromA=t,this.toA=i,this.fromB=r,this.toB=n}join(t){return new ss(Math.min(this.fromA,t.fromA),Math.max(this.toA,t.toA),Math.min(this.fromB,t.fromB),Math.max(this.toB,t.toB))}addToSet(t){let i=t.length,r=this;for(;i>0;i--){let n=t[i-1];if(!(n.fromA>r.toA)){if(n.toA<r.fromA)break;r=r.join(n),t.splice(i-1,1)}}return t.splice(i,0,r),t}static extendWithRanges(t,i){if(i.length==0)return t;let r=[];for(let n=0,s=0,o=0,a=0;;n++){let l=n==t.length?null:t[n],h=o-a,c=l?l.fromB:1e9;for(;s<i.length&&i[s]<c;){let u=i[s],d=i[s+1],f=Math.max(a,u),p=Math.min(c,d);if(f<=p&&new ss(f+h,p+h,f,p).addToSet(r),d>c)break;s+=2}if(!l)return r;new ss(l.fromA,l.toA,l.fromB,l.toB).addToSet(r),o=l.toA,a=l.toB}}},ud=class Wf{constructor(t,i,r){this.view=t,this.state=i,this.transactions=r,this.flags=0,this.startState=t.state,this.changes=ct.empty(this.startState.doc.length);for(let s of r)this.changes=this.changes.compose(s.changes);let n=[];this.changes.iterChangedRanges((s,o,a,l)=>n.push(new Ht(s,o,a,l))),this.changedRanges=n}static create(t,i,r){return new Wf(t,i,r)}get viewportChanged(){return(this.flags&4)>0}get heightChanged(){return(this.flags&2)>0}get geometryChanged(){return this.docChanged||(this.flags&10)>0}get focusChanged(){return(this.flags&1)>0}get docChanged(){return!this.changes.empty}get selectionSet(){return this.transactions.some(t=>t.selection)}get empty(){return this.flags==0&&this.transactions.length==0}},dd=class extends ne{get length(){return this.view.state.doc.length}constructor(e){super(),this.view=e,this.decorations=[],this.dynamicDecorationMap=[],this.domChanged=null,this.hasComposition=null,this.markedForComposition=new Set,this.lastCompositionAfterCursor=!1,this.minWidth=0,this.minWidthFrom=0,this.minWidthTo=0,this.impreciseAnchor=null,this.impreciseHead=null,this.forceSelection=!1,this.lastUpdate=Date.now(),this.setDOM(e.contentDOM),this.children=[new $e],this.children[0].setParent(this),this.updateDeco(),this.updateInner([new Ht(0,0,0,e.state.doc.length)],0,null)}update(e){var t;let i=e.changedRanges;this.minWidth>0&&i.length&&(i.every(({fromA:l,toA:h})=>h<this.minWidthFrom||l>this.minWidthTo)?(this.minWidthFrom=e.changes.mapPos(this.minWidthFrom,1),this.minWidthTo=e.changes.mapPos(this.minWidthTo,1)):this.minWidth=this.minWidthFrom=this.minWidthTo=0);let r=-1;this.view.inputState.composing>=0&&(!((t=this.domChanged)===null||t===void 0)&&t.newSel?r=this.domChanged.newSel.head:!lw(e.changes,this.hasComposition)&&!e.selectionSet&&(r=e.state.selection.main.head));let n=r>-1?rw(this.view,e.changes,r):null;if(this.domChanged=null,this.hasComposition){this.markedForComposition.clear();let{from:l,to:h}=this.hasComposition;i=new Ht(l,h,e.changes.mapPos(l,-1),e.changes.mapPos(h,1)).addToSet(i.slice())}this.hasComposition=n?{from:n.range.fromB,to:n.range.toB}:null,(A.ie||A.chrome)&&!n&&e&&e.state.doc.lines!=e.startState.doc.lines&&(this.forceSelection=!0);let s=this.decorations,o=this.updateDeco(),a=ow(s,o,e.changes);return i=Ht.extendWithRanges(i,a),!(this.flags&7)&&i.length==0?!1:(this.updateInner(i,e.startState.doc.length,n),e.transactions.length&&(this.lastUpdate=Date.now()),!0)}updateInner(e,t,i){this.view.viewState.mustMeasureContent=!0,this.updateChildren(e,t,i);let{observer:r}=this.view;r.ignore(()=>{this.dom.style.height=this.view.viewState.contentHeight/this.view.scaleY+"px",this.dom.style.flexBasis=this.minWidth?this.minWidth+"px":"";let s=A.chrome||A.ios?{node:r.selectionRange.focusNode,written:!1}:void 0;this.sync(this.view,s),this.flags&=-8,s&&(s.written||r.selectionRange.focusNode!=s.node)&&(this.forceSelection=!0),this.dom.style.height=""}),this.markedForComposition.forEach(s=>s.flags&=-9);let n=[];if(this.view.viewport.from||this.view.viewport.to<this.view.state.doc.length)for(let s of this.children)s instanceof rs&&s.widget instanceof fd&&n.push(s.dom);r.updateGaps(n)}updateChildren(e,t,i){let r=i?i.range.addToSet(e.slice()):e,n=this.childCursor(t);for(let s=r.length-1;;s--){let o=s>=0?r[s]:null;if(!o)break;let{fromA:a,toA:l,fromB:h,toB:c}=o,u,d,f,p;if(i&&i.range.fromB<c&&i.range.toB>h){let S=ra.build(this.view.state.doc,h,i.range.fromB,this.decorations,this.dynamicDecorationMap),w=ra.build(this.view.state.doc,i.range.toB,c,this.decorations,this.dynamicDecorationMap);d=S.breakAtStart,f=S.openStart,p=w.openEnd;let k=this.compositionView(i);w.breakAtStart?k.breakAfter=1:w.content.length&&k.merge(k.length,k.length,w.content[0],!1,w.openStart,0)&&(k.breakAfter=w.content[0].breakAfter,w.content.shift()),S.content.length&&k.merge(0,0,S.content[S.content.length-1],!0,0,S.openEnd)&&S.content.pop(),u=S.content.concat(k).concat(w.content)}else({content:u,breakAtStart:d,openStart:f,openEnd:p}=ra.build(this.view.state.doc,h,c,this.decorations,this.dynamicDecorationMap));let{i:O,off:g}=n.findPos(l,1),{i:y,off:b}=n.findPos(a,-1);sf(this,y,b,O,g,u,d,f,p)}i&&this.fixCompositionDOM(i)}compositionView(e){let t=new Kt(e.text.nodeValue);t.flags|=8;for(let{deco:r}of e.marks)t=new Ni(r,[t],t.length);let i=new $e;return i.append(t,0),i}fixCompositionDOM(e){let t=(n,s)=>{s.flags|=8|(s.children.some(a=>a.flags&7)?1:0),this.markedForComposition.add(s);let o=ne.get(n);o&&o!=s&&(o.dom=null),s.setDOM(n)},i=this.childPos(e.range.fromB,1),r=this.children[i.i];t(e.line,r);for(let n=e.marks.length-1;n>=-1;n--)i=r.childPos(i.off,1),r=r.children[i.i],t(n>=0?e.marks[n].node:e.text,r)}updateSelection(e=!1,t=!1){(e||!this.view.observer.selectionRange.focusNode)&&this.view.observer.readSelectionRange();let i=this.view.root.activeElement,r=i==this.dom,n=!r&&ts(this.dom,this.view.observer.selectionRange)&&!(i&&this.dom.contains(i));if(!(r||t||n))return;let s=this.forceSelection;this.forceSelection=!1;let o=this.view.state.selection.main,a=this.moveToLine(this.domAtPos(o.anchor)),l=o.empty?a:this.moveToLine(this.domAtPos(o.head));if(A.gecko&&o.empty&&!this.hasComposition&&iw(a)){let c=document.createTextNode("");this.view.observer.ignore(()=>a.node.insertBefore(c,a.node.childNodes[a.offset]||null)),a=l=new Ue(c,0),s=!0}let h=this.view.observer.selectionRange;(s||!h.focusNode||(!Er(a.node,a.offset,h.anchorNode,h.anchorOffset)||!Er(l.node,l.offset,h.focusNode,h.focusOffset))&&!this.suppressWidgetCursorChange(h,o))&&(this.view.observer.ignore(()=>{A.android&&A.chrome&&this.dom.contains(h.focusNode)&&aw(h.focusNode,this.dom)&&(this.dom.blur(),this.dom.focus({preventScroll:!0}));let c=ds(this.view.root);if(c)if(o.empty){if(A.gecko){let u=nw(a.node,a.offset);if(u&&u!=3){let d=(u==1?tf:rf)(a.node,a.offset);d&&(a=new Ue(d.node,d.offset))}}c.collapse(a.node,a.offset),o.bidiLevel!=null&&c.caretBidiLevel!==void 0&&(c.caretBidiLevel=o.bidiLevel)}else if(c.extend){c.collapse(a.node,a.offset);try{c.extend(l.node,l.offset)}catch{}}else{let u=document.createRange();o.anchor>o.head&&([a,l]=[l,a]),u.setEnd(l.node,l.offset),u.setStart(a.node,a.offset),c.removeAllRanges(),c.addRange(u)}n&&this.view.root.activeElement==this.dom&&(this.dom.blur(),i&&i.focus())}),this.view.observer.setSelectionRange(a,l)),this.impreciseAnchor=a.precise?null:new Ue(h.anchorNode,h.anchorOffset),this.impreciseHead=l.precise?null:new Ue(h.focusNode,h.focusOffset)}suppressWidgetCursorChange(e,t){return this.hasComposition&&t.empty&&Er(e.focusNode,e.focusOffset,e.anchorNode,e.anchorOffset)&&this.posFromDOM(e.focusNode,e.focusOffset)==t.head}enforceCursorAssoc(){if(this.hasComposition)return;let{view:e}=this,t=e.state.selection.main,i=ds(e.root),{anchorNode:r,anchorOffset:n}=e.observer.selectionRange;if(!i||!t.empty||!t.assoc||!i.modify)return;let s=$e.find(this,t.head);if(!s)return;let o=s.posAtStart;if(t.head==o||t.head==o+s.length)return;let a=this.coordsAt(t.head,-1),l=this.coordsAt(t.head,1);if(!a||!l||a.bottom>l.top)return;let h=this.domAtPos(t.head+t.assoc);i.collapse(h.node,h.offset),i.modify("move",t.assoc<0?"forward":"backward","lineboundary"),e.observer.readSelectionRange();let c=e.observer.selectionRange;e.docView.posFromDOM(c.anchorNode,c.anchorOffset)!=t.from&&i.collapse(r,n)}moveToLine(e){let t=this.dom,i;if(e.node!=t)return e;for(let r=e.offset;!i&&r<t.childNodes.length;r++){let n=ne.get(t.childNodes[r]);n instanceof $e&&(i=n.domAtPos(0))}for(let r=e.offset-1;!i&&r>=0;r--){let n=ne.get(t.childNodes[r]);n instanceof $e&&(i=n.domAtPos(n.length))}return i?new Ue(i.node,i.offset,!0):e}nearest(e){for(let t=e;t;){let i=ne.get(t);if(i&&i.rootView==this)return i;t=t.parentNode}return null}posFromDOM(e,t){let i=this.nearest(e);if(!i)throw new RangeError("Trying to find position for a DOM position outside of the document");return i.localPosFromDOM(e,t)+i.posAtStart}domAtPos(e){let{i:t,off:i}=this.childCursor().findPos(e,-1);for(;t<this.children.length-1;){let r=this.children[t];if(i<r.length||r instanceof $e)break;t++,i=0}return this.children[t].domAtPos(i)}coordsAt(e,t){let i=null,r=0;for(let n=this.length,s=this.children.length-1;s>=0;s--){let o=this.children[s],a=n-o.breakAfter,l=a-o.length;if(a<e)break;l<=e&&(l<e||o.covers(-1))&&(a>e||o.covers(1))&&(!i||o instanceof $e&&!(i instanceof $e&&t>=0))&&(i=o,r=l),n=l}return i?i.coordsAt(e-r,t):null}coordsForChar(e){let{i:t,off:i}=this.childPos(e,1),r=this.children[t];if(!(r instanceof $e))return null;for(;r.children.length;){let{i:o,off:a}=r.childPos(i,1);for(;;o++){if(o==r.children.length)return null;if((r=r.children[o]).length)break}i=a}if(!(r instanceof Kt))return null;let n=ht(r.text,i);if(n==i)return null;let s=wi(r.dom,i,n).getClientRects();for(let o=0;o<s.length;o++){let a=s[o];if(o==s.length-1||a.top<a.bottom&&a.left<a.right)return a}return null}measureVisibleLineHeights(e){let t=[],{from:i,to:r}=e,n=this.view.contentDOM.clientWidth,s=n>Math.max(this.view.scrollDOM.clientWidth,this.minWidth)+1,o=-1,a=this.view.textDirection==ee.LTR;for(let l=0,h=0;h<this.children.length;h++){let c=this.children[h],u=l+c.length;if(u>r)break;if(l>=i){let d=c.dom.getBoundingClientRect();if(t.push(d.height),s){let f=c.dom.lastChild,p=f?Rr(f):[];if(p.length){let O=p[p.length-1],g=a?O.right-d.left:d.right-O.left;g>o&&(o=g,this.minWidth=n,this.minWidthFrom=l,this.minWidthTo=u)}}}l=u+c.breakAfter}return t}textDirectionAt(e){let{i:t}=this.childPos(e,1);return getComputedStyle(this.children[t].dom).direction=="rtl"?ee.RTL:ee.LTR}measureTextSize(){for(let n of this.children)if(n instanceof $e){let s=n.measureTextSize();if(s)return s}let e=document.createElement("div"),t,i,r;return e.className="cm-line",e.style.width="99999px",e.style.position="absolute",e.textContent="abc def ghi jkl mno pqr stu",this.view.observer.ignore(()=>{this.dom.appendChild(e);let n=Rr(e.firstChild)[0];t=e.getBoundingClientRect().height,i=n?n.width/27:7,r=n?n.height:t,e.remove()}),{lineHeight:t,charWidth:i,textHeight:r}}childCursor(e=this.length){let t=this.children.length;return t&&(e-=this.children[--t].length),new nf(this.children,e,t)}computeBlockGapDeco(){let e=[],t=this.view.viewState;for(let i=0,r=0;;r++){let n=r==t.viewports.length?null:t.viewports[r],s=n?n.from-1:this.length;if(s>i){let o=(t.lineBlockAt(s).bottom-t.lineBlockAt(i).top)/this.view.scaleY;e.push(j.replace({widget:new fd(o),block:!0,inclusive:!0,isBlockGap:!0}).range(i,s))}if(!n)break;i=n.to+1}return j.set(e)}updateDeco(){let e=0,t=this.view.state.facet(Xr).map(n=>(this.dynamicDecorationMap[e++]=typeof n=="function")?n(this.view):n),i=!1,r=this.view.state.facet(Ef).map((n,s)=>{let o=typeof n=="function";return o&&(i=!0),o?n(this.view):n});for(r.length&&(this.dynamicDecorationMap[e++]=i,t.push(ie.join(r))),this.decorations=[...t,this.computeBlockGapDeco(),this.view.viewState.lineGapDeco];e<this.decorations.length;)this.dynamicDecorationMap[e++]=!1;return this.decorations}scrollIntoView(e){if(e.isSnapshot){let l=this.view.viewState.lineBlockAt(e.range.head);this.view.scrollDOM.scrollTop=l.top-e.yMargin,this.view.scrollDOM.scrollLeft=e.xMargin;return}for(let l of this.view.state.facet(Af))try{if(l(this.view,e.range,e))return!0}catch(h){Te(this.view.state,h,"scroll handler")}let{range:t}=e,i=this.coordsAt(t.head,t.empty?t.assoc:t.head>t.anchor?-1:1),r;if(!i)return;!t.empty&&(r=this.coordsAt(t.anchor,t.anchor>t.head?-1:1))&&(i={left:Math.min(i.left,r.left),top:Math.min(i.top,r.top),right:Math.max(i.right,r.right),bottom:Math.max(i.bottom,r.bottom)});let n=Mf(this.view),s={left:i.left-n.left,top:i.top-n.top,right:i.right+n.right,bottom:i.bottom+n.bottom},{offsetWidth:o,offsetHeight:a}=this.view.scrollDOM;Mb(this.view.scrollDOM,s,t.head<t.anchor?-1:1,e.x,e.y,Math.max(Math.min(e.xMargin,o),-o),Math.max(Math.min(e.yMargin,a),-a),this.view.textDirection==ee.LTR)}};function iw(e){return e.node.nodeType==1&&e.node.firstChild&&(e.offset==0||e.node.childNodes[e.offset-1].contentEditable=="false")&&(e.offset==e.node.childNodes.length||e.node.childNodes[e.offset].contentEditable=="false")}var fd=class extends Jt{constructor(e){super(),this.height=e}toDOM(){let e=document.createElement("div");return e.className="cm-gap",this.updateDOM(e),e}eq(e){return e.height==this.height}updateDOM(e){return e.style.height=this.height+"px",!0}get editable(){return!0}get estimatedHeight(){return this.height}ignoreEvent(){return!1}};function qf(e,t){let i=e.observer.selectionRange;if(!i.focusNode)return null;let r=tf(i.focusNode,i.focusOffset),n=rf(i.focusNode,i.focusOffset),s=r||n;if(n&&r&&n.node!=r.node){let a=ne.get(n.node);if(!a||a instanceof Kt&&a.text!=n.node.nodeValue)s=n;else if(e.docView.lastCompositionAfterCursor){let l=ne.get(r.node);!l||l instanceof Kt&&l.text!=r.node.nodeValue||(s=n)}}if(e.docView.lastCompositionAfterCursor=s!=r,!s)return null;let o=t-s.offset;return{from:o,to:o+s.node.nodeValue.length,node:s.node}}function rw(e,t,i){let r=qf(e,i);if(!r)return null;let{node:n,from:s,to:o}=r,a=n.nodeValue;if(/[\n\r]/.test(a)||e.state.doc.sliceString(r.from,r.to)!=a)return null;let l=t.invertedDesc,h=new Ht(l.mapPos(s),l.mapPos(o),s,o),c=[];for(let u=n.parentNode;;u=u.parentNode){let d=ne.get(u);if(d instanceof Ni)c.push({node:u,deco:d.mark});else{if(d instanceof $e||u.nodeName=="DIV"&&u.parentNode==e.contentDOM)return{range:h,text:n,marks:c,line:u};if(u!=e.contentDOM)c.push({node:u,deco:new Ba({inclusive:!0,attributes:jb(u),tagName:u.tagName.toLowerCase()})});else return null}}}function nw(e,t){return e.nodeType!=1?0:(t&&e.childNodes[t-1].contentEditable=="false"?1:0)|(t<e.childNodes.length&&e.childNodes[t].contentEditable=="false"?2:0)}var sw=class{constructor(){this.changes=[]}compareRange(e,t){Qa(e,t,this.changes)}comparePoint(e,t){Qa(e,t,this.changes)}};function ow(e,t,i){let r=new sw;return ie.compare(e,t,i,r),r.changes}function aw(e,t){for(let i=e;i&&i!=t;i=i.assignedSlot||i.parentNode)if(i.nodeType==1&&i.contentEditable=="false")return!0;return!1}function lw(e,t){let i=!1;return t&&e.iterChangedRanges((r,n)=>{r<t.to&&n>t.from&&(i=!0)}),i}function hw(e,t,i=1){let r=e.charCategorizer(t),n=e.doc.lineAt(t),s=t-n.from;if(n.length==0)return $.cursor(t);s==0?i=1:s==n.length&&(i=-1);let o=s,a=s;i<0?o=ht(n.text,s,!1):a=ht(n.text,s);let l=r(n.text.slice(o,a));for(;o>0;){let h=ht(n.text,o,!1);if(r(n.text.slice(h,o))!=l)break;o=h}for(;a<n.length;){let h=ht(n.text,a);if(r(n.text.slice(a,h))!=l)break;a=h}return $.range(o+n.from,a+n.from)}function cw(e,t){return t.left>e?t.left-e:Math.max(0,e-t.right)}function uw(e,t){return t.top>e?t.top-e:Math.max(0,e-t.bottom)}function oa(e,t){return e.top<t.bottom-1&&e.bottom>t.top+1}function pd(e,t){return t<e.top?{top:t,left:e.left,right:e.right,bottom:e.bottom}:e}function Od(e,t){return t>e.bottom?{top:e.top,left:e.left,right:e.right,bottom:t}:e}function Ra(e,t,i){let r,n,s,o,a=!1,l,h,c,u;for(let p=e.firstChild;p;p=p.nextSibling){let O=Rr(p);for(let g=0;g<O.length;g++){let y=O[g];n&&oa(n,y)&&(y=pd(Od(y,n.bottom),n.top));let b=cw(t,y),S=uw(i,y);if(b==0&&S==0)return p.nodeType==3?md(p,t,i):Ra(p,t,i);if(!r||o>S||o==S&&s>b){r=p,n=y,s=b,o=S;let w=S?i<y.top?-1:1:b?t<y.left?-1:1:0;a=!w||(w>0?g<O.length-1:g>0)}b==0?i>y.bottom&&(!c||c.bottom<y.bottom)?(l=p,c=y):i<y.top&&(!u||u.top>y.top)&&(h=p,u=y):c&&oa(c,y)?c=Od(c,y.bottom):u&&oa(u,y)&&(u=pd(u,y.top))}}if(c&&c.bottom>=i?(r=l,n=c):u&&u.top<=i&&(r=h,n=u),!r)return{node:e,offset:0};let d=Math.max(n.left,Math.min(n.right,t));if(r.nodeType==3)return md(r,d,i);if(a&&r.contentEditable!="false")return Ra(r,d,i);let f=Array.prototype.indexOf.call(e.childNodes,r)+(t>=(n.left+n.right)/2?1:0);return{node:e,offset:f}}function md(e,t,i){let r=e.nodeValue.length,n=-1,s=1e9,o=0;for(let a=0;a<r;a++){let l=wi(e,a,a+1).getClientRects();for(let h=0;h<l.length;h++){let c=l[h];if(c.top==c.bottom)continue;o||(o=t-c.left);let u=(c.top>i?c.top-i:i-c.bottom)-1;if(c.left-1<=t&&c.right+1>=t&&u<s){let d=t>=(c.left+c.right)/2,f=d;if((A.chrome||A.gecko)&&wi(e,a).getBoundingClientRect().left==c.right&&(f=!d),u<=0)return{node:e,offset:a+(f?1:0)};n=a+(f?1:0),s=u}}}return{node:e,offset:n>-1?n:o>0?e.nodeValue.length:0}}function Yf(e,t,i,r=-1){var n,s;let o=e.contentDOM.getBoundingClientRect(),a=o.top+e.viewState.paddingTop,l,{docHeight:h}=e.viewState,{x:c,y:u}=t,d=u-a;if(d<0)return 0;if(d>h)return e.state.doc.length;for(let w=e.viewState.heightOracle.textHeight/2,k=!1;l=e.elementAtHeight(d),l.type!=Ce.Text;)for(;d=r>0?l.bottom+w:l.top-w,!(d>=0&&d<=h);){if(k)return i?null:0;k=!0,r=-r}u=a+d;let f=l.from;if(f<e.viewport.from)return e.viewport.from==0?0:i?null:gd(e,o,l,c,u);if(f>e.viewport.to)return e.viewport.to==e.state.doc.length?e.state.doc.length:i?null:gd(e,o,l,c,u);let p=e.dom.ownerDocument,O=e.root.elementFromPoint?e.root:p,g=O.elementFromPoint(c,u);g&&!e.contentDOM.contains(g)&&(g=null),g||(c=Math.max(o.left+1,Math.min(o.right-1,c)),g=O.elementFromPoint(c,u),g&&!e.contentDOM.contains(g)&&(g=null));let y,b=-1;if(g&&((n=e.docView.nearest(g))===null||n===void 0?void 0:n.isEditable)!=!1){if(p.caretPositionFromPoint){let w=p.caretPositionFromPoint(c,u);w&&({offsetNode:y,offset:b}=w)}else if(p.caretRangeFromPoint){let w=p.caretRangeFromPoint(c,u);w&&({startContainer:y,startOffset:b}=w,(!e.contentDOM.contains(y)||A.safari&&dw(y,b,c)||A.chrome&&fw(y,b,c))&&(y=void 0))}}if(!y||!e.docView.dom.contains(y)){let w=$e.find(e.docView,f);if(!w)return d>l.top+l.height/2?l.to:l.from;({node:y,offset:b}=Ra(w.dom,c,u))}let S=e.docView.nearest(y);if(!S)return null;if(S.isWidget&&((s=S.dom)===null||s===void 0?void 0:s.nodeType)==1){let w=S.dom.getBoundingClientRect();return t.y<w.top||t.y<=w.bottom&&t.x<=(w.left+w.right)/2?S.posAtStart:S.posAtEnd}else return S.localPosFromDOM(y,b)+S.posAtStart}function gd(e,t,i,r,n){let s=Math.round((r-t.left)*e.defaultCharacterWidth);if(e.lineWrapping&&i.height>e.defaultLineHeight*1.5){let a=e.viewState.heightOracle.textHeight,l=Math.floor((n-i.top-(e.defaultLineHeight-a)*.5)/a);s+=l*e.viewState.heightOracle.lineLength}let o=e.state.sliceDoc(i.from,i.to);return i.from+Ku(o,s,e.state.tabSize)}function dw(e,t,i){let r;if(e.nodeType!=3||t!=(r=e.nodeValue.length))return!1;for(let n=e.nextSibling;n;n=n.nextSibling)if(n.nodeType!=1||n.nodeName!="BR")return!1;return wi(e,r-1,r).getBoundingClientRect().left>i}function fw(e,t,i){if(t!=0)return!1;for(let n=e;;){let s=n.parentNode;if(!s||s.nodeType!=1||s.firstChild!=n)return!1;if(s.classList.contains("cm-line"))break;n=s}let r=e.nodeType==1?e.getBoundingClientRect():wi(e,0,Math.max(e.nodeValue.length,1)).getBoundingClientRect();return i-r.left>5}function Xa(e,t){let i=e.lineBlockAt(t);if(Array.isArray(i.type)){for(let r of i.type)if(r.to>t||r.to==t&&(r.to==i.to||r.type==Ce.Text))return r}return i}function pw(e,t,i,r){let n=Xa(e,t.head),s=!r||n.type!=Ce.Text||!(e.lineWrapping||n.widgetLineBreaks)?null:e.coordsAtPos(t.assoc<0&&t.head>n.from?t.head-1:t.head);if(s){let o=e.dom.getBoundingClientRect(),a=e.textDirectionAt(n.from),l=e.posAtCoords({x:i==(a==ee.LTR)?o.right-1:o.left+1,y:(s.top+s.bottom)/2});if(l!=null)return $.cursor(l,i?-1:1)}return $.cursor(i?n.to:n.from,i?-1:1)}function yd(e,t,i,r){let n=e.state.doc.lineAt(t.head),s=e.bidiSpans(n),o=e.textDirectionAt(n.from);for(let a=t,l=null;;){let h=Kb(n,s,o,a,i),c=Sf;if(!h){if(n.number==(i?e.state.doc.lines:1))return a;c=`
-`,n=e.state.doc.line(n.number+(i?1:-1)),s=e.bidiSpans(n),h=e.visualLineSide(n,!i)}if(l){if(!l(c))return a}else{if(!r)return h;l=r(c)}a=h}}function Ow(e,t,i){let r=e.state.charCategorizer(t),n=r(i);return s=>{let o=r(s);return n==Xe.Space&&(n=o),n==o}}function mw(e,t,i,r){let n=t.head,s=i?1:-1;if(n==(i?e.state.doc.length:0))return $.cursor(n,t.assoc);let o=t.goalColumn,a,l=e.contentDOM.getBoundingClientRect(),h=e.coordsAtPos(n,t.assoc||-1),c=e.documentTop;if(h)o==null&&(o=h.left-l.left),a=s<0?h.top:h.bottom;else{let f=e.viewState.lineBlockAt(n);o==null&&(o=Math.min(l.right-l.left,e.defaultCharacterWidth*(n-f.from))),a=(s<0?f.top:f.bottom)+c}let u=l.left+o,d=r??e.viewState.heightOracle.textHeight>>1;for(let f=0;;f+=10){let p=a+(d+f)*s,O=Yf(e,{x:u,y:p},!1,s);if(p<l.top||p>l.bottom||(s<0?O<n:O>n)){let g=e.docView.coordsForChar(O),y=!g||p<g.top?-1:1;return $.cursor(O,y,void 0,o)}}}function os(e,t,i){for(;;){let r=0;for(let n of e)n.between(t-1,t+1,(s,o,a)=>{if(t>s&&t<o){let l=r||i||(t-s<o-t?-1:1);t=l<0?s:o,r=l}});if(!r)return t}}function aa(e,t,i){let r=os(e.state.facet(Ka).map(n=>n(e)),i.from,t.head>i.from?-1:1);return r==i.from?i:$.cursor(r,r<i.from?1:-1)}var gw=class{setSelectionOrigin(e){this.lastSelectionOrigin=e,this.lastSelectionTime=Date.now()}constructor(e){this.view=e,this.lastKeyCode=0,this.lastKeyTime=0,this.lastTouchTime=0,this.lastFocusTime=0,this.lastScrollTop=0,this.lastScrollLeft=0,this.pendingIOSKey=void 0,this.lastSelectionOrigin=null,this.lastSelectionTime=0,this.lastEscPress=0,this.lastContextMenu=0,this.scrollHandlers=[],this.handlers=Object.create(null),this.composing=-1,this.compositionFirstChange=null,this.compositionEndedAt=0,this.compositionPendingKey=!1,this.compositionPendingChange=!1,this.mouseSelection=null,this.draggedContent=null,this.handleEvent=this.handleEvent.bind(this),this.notifiedFocused=e.hasFocus,A.safari&&e.contentDOM.addEventListener("input",()=>null),A.gecko&&Rw(e.contentDOM.ownerDocument)}handleEvent(e){!kw(this.view,e)||this.ignoreDuringComposition(e)||e.type=="keydown"&&this.keydown(e)||this.runHandlers(e.type,e)}runHandlers(e,t){let i=this.handlers[e];if(i){for(let r of i.observers)r(this.view,t);for(let r of i.handlers){if(t.defaultPrevented)break;if(r(this.view,t)){t.preventDefault();break}}}}ensureHandlers(e){let t=yw(e),i=this.handlers,r=this.view.contentDOM;for(let n in t)if(n!="scroll"){let s=!t[n].handlers.length,o=i[n];o&&s!=!o.handlers.length&&(r.removeEventListener(n,this.handleEvent),o=null),o||r.addEventListener(n,this.handleEvent,{passive:s})}for(let n in i)n!="scroll"&&!t[n]&&r.removeEventListener(n,this.handleEvent);this.handlers=t}keydown(e){if(this.lastKeyCode=e.keyCode,this.lastKeyTime=Date.now(),e.keyCode==9&&Date.now()<this.lastEscPress+2e3)return!0;if(e.keyCode!=27&&Lf.indexOf(e.keyCode)<0&&(this.view.inputState.lastEscPress=0),A.android&&A.chrome&&!e.synthetic&&(e.keyCode==13||e.keyCode==8))return this.view.observer.delayAndroidKey(e.key,e.keyCode),!0;let t;return A.ios&&!e.synthetic&&!e.altKey&&!e.metaKey&&((t=If.find(i=>i.keyCode==e.keyCode))&&!e.ctrlKey||bw.indexOf(e.key)>-1&&e.ctrlKey&&!e.shiftKey)?(this.pendingIOSKey=t||e,setTimeout(()=>this.flushIOSKey(),250),!0):(e.keyCode!=229&&this.view.observer.forceFlush(),!1)}flushIOSKey(e){let t=this.pendingIOSKey;return!t||t.key=="Enter"&&e&&e.from<e.to&&/^\S+$/.test(e.insert.toString())?!1:(this.pendingIOSKey=void 0,Li(this.view.contentDOM,t.key,t.keyCode,t instanceof KeyboardEvent?t:void 0))}ignoreDuringComposition(e){return/^key/.test(e.type)?this.composing>0?!0:A.safari&&!A.ios&&this.compositionPendingKey&&Date.now()-this.compositionEndedAt<100?(this.compositionPendingKey=!1,!0):!1:!1}startMouseSelection(e){this.mouseSelection&&this.mouseSelection.destroy(),this.mouseSelection=e}update(e){this.mouseSelection&&this.mouseSelection.update(e),this.draggedContent&&e.docChanged&&(this.draggedContent=this.draggedContent.map(e.changes)),e.transactions.length&&(this.lastKeyCode=this.lastSelectionTime=0)}destroy(){this.mouseSelection&&this.mouseSelection.destroy()}};function bd(e,t){return(i,r)=>{try{return t.call(e,r,i)}catch(n){Te(i.state,n)}}}function yw(e){let t=Object.create(null);function i(r){return t[r]||(t[r]={observers:[],handlers:[]})}for(let r of e){let n=r.spec;if(n&&n.domEventHandlers)for(let s in n.domEventHandlers){let o=n.domEventHandlers[s];o&&i(s).handlers.push(bd(r.value,o))}if(n&&n.domEventObservers)for(let s in n.domEventObservers){let o=n.domEventObservers[s];o&&i(s).observers.push(bd(r.value,o))}}for(let r in ft)i(r).handlers.push(ft[r]);for(let r in st)i(r).observers.push(st[r]);return t}var If=[{key:"Backspace",keyCode:8,inputType:"deleteContentBackward"},{key:"Enter",keyCode:13,inputType:"insertParagraph"},{key:"Enter",keyCode:13,inputType:"insertLineBreak"},{key:"Delete",keyCode:46,inputType:"deleteContentForward"}],bw="dthko",Lf=[16,17,18,20,91,92,224,225],Un=6;function zn(e){return Math.max(0,e)*.7+8}function ww(e,t){return Math.max(Math.abs(e.clientX-t.clientX),Math.abs(e.clientY-t.clientY))}var vw=class{constructor(e,t,i,r){this.view=e,this.startEvent=t,this.style=i,this.mustSelect=r,this.scrollSpeed={x:0,y:0},this.scrolling=-1,this.lastEvent=t,this.scrollParent=Wb(e.contentDOM),this.atoms=e.state.facet(Ka).map(s=>s(e));let n=e.contentDOM.ownerDocument;n.addEventListener("mousemove",this.move=this.move.bind(this)),n.addEventListener("mouseup",this.up=this.up.bind(this)),this.extend=t.shiftKey,this.multiple=e.state.facet(he.allowMultipleSelections)&&Sw(e,t),this.dragging=Pw(e,t)&&Df(t)==1?null:!1}start(e){this.dragging===!1&&this.select(e)}move(e){var t;if(e.buttons==0)return this.destroy();if(this.dragging||this.dragging==null&&ww(this.startEvent,e)<10)return;this.select(this.lastEvent=e);let i=0,r=0,n=((t=this.scrollParent)===null||t===void 0?void 0:t.getBoundingClientRect())||{left:0,top:0,right:this.view.win.innerWidth,bottom:this.view.win.innerHeight},s=Mf(this.view);e.clientX-s.left<=n.left+Un?i=-zn(n.left-e.clientX):e.clientX+s.right>=n.right-Un&&(i=zn(e.clientX-n.right)),e.clientY-s.top<=n.top+Un?r=-zn(n.top-e.clientY):e.clientY+s.bottom>=n.bottom-Un&&(r=zn(e.clientY-n.bottom)),this.setScrollSpeed(i,r)}up(e){this.dragging==null&&this.select(this.lastEvent),this.dragging||e.preventDefault(),this.destroy()}destroy(){this.setScrollSpeed(0,0);let e=this.view.contentDOM.ownerDocument;e.removeEventListener("mousemove",this.move),e.removeEventListener("mouseup",this.up),this.view.inputState.mouseSelection=this.view.inputState.draggedContent=null}setScrollSpeed(e,t){this.scrollSpeed={x:e,y:t},e||t?this.scrolling<0&&(this.scrolling=setInterval(()=>this.scroll(),50)):this.scrolling>-1&&(clearInterval(this.scrolling),this.scrolling=-1)}scroll(){this.scrollParent?(this.scrollParent.scrollLeft+=this.scrollSpeed.x,this.scrollParent.scrollTop+=this.scrollSpeed.y):this.view.win.scrollBy(this.scrollSpeed.x,this.scrollSpeed.y),this.dragging===!1&&this.select(this.lastEvent)}skipAtoms(e){let t=null;for(let i=0;i<e.ranges.length;i++){let r=e.ranges[i],n=null;if(r.empty){let s=os(this.atoms,r.from,0);s!=r.from&&(n=$.cursor(s,-1))}else{let s=os(this.atoms,r.from,-1),o=os(this.atoms,r.to,1);(s!=r.from||o!=r.to)&&(n=$.range(r.from==r.anchor?s:o,r.from==r.head?s:o))}n&&(t||(t=e.ranges.slice()),t[i]=n)}return t?$.create(t,e.mainIndex):e}select(e){let{view:t}=this,i=this.skipAtoms(this.style.get(e,this.extend,this.multiple));(this.mustSelect||!i.eq(t.state.selection,this.dragging===!1))&&this.view.dispatch({selection:i,userEvent:"select.pointer"}),this.mustSelect=!1}update(e){this.style.update(e)&&setTimeout(()=>this.select(this.lastEvent),20)}};function Sw(e,t){let i=e.state.facet(xf);return i.length?i[0](t):A.mac?t.metaKey:t.ctrlKey}function xw(e,t){let i=e.state.facet(Pf);return i.length?i[0](t):A.mac?!t.altKey:!t.ctrlKey}function Pw(e,t){let{main:i}=e.state.selection;if(i.empty)return!1;let r=ds(e.root);if(!r||r.rangeCount==0)return!0;let n=r.getRangeAt(0).getClientRects();for(let s=0;s<n.length;s++){let o=n[s];if(o.left<=t.clientX&&o.right>=t.clientX&&o.top<=t.clientY&&o.bottom>=t.clientY)return!0}return!1}function kw(e,t){if(!t.bubbles)return!0;if(t.defaultPrevented)return!1;for(let i=t.target,r;i!=e.contentDOM;i=i.parentNode)if(!i||i.nodeType==11||(r=ne.get(i))&&r.ignoreEvent(t))return!1;return!0}var ft=Object.create(null),st=Object.create(null),Vf=A.ie&&A.ie_version<15||A.ios&&A.webkit_version<604;function Qw(e){let t=e.dom.parentNode;if(!t)return;let i=t.appendChild(document.createElement("textarea"));i.style.cssText="position: fixed; left: -10000px; top: 10px",i.focus(),setTimeout(()=>{e.focus(),i.remove(),Nf(e,i.value)},50)}function Nf(e,t){let{state:i}=e,r,n=1,s=i.toText(t),o=s.lines==i.selection.ranges.length;if(Ma!=null&&i.selection.ranges.every(a=>a.empty)&&Ma==s.toString()){let a=-1;r=i.changeByRange(l=>{let h=i.doc.lineAt(l.from);if(h.from==a)return{range:l};a=h.from;let c=i.toText((o?s.line(n++).text:t)+i.lineBreak);return{changes:{from:h.from,insert:c},range:$.cursor(l.from+c.length)}})}else o?r=i.changeByRange(a=>{let l=s.line(n++);return{changes:{from:a.from,to:a.to,insert:l.text},range:$.cursor(a.from+l.length)}}):r=i.replaceSelection(s);e.dispatch(r,{userEvent:"input.paste",scrollIntoView:!0})}st.scroll=e=>{e.inputState.lastScrollTop=e.scrollDOM.scrollTop,e.inputState.lastScrollLeft=e.scrollDOM.scrollLeft};ft.keydown=(e,t)=>(e.inputState.setSelectionOrigin("select"),t.keyCode==27&&(e.inputState.lastEscPress=Date.now()),!1);st.touchstart=(e,t)=>{e.inputState.lastTouchTime=Date.now(),e.inputState.setSelectionOrigin("select.pointer")};st.touchmove=e=>{e.inputState.setSelectionOrigin("select.pointer")};ft.mousedown=(e,t)=>{if(e.observer.flush(),e.inputState.lastTouchTime>Date.now()-2e3)return!1;let i=null;for(let r of e.state.facet(kf))if(i=r(e,t),i)break;if(!i&&t.button==0&&(i=Cw(e,t)),i){let r=!e.hasFocus;e.inputState.startMouseSelection(new vw(e,t,i,r)),r&&e.observer.ignore(()=>Kd(e.contentDOM));let n=e.inputState.mouseSelection;if(n)return n.start(t),n.dragging===!1}return!1};function wd(e,t,i,r){if(r==1)return $.cursor(t,i);if(r==2)return hw(e.state,t,i);{let n=$e.find(e.docView,t),s=e.state.doc.lineAt(n?n.posAtEnd:t),o=n?n.posAtStart:s.from,a=n?n.posAtEnd:s.to;return a<e.state.doc.length&&a==s.to&&a++,$.range(o,a)}}var jf=(e,t)=>e>=t.top&&e<=t.bottom,vd=(e,t,i)=>jf(t,i)&&e>=i.left&&e<=i.right;function $w(e,t,i,r){let n=$e.find(e.docView,t);if(!n)return 1;let s=t-n.posAtStart;if(s==0)return 1;if(s==n.length)return-1;let o=n.coordsAt(s,-1);if(o&&vd(i,r,o))return-1;let a=n.coordsAt(s,1);return a&&vd(i,r,a)?1:o&&jf(r,o)?-1:1}function Sd(e,t){let i=e.posAtCoords({x:t.clientX,y:t.clientY},!1);return{pos:i,bias:$w(e,i,t.clientX,t.clientY)}}var Tw=A.ie&&A.ie_version<=11,xd=null,Pd=0,kd=0;function Df(e){if(!Tw)return e.detail;let t=xd,i=kd;return xd=e,kd=Date.now(),Pd=!t||i>Date.now()-400&&Math.abs(t.clientX-e.clientX)<2&&Math.abs(t.clientY-e.clientY)<2?(Pd+1)%3:1}function Cw(e,t){let i=Sd(e,t),r=Df(t),n=e.state.selection;return{update(s){s.docChanged&&(i.pos=s.changes.mapPos(i.pos),n=n.map(s.changes))},get(s,o,a){let l=Sd(e,s),h,c=wd(e,l.pos,l.bias,r);if(i.pos!=l.pos&&!o){let u=wd(e,i.pos,i.bias,r),d=Math.min(u.from,c.from),f=Math.max(u.to,c.to);c=d<c.from?$.range(d,f):$.range(f,d)}return o?n.replaceRange(n.main.extend(c.from,c.to)):a&&r==1&&n.ranges.length>1&&(h=Aw(n,l.pos))?h:a?n.addRange(c):$.create([c])}}}function Aw(e,t){for(let i=0;i<e.ranges.length;i++){let{from:r,to:n}=e.ranges[i];if(r<=t&&n>=t)return $.create(e.ranges.slice(0,i).concat(e.ranges.slice(i+1)),e.mainIndex==i?0:e.mainIndex-(e.mainIndex>i?1:0))}return null}ft.dragstart=(e,t)=>{let{selection:{main:i}}=e.state;if(t.target.draggable){let n=e.docView.nearest(t.target);if(n&&n.isWidget){let s=n.posAtStart,o=s+n.length;(s>=i.to||o<=i.from)&&(i=$.range(s,o))}}let{inputState:r}=e;return r.mouseSelection&&(r.mouseSelection.dragging=!0),r.draggedContent=i,t.dataTransfer&&(t.dataTransfer.setData("Text",e.state.sliceDoc(i.from,i.to)),t.dataTransfer.effectAllowed="copyMove"),!1};ft.dragend=e=>(e.inputState.draggedContent=null,!1);function Qd(e,t,i,r){if(!i)return;let n=e.posAtCoords({x:t.clientX,y:t.clientY},!1),{draggedContent:s}=e.inputState,o=r&&s&&xw(e,t)?{from:s.from,to:s.to}:null,a={from:n,insert:i},l=e.state.changes(o?[o,a]:a);e.focus(),e.dispatch({changes:l,selection:{anchor:l.mapPos(n,-1),head:l.mapPos(n,1)},userEvent:o?"move.drop":"input.drop"}),e.inputState.draggedContent=null}ft.drop=(e,t)=>{if(!t.dataTransfer)return!1;if(e.state.readOnly)return!0;let i=t.dataTransfer.files;if(i&&i.length){let r=Array(i.length),n=0,s=()=>{++n==i.length&&Qd(e,t,r.filter(o=>o!=null).join(e.state.lineBreak),!1)};for(let o=0;o<i.length;o++){let a=new FileReader;a.onerror=s,a.onload=()=>{/[\x00-\x08\x0e-\x1f]{2}/.test(a.result)||(r[o]=a.result),s()},a.readAsText(i[o])}return!0}else{let r=t.dataTransfer.getData("Text");if(r)return Qd(e,t,r,!0),!0}return!1};ft.paste=(e,t)=>{if(e.state.readOnly)return!0;e.observer.flush();let i=Vf?null:t.clipboardData;return i?(Nf(e,i.getData("text/plain")||i.getData("text/uri-list")),!0):(Qw(e),!1)};function Zw(e,t){let i=e.dom.parentNode;if(!i)return;let r=i.appendChild(document.createElement("textarea"));r.style.cssText="position: fixed; left: -10000px; top: 10px",r.value=t,r.focus(),r.selectionEnd=t.length,r.selectionStart=0,setTimeout(()=>{r.remove(),e.focus()},50)}function Ew(e){let t=[],i=[],r=!1;for(let n of e.selection.ranges)n.empty||(t.push(e.sliceDoc(n.from,n.to)),i.push(n));if(!t.length){let n=-1;for(let{from:s}of e.selection.ranges){let o=e.doc.lineAt(s);o.number>n&&(t.push(o.text),i.push({from:o.from,to:Math.min(e.doc.length,o.to+1)})),n=o.number}r=!0}return{text:t.join(e.lineBreak),ranges:i,linewise:r}}var Ma=null;ft.copy=ft.cut=(e,t)=>{let{text:i,ranges:r,linewise:n}=Ew(e.state);if(!i&&!n)return!1;Ma=n?i:null,t.type=="cut"&&!e.state.readOnly&&e.dispatch({changes:r,scrollIntoView:!0,userEvent:"delete.cut"});let s=Vf?null:t.clipboardData;return s?(s.clearData(),s.setData("text/plain",i),!0):(Zw(e,i),!1)};var _f=Rt.define();function Uf(e,t){let i=[];for(let r of e.facet(Tf)){let n=r(e,t);n&&i.push(n)}return i?e.update({effects:i,annotations:_f.of(!0)}):null}function zf(e){setTimeout(()=>{let t=e.hasFocus;if(t!=e.inputState.notifiedFocused){let i=Uf(e.state,t);i?e.dispatch(i):e.update([])}},10)}st.focus=e=>{e.inputState.lastFocusTime=Date.now(),!e.scrollDOM.scrollTop&&(e.inputState.lastScrollTop||e.inputState.lastScrollLeft)&&(e.scrollDOM.scrollTop=e.inputState.lastScrollTop,e.scrollDOM.scrollLeft=e.inputState.lastScrollLeft),zf(e)};st.blur=e=>{e.observer.clearSelectionRange(),zf(e)};st.compositionstart=st.compositionupdate=e=>{e.inputState.compositionFirstChange==null&&(e.inputState.compositionFirstChange=!0),e.inputState.composing<0&&(e.inputState.composing=0)};st.compositionend=e=>{e.inputState.composing=-1,e.inputState.compositionEndedAt=Date.now(),e.inputState.compositionPendingKey=!0,e.inputState.compositionPendingChange=e.observer.pendingRecords().length>0,e.inputState.compositionFirstChange=null,A.chrome&&A.android?e.observer.flushSoon():e.inputState.compositionPendingChange?Promise.resolve().then(()=>e.observer.flush()):setTimeout(()=>{e.inputState.composing<0&&e.docView.hasComposition&&e.update([])},50)};st.contextmenu=e=>{e.inputState.lastContextMenu=Date.now()};ft.beforeinput=(e,t)=>{var i;let r;if(A.chrome&&A.android&&(r=If.find(n=>n.inputType==t.inputType))&&(e.observer.delayAndroidKey(r.key,r.keyCode),r.key=="Backspace"||r.key=="Delete")){let n=((i=window.visualViewport)===null||i===void 0?void 0:i.height)||0;setTimeout(()=>{var s;(((s=window.visualViewport)===null||s===void 0?void 0:s.height)||0)>n+10&&e.hasFocus&&(e.contentDOM.blur(),e.focus())},100)}return A.ios&&t.inputType=="deleteContentForward"&&e.observer.flushSoon(),A.safari&&t.inputType=="insertText"&&e.inputState.composing>=0&&setTimeout(()=>st.compositionend(e,t),20),!1};var $d=new Set;function Rw(e){$d.has(e)||($d.add(e),e.addEventListener("copy",()=>{}),e.addEventListener("cut",()=>{}))}var Td=["pre-wrap","normal","pre-line","break-spaces"],Xw=class{constructor(e){this.lineWrapping=e,this.doc=G.empty,this.heightSamples={},this.lineHeight=14,this.charWidth=7,this.textHeight=14,this.lineLength=30,this.heightChanged=!1}heightForGap(e,t){let i=this.doc.lineAt(t).number-this.doc.lineAt(e).number+1;return this.lineWrapping&&(i+=Math.max(0,Math.ceil((t-e-i*this.lineLength*.5)/this.lineLength))),this.lineHeight*i}heightForLine(e){return this.lineWrapping?(1+Math.max(0,Math.ceil((e-this.lineLength)/(this.lineLength-5))))*this.lineHeight:this.lineHeight}setDoc(e){return this.doc=e,this}mustRefreshForWrapping(e){return Td.indexOf(e)>-1!=this.lineWrapping}mustRefreshForHeights(e){let t=!1;for(let i=0;i<e.length;i++){let r=e[i];r<0?i++:this.heightSamples[Math.floor(r*10)]||(t=!0,this.heightSamples[Math.floor(r*10)]=!0)}return t}refresh(e,t,i,r,n,s){let o=Td.indexOf(e)>-1,a=Math.round(t)!=Math.round(this.lineHeight)||this.lineWrapping!=o;if(this.lineWrapping=o,this.lineHeight=t,this.charWidth=i,this.textHeight=r,this.lineLength=n,a){this.heightSamples={};for(let l=0;l<s.length;l++){let h=s[l];h<0?l++:this.heightSamples[Math.floor(h*10)]=!0}}return a}},Mw=class{constructor(e,t){this.from=e,this.heights=t,this.index=0}get more(){return this.index<this.heights.length}},Bt=class Bf{constructor(t,i,r,n,s){this.from=t,this.length=i,this.top=r,this.height=n,this._content=s}get type(){return typeof this._content=="number"?Ce.Text:Array.isArray(this._content)?this._content:this._content.type}get to(){return this.from+this.length}get bottom(){return this.top+this.height}get widget(){return this._content instanceof ji?this._content.widget:null}get widgetLineBreaks(){return typeof this._content=="number"?this._content:0}join(t){let i=(Array.isArray(this._content)?this._content:[this]).concat(Array.isArray(t._content)?t._content:[t]);return new Bf(this.from,this.length+t.length,this.top,this.height+t.height,i)}},re=function(e){return e[e.ByPos=0]="ByPos",e[e.ByHeight=1]="ByHeight",e[e.ByPosNoHeight=2]="ByPosNoHeight",e}(re||(re={})),as=.001,dt=class ls{constructor(t,i,r=2){this.length=t,this.height=i,this.flags=r}get outdated(){return(this.flags&2)>0}set outdated(t){this.flags=(t?2:0)|this.flags&-3}setHeight(t,i){this.height!=i&&(Math.abs(this.height-i)>as&&(t.heightChanged=!0),this.height=i)}replace(t,i,r){return ls.of(r)}decomposeLeft(t,i){i.push(this)}decomposeRight(t,i){i.push(this)}applyChanges(t,i,r,n){let s=this,o=r.doc;for(let a=n.length-1;a>=0;a--){let{fromA:l,toA:h,fromB:c,toB:u}=n[a],d=s.lineAt(l,re.ByPosNoHeight,r.setDoc(i),0,0),f=d.to>=h?d:s.lineAt(h,re.ByPosNoHeight,r,0,0);for(u+=f.to-h,h=f.to;a>0&&d.from<=n[a-1].toA;)l=n[a-1].fromA,c=n[a-1].fromB,a--,l<d.from&&(d=s.lineAt(l,re.ByPosNoHeight,r,0,0));c+=d.from-l,l=d.from;let p=Yw.build(r.setDoc(o),t,c,u);s=s.replace(l,h,p)}return s.updateHeight(r,0)}static empty(){return new kt(0,0)}static of(t){if(t.length==1)return t[0];let i=0,r=t.length,n=0,s=0;for(;;)if(i==r)if(n>s*2){let a=t[i-1];a.break?t.splice(--i,1,a.left,null,a.right):t.splice(--i,1,a.left,a.right),r+=1+a.break,n-=a.size}else if(s>n*2){let a=t[r];a.break?t.splice(r,1,a.left,null,a.right):t.splice(r,1,a.left,a.right),r+=2+a.break,s-=a.size}else break;else if(n<s){let a=t[i++];a&&(n+=a.size)}else{let a=t[--r];a&&(s+=a.size)}let o=0;return t[i-1]==null?(o=1,i--):t[i]==null&&(o=1,r++),new Ww(ls.of(t.slice(0,i)),o,ls.of(t.slice(r)))}};dt.prototype.size=1;var Gf=class extends dt{constructor(e,t,i){super(e,t),this.deco=i}blockAt(e,t,i,r){return new Bt(r,this.length,i,this.height,this.deco||0)}lineAt(e,t,i,r,n){return this.blockAt(0,i,r,n)}forEachLine(e,t,i,r,n,s){e<=n+this.length&&t>=n&&s(this.blockAt(0,i,r,n))}updateHeight(e,t=0,i=!1,r){return r&&r.from<=t&&r.more&&this.setHeight(e,r.heights[r.index++]),this.outdated=!1,this}toString(){return`block(${this.length})`}},kt=class Wa extends Gf{constructor(t,i){super(t,i,null),this.collapsed=0,this.widgetHeight=0,this.breaks=0}blockAt(t,i,r,n){return new Bt(n,this.length,r,this.height,this.breaks)}replace(t,i,r){let n=r[0];return r.length==1&&(n instanceof Wa||n instanceof Vi&&n.flags&4)&&Math.abs(this.length-n.length)<10?(n instanceof Vi?n=new Wa(n.length,this.height):n.height=this.height,this.outdated||(n.outdated=!1),n):dt.of(r)}updateHeight(t,i=0,r=!1,n){return n&&n.from<=i&&n.more?this.setHeight(t,n.heights[n.index++]):(r||this.outdated)&&this.setHeight(t,Math.max(this.widgetHeight,t.heightForLine(this.length-this.collapsed))+this.breaks*t.lineHeight),this.outdated=!1,this}toString(){return`line(${this.length}${this.collapsed?-this.collapsed:""}${this.widgetHeight?":"+this.widgetHeight:""})`}},Vi=class ut extends dt{constructor(t){super(t,0)}heightMetrics(t,i){let r=t.doc.lineAt(i).number,n=t.doc.lineAt(i+this.length).number,s=n-r+1,o,a=0;if(t.lineWrapping){let l=Math.min(this.height,t.lineHeight*s);o=l/s,this.length>s+1&&(a=(this.height-l)/(this.length-s-1))}else o=this.height/s;return{firstLine:r,lastLine:n,perLine:o,perChar:a}}blockAt(t,i,r,n){let{firstLine:s,lastLine:o,perLine:a,perChar:l}=this.heightMetrics(i,n);if(i.lineWrapping){let h=n+(t<i.lineHeight?0:Math.round(Math.max(0,Math.min(1,(t-r)/this.height))*this.length)),c=i.doc.lineAt(h),u=a+c.length*l,d=Math.max(r,t-u/2);return new Bt(c.from,c.length,d,u,0)}else{let h=Math.max(0,Math.min(o-s,Math.floor((t-r)/a))),{from:c,length:u}=i.doc.line(s+h);return new Bt(c,u,r+a*h,a,0)}}lineAt(t,i,r,n,s){if(i==re.ByHeight)return this.blockAt(t,r,n,s);if(i==re.ByPosNoHeight){let{from:f,to:p}=r.doc.lineAt(t);return new Bt(f,p-f,0,0,0)}let{firstLine:o,perLine:a,perChar:l}=this.heightMetrics(r,s),h=r.doc.lineAt(t),c=a+h.length*l,u=h.number-o,d=n+a*u+l*(h.from-s-u);return new Bt(h.from,h.length,Math.max(n,Math.min(d,n+this.height-c)),c,0)}forEachLine(t,i,r,n,s,o){t=Math.max(t,s),i=Math.min(i,s+this.length);let{firstLine:a,perLine:l,perChar:h}=this.heightMetrics(r,s);for(let c=t,u=n;c<=i;){let d=r.doc.lineAt(c);if(c==t){let p=d.number-a;u+=l*p+h*(t-s-p)}let f=l+h*d.length;o(new Bt(d.from,d.length,u,f,0)),u+=f,c=d.to+1}}replace(t,i,r){let n=this.length-i;if(n>0){let s=r[r.length-1];s instanceof ut?r[r.length-1]=new ut(s.length+n):r.push(null,new ut(n-1))}if(t>0){let s=r[0];s instanceof ut?r[0]=new ut(t+s.length):r.unshift(new ut(t-1),null)}return dt.of(r)}decomposeLeft(t,i){i.push(new ut(t-1),null)}decomposeRight(t,i){i.push(null,new ut(this.length-t-1))}updateHeight(t,i=0,r=!1,n){let s=i+this.length;if(n&&n.from<=i+this.length&&n.more){let o=[],a=Math.max(i,n.from),l=-1;for(n.from>i&&o.push(new ut(n.from-i-1).updateHeight(t,i));a<=s&&n.more;){let c=t.doc.lineAt(a).length;o.length&&o.push(null);let u=n.heights[n.index++];l==-1?l=u:Math.abs(u-l)>=as&&(l=-2);let d=new kt(c,u);d.outdated=!1,o.push(d),a+=c+1}a<=s&&o.push(null,new ut(s-a).updateHeight(t,a));let h=dt.of(o);return(l<0||Math.abs(h.height-this.height)>=as||Math.abs(l-this.heightMetrics(t,i).perLine)>=as)&&(t.heightChanged=!0),h}else(r||this.outdated)&&(this.setHeight(t,t.heightForGap(i,i+this.length)),this.outdated=!1);return this}toString(){return`gap(${this.length})`}},Ww=class extends dt{constructor(e,t,i){super(e.length+t+i.length,e.height+i.height,t|(e.outdated||i.outdated?2:0)),this.left=e,this.right=i,this.size=e.size+i.size}get break(){return this.flags&1}blockAt(e,t,i,r){let n=i+this.left.height;return e<n?this.left.blockAt(e,t,i,r):this.right.blockAt(e,t,n,r+this.left.length+this.break)}lineAt(e,t,i,r,n){let s=r+this.left.height,o=n+this.left.length+this.break,a=t==re.ByHeight?e<s:e<o,l=a?this.left.lineAt(e,t,i,r,n):this.right.lineAt(e,t,i,s,o);if(this.break||(a?l.to<o:l.from>o))return l;let h=t==re.ByPosNoHeight?re.ByPosNoHeight:re.ByPos;return a?l.join(this.right.lineAt(o,h,i,s,o)):this.left.lineAt(o,h,i,r,n).join(l)}forEachLine(e,t,i,r,n,s){let o=r+this.left.height,a=n+this.left.length+this.break;if(this.break)e<a&&this.left.forEachLine(e,t,i,r,n,s),t>=a&&this.right.forEachLine(e,t,i,o,a,s);else{let l=this.lineAt(a,re.ByPos,i,r,n);e<l.from&&this.left.forEachLine(e,l.from-1,i,r,n,s),l.to>=e&&l.from<=t&&s(l),t>l.to&&this.right.forEachLine(l.to+1,t,i,o,a,s)}}replace(e,t,i){let r=this.left.length+this.break;if(t<r)return this.balanced(this.left.replace(e,t,i),this.right);if(e>this.left.length)return this.balanced(this.left,this.right.replace(e-r,t-r,i));let n=[];e>0&&this.decomposeLeft(e,n);let s=n.length;for(let o of i)n.push(o);if(e>0&&Cd(n,s-1),t<this.length){let o=n.length;this.decomposeRight(t,n),Cd(n,o)}return dt.of(n)}decomposeLeft(e,t){let i=this.left.length;if(e<=i)return this.left.decomposeLeft(e,t);t.push(this.left),this.break&&(i++,e>=i&&t.push(null)),e>i&&this.right.decomposeLeft(e-i,t)}decomposeRight(e,t){let i=this.left.length,r=i+this.break;if(e>=r)return this.right.decomposeRight(e-r,t);e<i&&this.left.decomposeRight(e,t),this.break&&e<r&&t.push(null),t.push(this.right)}balanced(e,t){return e.size>2*t.size||t.size>2*e.size?dt.of(this.break?[e,null,t]:[e,t]):(this.left=e,this.right=t,this.height=e.height+t.height,this.outdated=e.outdated||t.outdated,this.size=e.size+t.size,this.length=e.length+this.break+t.length,this)}updateHeight(e,t=0,i=!1,r){let{left:n,right:s}=this,o=t+n.length+this.break,a=null;return r&&r.from<=t+n.length&&r.more?a=n=n.updateHeight(e,t,i,r):n.updateHeight(e,t,i),r&&r.from<=o+s.length&&r.more?a=s=s.updateHeight(e,o,i,r):s.updateHeight(e,o,i),a?this.balanced(n,s):(this.height=this.left.height+this.right.height,this.outdated=!1,this)}toString(){return this.left+(this.break?" ":"-")+this.right}};function Cd(e,t){let i,r;e[t]==null&&(i=e[t-1])instanceof Vi&&(r=e[t+1])instanceof Vi&&e.splice(t-1,3,new Vi(i.length+1+r.length))}var qw=5,Yw=class Ff{constructor(t,i){this.pos=t,this.oracle=i,this.nodes=[],this.lineStart=-1,this.lineEnd=-1,this.covering=null,this.writtenTo=t}get isCovered(){return this.covering&&this.nodes[this.nodes.length-1]==this.covering}span(t,i){if(this.lineStart>-1){let r=Math.min(i,this.lineEnd),n=this.nodes[this.nodes.length-1];n instanceof kt?n.length+=r-this.pos:(r>this.pos||!this.isCovered)&&this.nodes.push(new kt(r-this.pos,-1)),this.writtenTo=r,i>r&&(this.nodes.push(null),this.writtenTo++,this.lineStart=-1)}this.pos=i}point(t,i,r){if(t<i||r.heightRelevant){let n=r.widget?r.widget.estimatedHeight:0,s=r.widget?r.widget.lineBreaks:0;n<0&&(n=this.oracle.lineHeight);let o=i-t;r.block?this.addBlock(new Gf(o,n,r)):(o||s||n>=qw)&&this.addLineDeco(n,s,o)}else i>t&&this.span(t,i);this.lineEnd>-1&&this.lineEnd<this.pos&&(this.lineEnd=this.oracle.doc.lineAt(this.pos).to)}enterLine(){if(this.lineStart>-1)return;let{from:t,to:i}=this.oracle.doc.lineAt(this.pos);this.lineStart=t,this.lineEnd=i,this.writtenTo<t&&((this.writtenTo<t-1||this.nodes[this.nodes.length-1]==null)&&this.nodes.push(this.blankContent(this.writtenTo,t-1)),this.nodes.push(null)),this.pos>t&&this.nodes.push(new kt(this.pos-t,-1)),this.writtenTo=this.pos}blankContent(t,i){let r=new Vi(i-t);return this.oracle.doc.lineAt(t).to==i&&(r.flags|=4),r}ensureLine(){this.enterLine();let t=this.nodes.length?this.nodes[this.nodes.length-1]:null;if(t instanceof kt)return t;let i=new kt(0,-1);return this.nodes.push(i),i}addBlock(t){this.enterLine();let i=t.deco;i&&i.startSide>0&&!this.isCovered&&this.ensureLine(),this.nodes.push(t),this.writtenTo=this.pos=this.pos+t.length,i&&i.endSide>0&&(this.covering=t)}addLineDeco(t,i,r){let n=this.ensureLine();n.length+=r,n.collapsed+=r,n.widgetHeight=Math.max(n.widgetHeight,t),n.breaks+=i,this.writtenTo=this.pos=this.pos+r}finish(t){let i=this.nodes.length==0?null:this.nodes[this.nodes.length-1];this.lineStart>-1&&!(i instanceof kt)&&!this.isCovered?this.nodes.push(new kt(0,-1)):(this.writtenTo<this.pos||i==null)&&this.nodes.push(this.blankContent(this.writtenTo,this.pos));let r=t;for(let n of this.nodes)n instanceof kt&&n.updateHeight(this.oracle,r),r+=n?n.length:1;return this.nodes}static build(t,i,r,n){let s=new Ff(r,t);return ie.spans(i,r,n,s,0),s.finish(r)}};function Iw(e,t,i){let r=new Lw;return ie.compare(e,t,i,r,0),r.changes}var Lw=class{constructor(){this.changes=[]}compareRange(){}comparePoint(e,t,i,r){(e<t||i&&i.heightRelevant||r&&r.heightRelevant)&&Qa(e,t,this.changes,5)}};function Vw(e,t){let i=e.getBoundingClientRect(),r=e.ownerDocument,n=r.defaultView||window,s=Math.max(0,i.left),o=Math.min(n.innerWidth,i.right),a=Math.max(0,i.top),l=Math.min(n.innerHeight,i.bottom);for(let h=e.parentNode;h&&h!=r.body;)if(h.nodeType==1){let c=h,u=window.getComputedStyle(c);if((c.scrollHeight>c.clientHeight||c.scrollWidth>c.clientWidth)&&u.overflow!="visible"){let d=c.getBoundingClientRect();s=Math.max(s,d.left),o=Math.min(o,d.right),a=Math.max(a,d.top),l=h==e.parentNode?d.bottom:Math.min(l,d.bottom)}h=u.position=="absolute"||u.position=="fixed"?c.offsetParent:c.parentNode}else if(h.nodeType==11)h=h.host;else break;return{left:s-i.left,right:Math.max(s,o)-i.left,top:a-(i.top+t),bottom:Math.max(a,l)-(i.top+t)}}function Nw(e,t){let i=e.getBoundingClientRect();return{left:0,right:i.right-i.left,top:t,bottom:i.bottom-(i.top+t)}}var la=class{constructor(e,t,i){this.from=e,this.to=t,this.size=i}static same(e,t){if(e.length!=t.length)return!1;for(let i=0;i<e.length;i++){let r=e[i],n=t[i];if(r.from!=n.from||r.to!=n.to||r.size!=n.size)return!1}return!0}draw(e,t){return j.replace({widget:new jw(this.size*(t?e.scaleY:e.scaleX),t)}).range(this.from,this.to)}},jw=class extends Jt{constructor(e,t){super(),this.size=e,this.vertical=t}eq(e){return e.size==this.size&&e.vertical==this.vertical}toDOM(){let e=document.createElement("div");return this.vertical?e.style.height=this.size+"px":(e.style.width=this.size+"px",e.style.height="2px",e.style.display="inline-block"),e}get estimatedHeight(){return this.vertical?this.size:-1}},Ad=class{constructor(e){this.state=e,this.pixelViewport={left:0,right:window.innerWidth,top:0,bottom:0},this.inView=!0,this.paddingTop=0,this.paddingBottom=0,this.contentDOMWidth=0,this.contentDOMHeight=0,this.editorHeight=0,this.editorWidth=0,this.scrollTop=0,this.scrolledToBottom=!1,this.scaleX=1,this.scaleY=1,this.scrollAnchorPos=0,this.scrollAnchorHeight=-1,this.scaler=Zd,this.scrollTarget=null,this.printing=!1,this.mustMeasureContent=!0,this.defaultTextDirection=ee.LTR,this.visibleRanges=[],this.mustEnforceCursorAssoc=!1;let t=e.facet(Ha).some(i=>typeof i!="function"&&i.class=="cm-lineWrapping");this.heightOracle=new Xw(t),this.stateDeco=e.facet(Xr).filter(i=>typeof i!="function"),this.heightMap=dt.empty().applyChanges(this.stateDeco,G.empty,this.heightOracle.setDoc(e.doc),[new Ht(0,0,0,e.doc.length)]),this.viewport=this.getViewport(0,null),this.updateViewportLines(),this.updateForViewport(),this.lineGaps=this.ensureLineGaps([]),this.lineGapDeco=j.set(this.lineGaps.map(i=>i.draw(this,!1))),this.computeVisibleRanges()}updateForViewport(){let e=[this.viewport],{main:t}=this.state.selection;for(let i=0;i<=1;i++){let r=i?t.head:t.anchor;if(!e.some(({from:n,to:s})=>r>=n&&r<=s)){let{from:n,to:s}=this.lineBlockAt(r);e.push(new Bn(n,s))}}this.viewports=e.sort((i,r)=>i.from-r.from),this.scaler=this.heightMap.height<=7e6?Zd:new Uw(this.heightOracle,this.heightMap,this.viewports)}updateViewportLines(){this.viewportLines=[],this.heightMap.forEachLine(this.viewport.from,this.viewport.to,this.heightOracle.setDoc(this.state.doc),0,0,e=>{this.viewportLines.push(this.scaler.scale==1?e:Cr(e,this.scaler))})}update(e,t=null){this.state=e.state;let i=this.stateDeco;this.stateDeco=this.state.facet(Xr).filter(h=>typeof h!="function");let r=e.changedRanges,n=Ht.extendWithRanges(r,Iw(i,this.stateDeco,e?e.changes:ct.empty(this.state.doc.length))),s=this.heightMap.height,o=this.scrolledToBottom?null:this.scrollAnchorAt(this.scrollTop);this.heightMap=this.heightMap.applyChanges(this.stateDeco,e.startState.doc,this.heightOracle.setDoc(this.state.doc),n),this.heightMap.height!=s&&(e.flags|=2),o?(this.scrollAnchorPos=e.changes.mapPos(o.from,-1),this.scrollAnchorHeight=o.top):(this.scrollAnchorPos=-1,this.scrollAnchorHeight=this.heightMap.height);let a=n.length?this.mapViewport(this.viewport,e.changes):this.viewport;(t&&(t.range.head<a.from||t.range.head>a.to)||!this.viewportIsAppropriate(a))&&(a=this.getViewport(0,t));let l=!e.changes.empty||e.flags&2||a.from!=this.viewport.from||a.to!=this.viewport.to;this.viewport=a,this.updateForViewport(),l&&this.updateViewportLines(),(this.lineGaps.length||this.viewport.to-this.viewport.from>4e3)&&this.updateLineGaps(this.ensureLineGaps(this.mapLineGaps(this.lineGaps,e.changes))),e.flags|=this.computeVisibleRanges(),t&&(this.scrollTarget=t),!this.mustEnforceCursorAssoc&&e.selectionSet&&e.view.lineWrapping&&e.state.selection.main.empty&&e.state.selection.main.assoc&&!e.state.facet(ew)&&(this.mustEnforceCursorAssoc=!0)}measure(e){let t=e.contentDOM,i=window.getComputedStyle(t),r=this.heightOracle,n=i.whiteSpace;this.defaultTextDirection=i.direction=="rtl"?ee.RTL:ee.LTR;let s=this.heightOracle.mustRefreshForWrapping(n),o=t.getBoundingClientRect(),a=s||this.mustMeasureContent||this.contentDOMHeight!=o.height;this.contentDOMHeight=o.height,this.mustMeasureContent=!1;let l=0,h=0;if(o.width&&o.height){let{scaleX:S,scaleY:w}=Hd(t,o);(S>.005&&Math.abs(this.scaleX-S)>.005||w>.005&&Math.abs(this.scaleY-w)>.005)&&(this.scaleX=S,this.scaleY=w,l|=8,s=a=!0)}let c=(parseInt(i.paddingTop)||0)*this.scaleY,u=(parseInt(i.paddingBottom)||0)*this.scaleY;(this.paddingTop!=c||this.paddingBottom!=u)&&(this.paddingTop=c,this.paddingBottom=u,l|=10),this.editorWidth!=e.scrollDOM.clientWidth&&(r.lineWrapping&&(a=!0),this.editorWidth=e.scrollDOM.clientWidth,l|=8);let d=e.scrollDOM.scrollTop*this.scaleY;this.scrollTop!=d&&(this.scrollAnchorHeight=-1,this.scrollTop=d),this.scrolledToBottom=ef(e.scrollDOM);let f=(this.printing?Nw:Vw)(t,this.paddingTop),p=f.top-this.pixelViewport.top,O=f.bottom-this.pixelViewport.bottom;this.pixelViewport=f;let g=this.pixelViewport.bottom>this.pixelViewport.top&&this.pixelViewport.right>this.pixelViewport.left;if(g!=this.inView&&(this.inView=g,g&&(a=!0)),!this.inView&&!this.scrollTarget)return 0;let y=o.width;if((this.contentDOMWidth!=y||this.editorHeight!=e.scrollDOM.clientHeight)&&(this.contentDOMWidth=o.width,this.editorHeight=e.scrollDOM.clientHeight,l|=8),a){let S=e.docView.measureVisibleLineHeights(this.viewport);if(r.mustRefreshForHeights(S)&&(s=!0),s||r.lineWrapping&&Math.abs(y-this.contentDOMWidth)>r.charWidth){let{lineHeight:w,charWidth:k,textHeight:Z}=e.docView.measureTextSize();s=w>0&&r.refresh(n,w,k,Z,y/k,S),s&&(e.docView.minWidth=0,l|=8)}p>0&&O>0?h=Math.max(p,O):p<0&&O<0&&(h=Math.min(p,O)),r.heightChanged=!1;for(let w of this.viewports){let k=w.from==this.viewport.from?S:e.docView.measureVisibleLineHeights(w);this.heightMap=(s?dt.empty().applyChanges(this.stateDeco,G.empty,this.heightOracle,[new Ht(0,0,0,e.state.doc.length)]):this.heightMap).updateHeight(r,0,s,new Mw(w.from,k))}r.heightChanged&&(l|=2)}let b=!this.viewportIsAppropriate(this.viewport,h)||this.scrollTarget&&(this.scrollTarget.range.head<this.viewport.from||this.scrollTarget.range.head>this.viewport.to);return b&&(this.viewport=this.getViewport(h,this.scrollTarget)),this.updateForViewport(),(l&2||b)&&this.updateViewportLines(),(this.lineGaps.length||this.viewport.to-this.viewport.from>4e3)&&this.updateLineGaps(this.ensureLineGaps(s?[]:this.lineGaps,e)),l|=this.computeVisibleRanges(),this.mustEnforceCursorAssoc&&(this.mustEnforceCursorAssoc=!1,e.docView.enforceCursorAssoc()),l}get visibleTop(){return this.scaler.fromDOM(this.pixelViewport.top)}get visibleBottom(){return this.scaler.fromDOM(this.pixelViewport.bottom)}getViewport(e,t){let i=.5-Math.max(-.5,Math.min(.5,e/1e3/2)),r=this.heightMap,n=this.heightOracle,{visibleTop:s,visibleBottom:o}=this,a=new Bn(r.lineAt(s-i*1e3,re.ByHeight,n,0,0).from,r.lineAt(o+(1-i)*1e3,re.ByHeight,n,0,0).to);if(t){let{head:l}=t.range;if(l<a.from||l>a.to){let h=Math.min(this.editorHeight,this.pixelViewport.bottom-this.pixelViewport.top),c=r.lineAt(l,re.ByPos,n,0,0),u;t.y=="center"?u=(c.top+c.bottom)/2-h/2:t.y=="start"||t.y=="nearest"&&l<a.from?u=c.top:u=c.bottom-h,a=new Bn(r.lineAt(u-1e3/2,re.ByHeight,n,0,0).from,r.lineAt(u+h+1e3/2,re.ByHeight,n,0,0).to)}}return a}mapViewport(e,t){let i=t.mapPos(e.from,-1),r=t.mapPos(e.to,1);return new Bn(this.heightMap.lineAt(i,re.ByPos,this.heightOracle,0,0).from,this.heightMap.lineAt(r,re.ByPos,this.heightOracle,0,0).to)}viewportIsAppropriate({from:e,to:t},i=0){if(!this.inView)return!0;let{top:r}=this.heightMap.lineAt(e,re.ByPos,this.heightOracle,0,0),{bottom:n}=this.heightMap.lineAt(t,re.ByPos,this.heightOracle,0,0),{visibleTop:s,visibleBottom:o}=this;return(e==0||r<=s-Math.max(10,Math.min(-i,250)))&&(t==this.state.doc.length||n>=o+Math.max(10,Math.min(i,250)))&&r>s-2*1e3&&n<o+2*1e3}mapLineGaps(e,t){if(!e.length||t.empty)return e;let i=[];for(let r of e)t.touchesRange(r.from,r.to)||i.push(new la(t.mapPos(r.from),t.mapPos(r.to),r.size));return i}ensureLineGaps(e,t){let i=this.heightOracle.lineWrapping,r=i?1e4:2e3,n=r>>1,s=r<<1;if(this.defaultTextDirection!=ee.LTR&&!i)return[];let o=[],a=(l,h,c,u)=>{if(h-l<n)return;let d=this.state.selection.main,f=[d.from];d.empty||f.push(d.to);for(let O of f)if(O>l&&O<h){a(l,O-10,c,u),a(O+10,h,c,u);return}let p=_w(e,O=>O.from>=c.from&&O.to<=c.to&&Math.abs(O.from-l)<n&&Math.abs(O.to-h)<n&&!f.some(g=>O.from<g&&O.to>g));if(!p){if(h<c.to&&t&&i&&t.visibleRanges.some(O=>O.from<=h&&O.to>=h)){let O=t.moveToLineBoundary($.cursor(h),!1,!0).head;O>l&&(h=O)}p=new la(l,h,this.gapSize(c,l,h,u))}o.push(p)};for(let l of this.viewportLines){if(l.length<s)continue;let h=Dw(l.from,l.to,this.stateDeco);if(h.total<s)continue;let c=this.scrollTarget?this.scrollTarget.range.head:null,u,d;if(i){let f=r/this.heightOracle.lineLength*this.heightOracle.lineHeight,p,O;if(c!=null){let g=Fn(h,c),y=((this.visibleBottom-this.visibleTop)/2+f)/l.height;p=g-y,O=g+y}else p=(this.visibleTop-l.top-f)/l.height,O=(this.visibleBottom-l.top+f)/l.height;u=Gn(h,p),d=Gn(h,O)}else{let f=h.total*this.heightOracle.charWidth,p=r*this.heightOracle.charWidth,O,g;if(c!=null){let y=Fn(h,c),b=((this.pixelViewport.right-this.pixelViewport.left)/2+p)/f;O=y-b,g=y+b}else O=(this.pixelViewport.left-p)/f,g=(this.pixelViewport.right+p)/f;u=Gn(h,O),d=Gn(h,g)}u>l.from&&a(l.from,u,l,h),d<l.to&&a(d,l.to,l,h)}return o}gapSize(e,t,i,r){let n=Fn(r,i)-Fn(r,t);return this.heightOracle.lineWrapping?e.height*n:r.total*this.heightOracle.charWidth*n}updateLineGaps(e){la.same(e,this.lineGaps)||(this.lineGaps=e,this.lineGapDeco=j.set(e.map(t=>t.draw(this,this.heightOracle.lineWrapping))))}computeVisibleRanges(){let e=this.stateDeco;this.lineGaps.length&&(e=e.concat(this.lineGapDeco));let t=[];ie.spans(e,this.viewport.from,this.viewport.to,{span(r,n){t.push({from:r,to:n})},point(){}},20);let i=t.length!=this.visibleRanges.length||this.visibleRanges.some((r,n)=>r.from!=t[n].from||r.to!=t[n].to);return this.visibleRanges=t,i?4:0}lineBlockAt(e){return e>=this.viewport.from&&e<=this.viewport.to&&this.viewportLines.find(t=>t.from<=e&&t.to>=e)||Cr(this.heightMap.lineAt(e,re.ByPos,this.heightOracle,0,0),this.scaler)}lineBlockAtHeight(e){return Cr(this.heightMap.lineAt(this.scaler.fromDOM(e),re.ByHeight,this.heightOracle,0,0),this.scaler)}scrollAnchorAt(e){let t=this.lineBlockAtHeight(e+8);return t.from>=this.viewport.from||this.viewportLines[0].top-e>200?t:this.viewportLines[0]}elementAtHeight(e){return Cr(this.heightMap.blockAt(this.scaler.fromDOM(e),this.heightOracle,0,0),this.scaler)}get docHeight(){return this.scaler.toDOM(this.heightMap.height)}get contentHeight(){return this.docHeight+this.paddingTop+this.paddingBottom}},Bn=class{constructor(e,t){this.from=e,this.to=t}};function Dw(e,t,i){let r=[],n=e,s=0;return ie.spans(i,e,t,{span(){},point(o,a){o>n&&(r.push({from:n,to:o}),s+=o-n),n=a}},20),n<t&&(r.push({from:n,to:t}),s+=t-n),{total:s,ranges:r}}function Gn({total:e,ranges:t},i){if(i<=0)return t[0].from;if(i>=1)return t[t.length-1].to;let r=Math.floor(e*i);for(let n=0;;n++){let{from:s,to:o}=t[n],a=o-s;if(r<=a)return s+r;r-=a}}function Fn(e,t){let i=0;for(let{from:r,to:n}of e.ranges){if(t<=n){i+=t-r;break}i+=n-r}return i/e.total}function _w(e,t){for(let i of e)if(t(i))return i}var Zd={toDOM(e){return e},fromDOM(e){return e},scale:1},Uw=class{constructor(e,t,i){let r=0,n=0,s=0;this.viewports=i.map(({from:o,to:a})=>{let l=t.lineAt(o,re.ByPos,e,0,0).top,h=t.lineAt(a,re.ByPos,e,0,0).bottom;return r+=h-l,{from:o,to:a,top:l,bottom:h,domTop:0,domBottom:0}}),this.scale=(7e6-r)/(t.height-r);for(let o of this.viewports)o.domTop=s+(o.top-n)*this.scale,s=o.domBottom=o.domTop+(o.bottom-o.top),n=o.bottom}toDOM(e){for(let t=0,i=0,r=0;;t++){let n=t<this.viewports.length?this.viewports[t]:null;if(!n||e<n.top)return r+(e-i)*this.scale;if(e<=n.bottom)return n.domTop+(e-n.top);i=n.bottom,r=n.domBottom}}fromDOM(e){for(let t=0,i=0,r=0;;t++){let n=t<this.viewports.length?this.viewports[t]:null;if(!n||e<n.domTop)return i+(e-r)/this.scale;if(e<=n.domBottom)return n.top+(e-n.domTop);i=n.bottom,r=n.domBottom}}};function Cr(e,t){if(t.scale==1)return e;let i=t.toDOM(e.top),r=t.toDOM(e.bottom);return new Bt(e.from,e.length,i,r-i,Array.isArray(e._content)?e._content.map(n=>Cr(n,t)):e._content)}var Hn=E.define({combine:e=>e.join(" ")}),qa=E.define({combine:e=>e.indexOf(!0)>-1}),Ya=xt.newName(),Hf=xt.newName(),Kf=xt.newName(),Jf={"&light":"."+Hf,"&dark":"."+Kf};function Ia(e,t,i){return new xt(t,{finish(r){return/&/.test(r)?r.replace(/&\w*/,n=>{if(n=="&")return e;if(!i||!i[n])throw new RangeError(`Unsupported selector: ${n}`);return i[n]}):e+" "+r}})}var zw=Ia("."+Ya,{"&":{position:"relative !important",boxSizing:"border-box","&.cm-focused":{outline:"1px dotted #212121"},display:"flex !important",flexDirection:"column"},".cm-scroller":{display:"flex !important",alignItems:"flex-start !important",fontFamily:"monospace",lineHeight:1.4,height:"100%",overflowX:"auto",position:"relative",zIndex:0},".cm-content":{margin:0,flexGrow:2,flexShrink:0,display:"block",whiteSpace:"pre",wordWrap:"normal",boxSizing:"border-box",minHeight:"100%",padding:"4px 0",outline:"none","&[contenteditable=true]":{WebkitUserModify:"read-write-plaintext-only"}},".cm-lineWrapping":{whiteSpace_fallback:"pre-wrap",whiteSpace:"break-spaces",wordBreak:"break-word",overflowWrap:"anywhere",flexShrink:1},"&light .cm-content":{caretColor:"black"},"&dark .cm-content":{caretColor:"white"},".cm-line":{display:"block",padding:"0 2px 0 6px"},".cm-layer":{position:"absolute",left:0,top:0,contain:"size style","& > *":{position:"absolute"}},"&light .cm-selectionBackground":{background:"#d9d9d9"},"&dark .cm-selectionBackground":{background:"#222"},"&light.cm-focused > .cm-scroller > .cm-selectionLayer .cm-selectionBackground":{background:"#d7d4f0"},"&dark.cm-focused > .cm-scroller > .cm-selectionLayer .cm-selectionBackground":{background:"#233"},".cm-cursorLayer":{pointerEvents:"none"},"&.cm-focused > .cm-scroller > .cm-cursorLayer":{animation:"steps(1) cm-blink 1.2s infinite"},"@keyframes cm-blink":{"0%":{},"50%":{opacity:0},"100%":{}},"@keyframes cm-blink2":{"0%":{},"50%":{opacity:0},"100%":{}},".cm-cursor, .cm-dropCursor":{borderLeft:"1.2px solid black",marginLeft:"-0.6px",pointerEvents:"none"},".cm-cursor":{display:"none"},"&dark .cm-cursor":{borderLeftColor:"#444"},".cm-dropCursor":{position:"absolute"},"&.cm-focused > .cm-scroller > .cm-cursorLayer .cm-cursor":{display:"block"},".cm-iso":{unicodeBidi:"isolate"},".cm-announced":{position:"fixed",top:"-10000px"},"@media print":{".cm-announced":{display:"none"}},"&light .cm-activeLine":{backgroundColor:"#cceeff44"},"&dark .cm-activeLine":{backgroundColor:"#99eeff33"},"&light .cm-specialChar":{color:"red"},"&dark .cm-specialChar":{color:"#f78"},".cm-gutters":{flexShrink:0,display:"flex",height:"100%",boxSizing:"border-box",insetInlineStart:0,zIndex:200},"&light .cm-gutters":{backgroundColor:"#f5f5f5",color:"#6c6c6c",borderRight:"1px solid #ddd"},"&dark .cm-gutters":{backgroundColor:"#333338",color:"#ccc"},".cm-gutter":{display:"flex !important",flexDirection:"column",flexShrink:0,boxSizing:"border-box",minHeight:"100%",overflow:"hidden"},".cm-gutterElement":{boxSizing:"border-box"},".cm-lineNumbers .cm-gutterElement":{padding:"0 3px 0 5px",minWidth:"20px",textAlign:"right",whiteSpace:"nowrap"},"&light .cm-activeLineGutter":{backgroundColor:"#e2f2ff"},"&dark .cm-activeLineGutter":{backgroundColor:"#222227"},".cm-panels":{boxSizing:"border-box",position:"sticky",left:0,right:0},"&light .cm-panels":{backgroundColor:"#f5f5f5",color:"black"},"&light .cm-panels-top":{borderBottom:"1px solid #ddd"},"&light .cm-panels-bottom":{borderTop:"1px solid #ddd"},"&dark .cm-panels":{backgroundColor:"#333338",color:"white"},".cm-tab":{display:"inline-block",overflow:"hidden",verticalAlign:"bottom"},".cm-widgetBuffer":{verticalAlign:"text-top",height:"1em",width:0,display:"inline"},".cm-placeholder":{color:"#888",display:"inline-block",verticalAlign:"top"},".cm-highlightSpace:before":{content:"attr(data-display)",position:"absolute",pointerEvents:"none",color:"#888"},".cm-highlightTab":{backgroundImage:`url('data:image/svg+xml,<svg xmlns="http://www.w3.org/2000/svg" width="200" height="20"><path stroke="%23888" stroke-width="1" fill="none" d="M1 10H196L190 5M190 15L196 10M197 4L197 16"/></svg>')`,backgroundSize:"auto 100%",backgroundPosition:"right 90%",backgroundRepeat:"no-repeat"},".cm-trailingSpace":{backgroundColor:"#ff332255"},".cm-button":{verticalAlign:"middle",color:"inherit",fontSize:"70%",padding:".2em 1em",borderRadius:"1px"},"&light .cm-button":{backgroundImage:"linear-gradient(#eff1f5, #d9d9df)",border:"1px solid #888","&:active":{backgroundImage:"linear-gradient(#b4b4b4, #d0d3d6)"}},"&dark .cm-button":{backgroundImage:"linear-gradient(#393939, #111)",border:"1px solid #888","&:active":{backgroundImage:"linear-gradient(#111, #333)"}},".cm-textfield":{verticalAlign:"middle",color:"inherit",fontSize:"70%",border:"1px solid silver",padding:".2em .5em"},"&light .cm-textfield":{backgroundColor:"white"},"&dark .cm-textfield":{border:"1px solid #555",backgroundColor:"inherit"}},Jf),Ar="\uFFFF",Bw=class{constructor(e,t){this.points=e,this.text="",this.lineSeparator=t.facet(he.lineSeparator)}append(e){this.text+=e}lineBreak(){this.text+=Ar}readRange(e,t){if(!e)return this;let i=e.parentNode;for(let r=e;;){this.findPointBefore(i,r);let n=this.text.length;this.readNode(r);let s=r.nextSibling;if(s==t)break;let o=ne.get(r),a=ne.get(s);(o&&a?o.breakAfter:(o?o.breakAfter:fs(r))||fs(s)&&(r.nodeName!="BR"||r.cmIgnore)&&this.text.length>n)&&this.lineBreak(),r=s}return this.findPointBefore(i,t),this}readTextNode(e){let t=e.nodeValue;for(let i of this.points)i.node==e&&(i.pos=this.text.length+Math.min(i.offset,t.length));for(let i=0,r=this.lineSeparator?null:/\r\n?|\n/g;;){let n=-1,s=1,o;if(this.lineSeparator?(n=t.indexOf(this.lineSeparator,i),s=this.lineSeparator.length):(o=r.exec(t))&&(n=o.index,s=o[0].length),this.append(t.slice(i,n<0?t.length:n)),n<0)break;if(this.lineBreak(),s>1)for(let a of this.points)a.node==e&&a.pos>this.text.length&&(a.pos-=s-1);i=n+s}}readNode(e){if(e.cmIgnore)return;let t=ne.get(e),i=t&&t.overrideDOMText;if(i!=null){this.findPointInside(e,i.length);for(let r=i.iter();!r.next().done;)r.lineBreak?this.lineBreak():this.append(r.value)}else e.nodeType==3?this.readTextNode(e):e.nodeName=="BR"?e.nextSibling&&this.lineBreak():e.nodeType==1&&this.readRange(e.firstChild,null)}findPointBefore(e,t){for(let i of this.points)i.node==e&&e.childNodes[i.offset]==t&&(i.pos=this.text.length)}findPointInside(e,t){for(let i of this.points)(e.nodeType==3?i.node==e:e.contains(i.node))&&(i.pos=this.text.length+(Gw(e,i.node,i.offset)?t:0))}};function Gw(e,t,i){for(;;){if(!t||i<Wt(t))return!1;if(t==e)return!0;i=bi(t)+1,t=t.parentNode}}var Ed=class{constructor(e,t){this.node=e,this.offset=t,this.pos=-1}},Fw=class{constructor(e,t,i,r){this.typeOver=r,this.bounds=null,this.text="";let{impreciseHead:n,impreciseAnchor:s}=e.docView;if(e.state.readOnly&&t>-1)this.newSel=null;else if(t>-1&&(this.bounds=e.docView.domBoundsAround(t,i,0))){let o=n||s?[]:Jw(e),a=new Bw(o,e.state);a.readRange(this.bounds.startDOM,this.bounds.endDOM),this.text=a.text,this.newSel=ev(o,this.bounds.from)}else{let o=e.observer.selectionRange,a=n&&n.node==o.focusNode&&n.offset==o.focusOffset||!pa(e.contentDOM,o.focusNode)?e.state.selection.main.head:e.docView.posFromDOM(o.focusNode,o.focusOffset),l=s&&s.node==o.anchorNode&&s.offset==o.anchorOffset||!pa(e.contentDOM,o.anchorNode)?e.state.selection.main.anchor:e.docView.posFromDOM(o.anchorNode,o.anchorOffset),h=e.viewport;if((A.ios||A.chrome)&&e.state.selection.main.empty&&a!=l&&(h.from>0||h.to<e.state.doc.length)){let c=Math.min(a,l),u=Math.max(a,l),d=h.from-c,f=h.to-u;(d==0||d==1||c==0)&&(f==0||f==-1||u==e.state.doc.length)&&(a=0,l=e.state.doc.length)}this.newSel=$.single(l,a)}}};function ep(e,t){let i,{newSel:r}=t,n=e.state.selection.main,s=e.inputState.lastKeyTime>Date.now()-100?e.inputState.lastKeyCode:-1;if(t.bounds){let{from:o,to:a}=t.bounds,l=n.from,h=null;(s===8||A.android&&t.text.length<a-o)&&(l=n.to,h="end");let c=Kw(e.state.doc.sliceString(o,a,Ar),t.text,l-o,h);c&&(A.chrome&&s==13&&c.toB==c.from+2&&t.text.slice(c.from,c.toB)==Ar+Ar&&c.toB--,i={from:o+c.from,to:o+c.toA,insert:G.of(t.text.slice(c.from,c.toB).split(Ar))})}else r&&(!e.hasFocus&&e.state.facet(ms)||r.main.eq(n))&&(r=null);if(!i&&!r)return!1;if(!i&&t.typeOver&&!n.empty&&r&&r.main.empty?i={from:n.from,to:n.to,insert:e.state.doc.slice(n.from,n.to)}:i&&i.from>=n.from&&i.to<=n.to&&(i.from!=n.from||i.to!=n.to)&&n.to-n.from-(i.to-i.from)<=4?i={from:n.from,to:n.to,insert:e.state.doc.slice(n.from,i.from).append(i.insert).append(e.state.doc.slice(i.to,n.to))}:(A.mac||A.android)&&i&&i.from==i.to&&i.from==n.head-1&&/^\. ?$/.test(i.insert.toString())&&e.contentDOM.getAttribute("autocorrect")=="off"?(r&&i.insert.length==2&&(r=$.single(r.main.anchor-1,r.main.head-1)),i={from:n.from,to:n.to,insert:G.of([" "])}):A.chrome&&i&&i.from==i.to&&i.from==n.head&&i.insert.toString()==`
- `&&e.lineWrapping&&(r&&(r=$.single(r.main.anchor-1,r.main.head-1)),i={from:n.from,to:n.to,insert:G.of([" "])}),i){if(A.ios&&e.inputState.flushIOSKey(i)||A.android&&(i.to==n.to&&(i.from==n.from||i.from==n.from-1&&e.state.sliceDoc(i.from,n.from)==" ")&&i.insert.length==1&&i.insert.lines==2&&Li(e.contentDOM,"Enter",13)||(i.from==n.from-1&&i.to==n.to&&i.insert.length==0||s==8&&i.insert.length<i.to-i.from&&i.to>n.head)&&Li(e.contentDOM,"Backspace",8)||i.from==n.from&&i.to==n.to+1&&i.insert.length==0&&Li(e.contentDOM,"Delete",46)))return!0;let o=i.insert.toString();e.inputState.composing>=0&&e.inputState.composing++;let a,l=()=>a||(a=Hw(e,i,r));return e.state.facet($f).some(h=>h(e,i.from,i.to,o,l))||e.dispatch(l()),!0}else if(r&&!r.main.eq(n)){let o=!1,a="select";return e.inputState.lastSelectionTime>Date.now()-50&&(e.inputState.lastSelectionOrigin=="select"&&(o=!0),a=e.inputState.lastSelectionOrigin),e.dispatch({selection:r,scrollIntoView:o,userEvent:a}),!0}else return!1}function Hw(e,t,i){let r,n=e.state,s=n.selection.main;if(t.from>=s.from&&t.to<=s.to&&t.to-t.from>=(s.to-s.from)/3&&(!i||i.main.empty&&i.main.from==t.from+t.insert.length)&&e.inputState.composing<0){let a=s.from<t.from?n.sliceDoc(s.from,t.from):"",l=s.to>t.to?n.sliceDoc(t.to,s.to):"";r=n.replaceSelection(e.state.toText(a+t.insert.sliceString(0,void 0,e.state.lineBreak)+l))}else{let a=n.changes(t),l=i&&i.main.to<=a.newLength?i.main:void 0;if(n.selection.ranges.length>1&&e.inputState.composing>=0&&t.to<=s.to&&t.to>=s.to-10){let h=e.state.sliceDoc(t.from,t.to),c,u=i&&qf(e,i.main.head);if(u){let p=t.insert.length-(t.to-t.from);c={from:u.from,to:u.to-p}}else c=e.state.doc.lineAt(s.head);let d=s.to-t.to,f=s.to-s.from;r=n.changeByRange(p=>{if(p.from==s.from&&p.to==s.to)return{changes:a,range:l||p.map(a)};let O=p.to-d,g=O-h.length;if(p.to-p.from!=f||e.state.sliceDoc(g,O)!=h||p.to>=c.from&&p.from<=c.to)return{range:p};let y=n.changes({from:g,to:O,insert:t.insert}),b=p.to-s.to;return{changes:y,range:l?$.range(Math.max(0,l.anchor+b),Math.max(0,l.head+b)):p.map(y)}})}else r={changes:a,selection:l&&n.selection.replaceRange(l)}}let o="input.type";return(e.composing||e.inputState.compositionPendingChange&&e.inputState.compositionEndedAt>Date.now()-50)&&(e.inputState.compositionPendingChange=!1,o+=".compose",e.inputState.compositionFirstChange&&(o+=".start",e.inputState.compositionFirstChange=!1)),n.update(r,{userEvent:o,scrollIntoView:!0})}function Kw(e,t,i,r){let n=Math.min(e.length,t.length),s=0;for(;s<n&&e.charCodeAt(s)==t.charCodeAt(s);)s++;if(s==n&&e.length==t.length)return null;let o=e.length,a=t.length;for(;o>0&&a>0&&e.charCodeAt(o-1)==t.charCodeAt(a-1);)o--,a--;if(r=="end"){let l=Math.max(0,s-Math.min(o,a));i-=o+l-s}if(o<s&&e.length<t.length){let l=i<=s&&i>=o?s-i:0;s-=l,a=s+(a-o),o=s}else if(a<s){let l=i<=s&&i>=a?s-i:0;s-=l,o=s+(o-a),a=s}return{from:s,toA:o,toB:a}}function Jw(e){let t=[];if(e.root.activeElement!=e.contentDOM)return t;let{anchorNode:i,anchorOffset:r,focusNode:n,focusOffset:s}=e.observer.selectionRange;return i&&(t.push(new Ed(i,r)),(n!=i||s!=r)&&t.push(new Ed(n,s))),t}function ev(e,t){if(e.length==0)return null;let i=e[0].pos,r=e.length==2?e[1].pos:i;return i>-1&&r>-1?$.single(i+t,r+t):null}var tv={childList:!0,characterData:!0,subtree:!0,attributes:!0,characterDataOldValue:!0},ha=A.ie&&A.ie_version<=11,iv=class{constructor(e){this.view=e,this.active=!1,this.selectionRange=new qb,this.selectionChanged=!1,this.delayedFlush=-1,this.resizeTimeout=-1,this.queue=[],this.delayedAndroidKey=null,this.flushingAndroidKey=-1,this.lastChange=0,this.scrollTargets=[],this.intersection=null,this.resizeScroll=null,this.intersecting=!1,this.gapIntersection=null,this.gaps=[],this.printQuery=null,this.parentCheck=-1,this.dom=e.contentDOM,this.observer=new MutationObserver(t=>{for(let i of t)this.queue.push(i);(A.ie&&A.ie_version<=11||A.ios&&e.composing)&&t.some(i=>i.type=="childList"&&i.removedNodes.length||i.type=="characterData"&&i.oldValue.length>i.target.nodeValue.length)?this.flushSoon():this.flush()}),ha&&(this.onCharData=t=>{this.queue.push({target:t.target,type:"characterData",oldValue:t.prevValue}),this.flushSoon()}),this.onSelectionChange=this.onSelectionChange.bind(this),this.onResize=this.onResize.bind(this),this.onPrint=this.onPrint.bind(this),this.onScroll=this.onScroll.bind(this),window.matchMedia&&(this.printQuery=window.matchMedia("print")),typeof ResizeObserver=="function"&&(this.resizeScroll=new ResizeObserver(()=>{var t;((t=this.view.docView)===null||t===void 0?void 0:t.lastUpdate)<Date.now()-75&&this.onResize()}),this.resizeScroll.observe(e.scrollDOM)),this.addWindowListeners(this.win=e.win),this.start(),typeof IntersectionObserver=="function"&&(this.intersection=new IntersectionObserver(t=>{this.parentCheck<0&&(this.parentCheck=setTimeout(this.listenForScroll.bind(this),1e3)),t.length>0&&t[t.length-1].intersectionRatio>0!=this.intersecting&&(this.intersecting=!this.intersecting,this.intersecting!=this.view.inView&&this.onScrollChanged(document.createEvent("Event")))},{threshold:[0,.001]}),this.intersection.observe(this.dom),this.gapIntersection=new IntersectionObserver(t=>{t.length>0&&t[t.length-1].intersectionRatio>0&&this.onScrollChanged(document.createEvent("Event"))},{})),this.listenForScroll(),this.readSelectionRange()}onScrollChanged(e){this.view.inputState.runHandlers("scroll",e),this.intersecting&&this.view.measure()}onScroll(e){this.intersecting&&this.flush(!1),this.onScrollChanged(e)}onResize(){this.resizeTimeout<0&&(this.resizeTimeout=setTimeout(()=>{this.resizeTimeout=-1,this.view.requestMeasure()},50))}onPrint(e){e.type=="change"&&!e.matches||(this.view.viewState.printing=!0,this.view.measure(),setTimeout(()=>{this.view.viewState.printing=!1,this.view.requestMeasure()},500))}updateGaps(e){if(this.gapIntersection&&(e.length!=this.gaps.length||this.gaps.some((t,i)=>t!=e[i]))){this.gapIntersection.disconnect();for(let t of e)this.gapIntersection.observe(t);this.gaps=e}}onSelectionChange(e){let t=this.selectionChanged;if(!this.readSelectionRange()||this.delayedAndroidKey)return;let{view:i}=this,r=this.selectionRange;if(i.state.facet(ms)?i.root.activeElement!=this.dom:!ts(i.dom,r))return;let n=r.anchorNode&&i.docView.nearest(r.anchorNode);if(n&&n.ignoreEvent(e)){t||(this.selectionChanged=!1);return}(A.ie&&A.ie_version<=11||A.android&&A.chrome)&&!i.state.selection.main.empty&&r.focusNode&&Er(r.focusNode,r.focusOffset,r.anchorNode,r.anchorOffset)?this.flushSoon():this.flush(!1)}readSelectionRange(){let{view:e}=this,t=ds(e.root);if(!t)return!1;let i=A.safari&&e.root.nodeType==11&&Rb(this.dom.ownerDocument)==this.dom&&rv(this.view,t)||t;if(!i||this.selectionRange.eq(i))return!1;let r=ts(this.dom,i);return r&&!this.selectionChanged&&e.inputState.lastFocusTime>Date.now()-200&&e.inputState.lastTouchTime<Date.now()-300&&Ib(this.dom,i)?(this.view.inputState.lastFocusTime=0,e.docView.updateSelection(),!1):(this.selectionRange.setRange(i),r&&(this.selectionChanged=!0),!0)}setSelectionRange(e,t){this.selectionRange.set(e.node,e.offset,t.node,t.offset),this.selectionChanged=!1}clearSelectionRange(){this.selectionRange.set(null,0,null,0)}listenForScroll(){this.parentCheck=-1;let e=0,t=null;for(let i=this.dom;i;)if(i.nodeType==1)!t&&e<this.scrollTargets.length&&this.scrollTargets[e]==i?e++:t||(t=this.scrollTargets.slice(0,e)),t&&t.push(i),i=i.assignedSlot||i.parentNode;else if(i.nodeType==11)i=i.host;else break;if(e<this.scrollTargets.length&&!t&&(t=this.scrollTargets.slice(0,e)),t){for(let i of this.scrollTargets)i.removeEventListener("scroll",this.onScroll);for(let i of this.scrollTargets=t)i.addEventListener("scroll",this.onScroll)}}ignore(e){if(!this.active)return e();try{return this.stop(),e()}finally{this.start(),this.clear()}}start(){this.active||(this.observer.observe(this.dom,tv),ha&&this.dom.addEventListener("DOMCharacterDataModified",this.onCharData),this.active=!0)}stop(){this.active&&(this.active=!1,this.observer.disconnect(),ha&&this.dom.removeEventListener("DOMCharacterDataModified",this.onCharData))}clear(){this.processRecords(),this.queue.length=0,this.selectionChanged=!1}delayAndroidKey(e,t){var i;if(!this.delayedAndroidKey){let r=()=>{let n=this.delayedAndroidKey;n&&(this.clearDelayedAndroidKey(),this.view.inputState.lastKeyCode=n.keyCode,this.view.inputState.lastKeyTime=Date.now(),!this.flush()&&n.force&&Li(this.dom,n.key,n.keyCode))};this.flushingAndroidKey=this.view.win.requestAnimationFrame(r)}(!this.delayedAndroidKey||e=="Enter")&&(this.delayedAndroidKey={key:e,keyCode:t,force:this.lastChange<Date.now()-50||!!(!((i=this.delayedAndroidKey)===null||i===void 0)&&i.force)})}clearDelayedAndroidKey(){this.win.cancelAnimationFrame(this.flushingAndroidKey),this.delayedAndroidKey=null,this.flushingAndroidKey=-1}flushSoon(){this.delayedFlush<0&&(this.delayedFlush=this.view.win.requestAnimationFrame(()=>{this.delayedFlush=-1,this.flush()}))}forceFlush(){this.delayedFlush>=0&&(this.view.win.cancelAnimationFrame(this.delayedFlush),this.delayedFlush=-1),this.flush()}pendingRecords(){for(let e of this.observer.takeRecords())this.queue.push(e);return this.queue}processRecords(){let e=this.pendingRecords();e.length&&(this.queue=[]);let t=-1,i=-1,r=!1;for(let n of e){let s=this.readMutation(n);s&&(s.typeOver&&(r=!0),t==-1?{from:t,to:i}=s:(t=Math.min(s.from,t),i=Math.max(s.to,i)))}return{from:t,to:i,typeOver:r}}readChange(){let{from:e,to:t,typeOver:i}=this.processRecords(),r=this.selectionChanged&&ts(this.dom,this.selectionRange);if(e<0&&!r)return null;e>-1&&(this.lastChange=Date.now()),this.view.inputState.lastFocusTime=0,this.selectionChanged=!1;let n=new Fw(this.view,e,t,i);return this.view.docView.domChanged={newSel:n.newSel?n.newSel.main:null},n}flush(e=!0){if(this.delayedFlush>=0||this.delayedAndroidKey)return!1;e&&this.readSelectionRange();let t=this.readChange();if(!t)return this.view.requestMeasure(),!1;let i=this.view.state,r=ep(this.view,t);return this.view.state==i&&this.view.update([]),r}readMutation(e){let t=this.view.docView.nearest(e.target);if(!t||t.ignoreMutation(e))return null;if(t.markDirty(e.type=="attributes"),e.type=="attributes"&&(t.flags|=4),e.type=="childList"){let i=Rd(t,e.previousSibling||e.target.previousSibling,-1),r=Rd(t,e.nextSibling||e.target.nextSibling,1);return{from:i?t.posAfter(i):t.posAtStart,to:r?t.posBefore(r):t.posAtEnd,typeOver:!1}}else return e.type=="characterData"?{from:t.posAtStart,to:t.posAtEnd,typeOver:e.target.nodeValue==e.oldValue}:null}setWindow(e){e!=this.win&&(this.removeWindowListeners(this.win),this.win=e,this.addWindowListeners(this.win))}addWindowListeners(e){e.addEventListener("resize",this.onResize),this.printQuery?this.printQuery.addEventListener("change",this.onPrint):e.addEventListener("beforeprint",this.onPrint),e.addEventListener("scroll",this.onScroll),e.document.addEventListener("selectionchange",this.onSelectionChange)}removeWindowListeners(e){e.removeEventListener("scroll",this.onScroll),e.removeEventListener("resize",this.onResize),this.printQuery?this.printQuery.removeEventListener("change",this.onPrint):e.removeEventListener("beforeprint",this.onPrint),e.document.removeEventListener("selectionchange",this.onSelectionChange)}destroy(){var e,t,i;this.stop(),(e=this.intersection)===null||e===void 0||e.disconnect(),(t=this.gapIntersection)===null||t===void 0||t.disconnect(),(i=this.resizeScroll)===null||i===void 0||i.disconnect();for(let r of this.scrollTargets)r.removeEventListener("scroll",this.onScroll);this.removeWindowListeners(this.win),clearTimeout(this.parentCheck),clearTimeout(this.resizeTimeout),this.win.cancelAnimationFrame(this.delayedFlush),this.win.cancelAnimationFrame(this.flushingAndroidKey)}};function Rd(e,t,i){for(;t;){let r=ne.get(t);if(r&&r.parent==e)return r;let n=t.parentNode;t=n!=e.dom?n:i>0?t.nextSibling:t.previousSibling}return null}function Xd(e,t){let i=t.startContainer,r=t.startOffset,n=t.endContainer,s=t.endOffset,o=e.docView.domAtPos(e.state.selection.main.anchor);return Er(o.node,o.offset,n,s)&&([i,r,n,s]=[n,s,i,r]),{anchorNode:i,anchorOffset:r,focusNode:n,focusOffset:s}}function rv(e,t){if(t.getComposedRanges){let n=t.getComposedRanges(e.root)[0];if(n)return Xd(e,n)}let i=null;function r(n){n.preventDefault(),n.stopImmediatePropagation(),i=n.getTargetRanges()[0]}return e.contentDOM.addEventListener("beforeinput",r,!0),e.dom.ownerDocument.execCommand("indent"),e.contentDOM.removeEventListener("beforeinput",r,!0),i?Xd(e,i):null}var W=class La{get state(){return this.viewState.state}get viewport(){return this.viewState.viewport}get visibleRanges(){return this.viewState.visibleRanges}get inView(){return this.viewState.inView}get composing(){return this.inputState.composing>0}get compositionStarted(){return this.inputState.composing>=0}get root(){return this._root}get win(){return this.dom.ownerDocument.defaultView||window}constructor(t={}){this.plugins=[],this.pluginMap=new Map,this.editorAttrs={},this.contentAttrs={},this.bidiCache=[],this.destroyed=!1,this.updateState=2,this.measureScheduled=-1,this.measureRequests=[],this.contentDOM=document.createElement("div"),this.scrollDOM=document.createElement("div"),this.scrollDOM.tabIndex=-1,this.scrollDOM.className="cm-scroller",this.scrollDOM.appendChild(this.contentDOM),this.announceDOM=document.createElement("div"),this.announceDOM.className="cm-announced",this.announceDOM.setAttribute("aria-live","polite"),this.dom=document.createElement("div"),this.dom.appendChild(this.announceDOM),this.dom.appendChild(this.scrollDOM),t.parent&&t.parent.appendChild(this.dom);let{dispatch:i}=t;this.dispatchTransactions=t.dispatchTransactions||i&&(r=>r.forEach(n=>i(n,this)))||(r=>this.update(r)),this.dispatch=this.dispatch.bind(this),this._root=t.root||Yb(t.parent)||document,this.viewState=new Ad(t.state||he.create(t)),t.scrollTo&&t.scrollTo.is(_n)&&(this.viewState.scrollTarget=t.scrollTo.value.clip(this.viewState.state)),this.plugins=this.state.facet($r).map(r=>new sa(r));for(let r of this.plugins)r.update(this);this.observer=new iv(this),this.inputState=new gw(this),this.inputState.ensureHandlers(this.plugins),this.docView=new dd(this),this.mountStyles(),this.updateAttrs(),this.updateState=0,this.requestMeasure()}dispatch(...t){let i=t.length==1&&t[0]instanceof Me?t:t.length==1&&Array.isArray(t[0])?t[0]:[this.state.update(...t)];this.dispatchTransactions(i,this)}update(t){if(this.updateState!=0)throw new Error("Calls to EditorView.update are not allowed while an update is in progress");let i=!1,r=!1,n,s=this.state;for(let d of t){if(d.startState!=s)throw new RangeError("Trying to update state with a transaction that doesn't start from the previous state.");s=d.state}if(this.destroyed){this.viewState.state=s;return}let o=this.hasFocus,a=0,l=null;t.some(d=>d.annotation(_f))?(this.inputState.notifiedFocused=o,a=1):o!=this.inputState.notifiedFocused&&(this.inputState.notifiedFocused=o,l=Uf(s,o),l||(a=1));let h=this.observer.delayedAndroidKey,c=null;if(h?(this.observer.clearDelayedAndroidKey(),c=this.observer.readChange(),(c&&!this.state.doc.eq(s.doc)||!this.state.selection.eq(s.selection))&&(c=null)):this.observer.clear(),s.facet(he.phrases)!=this.state.facet(he.phrases))return this.setState(s);n=ud.create(this,s,t),n.flags|=a;let u=this.viewState.scrollTarget;try{this.updateState=2;for(let d of t){if(u&&(u=u.map(d.changes)),d.scrollIntoView){let{main:f}=d.state.selection;u=new na(f.empty?f:$.cursor(f.head,f.head>f.anchor?-1:1))}for(let f of d.effects)f.is(_n)&&(u=f.value.clip(this.state))}this.viewState.update(n,u),this.bidiCache=Wd.update(this.bidiCache,n.changes),n.empty||(this.updatePlugins(n),this.inputState.update(n)),i=this.docView.update(n),this.state.facet(Tr)!=this.styleModules&&this.mountStyles(),r=this.updateAttrs(),this.showAnnouncements(t),this.docView.updateSelection(i,t.some(d=>d.isUserEvent("select.pointer")))}finally{this.updateState=0}if(n.startState.facet(Hn)!=n.state.facet(Hn)&&(this.viewState.mustMeasureContent=!0),(i||r||u||this.viewState.mustEnforceCursorAssoc||this.viewState.mustMeasureContent)&&this.requestMeasure(),i&&this.docViewUpdate(),!n.empty)for(let d of this.state.facet(Aa))try{d(n)}catch(f){Te(this.state,f,"update listener")}(l||c)&&Promise.resolve().then(()=>{l&&this.state==l.startState&&this.dispatch(l),c&&!ep(this,c)&&h.force&&Li(this.contentDOM,h.key,h.keyCode)})}setState(t){if(this.updateState!=0)throw new Error("Calls to EditorView.setState are not allowed while an update is in progress");if(this.destroyed){this.viewState.state=t;return}this.updateState=2;let i=this.hasFocus;try{for(let r of this.plugins)r.destroy(this);this.viewState=new Ad(t),this.plugins=t.facet($r).map(r=>new sa(r)),this.pluginMap.clear();for(let r of this.plugins)r.update(this);this.docView.destroy(),this.docView=new dd(this),this.inputState.ensureHandlers(this.plugins),this.mountStyles(),this.updateAttrs(),this.bidiCache=[]}finally{this.updateState=0}i&&this.focus(),this.requestMeasure()}updatePlugins(t){let i=t.startState.facet($r),r=t.state.facet($r);if(i!=r){let n=[];for(let s of r){let o=i.indexOf(s);if(o<0)n.push(new sa(s));else{let a=this.plugins[o];a.mustUpdate=t,n.push(a)}}for(let s of this.plugins)s.mustUpdate!=t&&s.destroy(this);this.plugins=n,this.pluginMap.clear()}else for(let n of this.plugins)n.mustUpdate=t;for(let n=0;n<this.plugins.length;n++)this.plugins[n].update(this);i!=r&&this.inputState.ensureHandlers(this.plugins)}docViewUpdate(){for(let t of this.plugins){let i=t.value;if(i&&i.docViewUpdate)try{i.docViewUpdate(this)}catch(r){Te(this.state,r,"doc view update listener")}}}measure(t=!0){if(this.destroyed)return;if(this.measureScheduled>-1&&this.win.cancelAnimationFrame(this.measureScheduled),this.observer.delayedAndroidKey){this.measureScheduled=-1,this.requestMeasure();return}this.measureScheduled=0,t&&this.observer.forceFlush();let i=null,r=this.scrollDOM,n=r.scrollTop*this.scaleY,{scrollAnchorPos:s,scrollAnchorHeight:o}=this.viewState;Math.abs(n-this.viewState.scrollTop)>1&&(o=-1),this.viewState.scrollAnchorHeight=-1;try{for(let a=0;;a++){if(o<0)if(ef(r))s=-1,o=this.viewState.heightMap.height;else{let f=this.viewState.scrollAnchorAt(n);s=f.from,o=f.top}this.updateState=1;let l=this.viewState.measure(this);if(!l&&!this.measureRequests.length&&this.viewState.scrollTarget==null)break;if(a>5){console.warn(this.measureRequests.length?"Measure loop restarted more than 5 times":"Viewport failed to stabilize");break}let h=[];l&4||([this.measureRequests,h]=[h,this.measureRequests]);let c=h.map(f=>{try{return f.read(this)}catch(p){return Te(this.state,p),Md}}),u=ud.create(this,this.state,[]),d=!1;u.flags|=l,i?i.flags|=l:i=u,this.updateState=2,u.empty||(this.updatePlugins(u),this.inputState.update(u),this.updateAttrs(),d=this.docView.update(u),d&&this.docViewUpdate());for(let f=0;f<h.length;f++)if(c[f]!=Md)try{let p=h[f];p.write&&p.write(c[f],this)}catch(p){Te(this.state,p)}if(d&&this.docView.updateSelection(!0),!u.viewportChanged&&this.measureRequests.length==0){if(this.viewState.editorHeight)if(this.viewState.scrollTarget){this.docView.scrollIntoView(this.viewState.scrollTarget),this.viewState.scrollTarget=null,o=-1;continue}else{let f=(s<0?this.viewState.heightMap.height:this.viewState.lineBlockAt(s).top)-o;if(f>1||f<-1){n=n+f,r.scrollTop=n/this.scaleY,o=-1;continue}}break}}}finally{this.updateState=0,this.measureScheduled=-1}if(i&&!i.empty)for(let a of this.state.facet(Aa))a(i)}get themeClasses(){return Ya+" "+(this.state.facet(qa)?Kf:Hf)+" "+this.state.facet(Hn)}updateAttrs(){let t=qd(this,Zf,{class:"cm-editor"+(this.hasFocus?" cm-focused ":" ")+this.themeClasses}),i={spellcheck:"false",autocorrect:"off",autocapitalize:"off",translate:"no",contenteditable:this.state.facet(ms)?"true":"false",class:"cm-content",style:`${A.tabSize}: ${this.state.tabSize}`,role:"textbox","aria-multiline":"true"};this.state.readOnly&&(i["aria-readonly"]="true"),qd(this,Ha,i);let r=this.observer.ignore(()=>{let n=ka(this.contentDOM,this.contentAttrs,i),s=ka(this.dom,this.editorAttrs,t);return n||s});return this.editorAttrs=t,this.contentAttrs=i,r}showAnnouncements(t){let i=!0;for(let r of t)for(let n of r.effects)if(n.is(La.announce)){i&&(this.announceDOM.textContent=""),i=!1;let s=this.announceDOM.appendChild(document.createElement("div"));s.textContent=n.value}}mountStyles(){this.styleModules=this.state.facet(Tr);let t=this.state.facet(La.cspNonce);xt.mount(this.root,this.styleModules.concat(zw).reverse(),t?{nonce:t}:void 0)}readMeasured(){if(this.updateState==2)throw new Error("Reading the editor layout isn't allowed during an update");this.updateState==0&&this.measureScheduled>-1&&this.measure(!1)}requestMeasure(t){if(this.measureScheduled<0&&(this.measureScheduled=this.win.requestAnimationFrame(()=>this.measure())),t){if(this.measureRequests.indexOf(t)>-1)return;if(t.key!=null){for(let i=0;i<this.measureRequests.length;i++)if(this.measureRequests[i].key===t.key){this.measureRequests[i]=t;return}}this.measureRequests.push(t)}}plugin(t){let i=this.pluginMap.get(t);return(i===void 0||i&&i.spec!=t)&&this.pluginMap.set(t,i=this.plugins.find(r=>r.spec==t)||null),i&&i.update(this).value}get documentTop(){return this.contentDOM.getBoundingClientRect().top+this.viewState.paddingTop}get documentPadding(){return{top:this.viewState.paddingTop,bottom:this.viewState.paddingBottom}}get scaleX(){return this.viewState.scaleX}get scaleY(){return this.viewState.scaleY}elementAtHeight(t){return this.readMeasured(),this.viewState.elementAtHeight(t)}lineBlockAtHeight(t){return this.readMeasured(),this.viewState.lineBlockAtHeight(t)}get viewportLineBlocks(){return this.viewState.viewportLines}lineBlockAt(t){return this.viewState.lineBlockAt(t)}get contentHeight(){return this.viewState.contentHeight}moveByChar(t,i,r){return aa(this,t,yd(this,t,i,r))}moveByGroup(t,i){return aa(this,t,yd(this,t,i,r=>Ow(this,t.head,r)))}visualLineSide(t,i){let r=this.bidiSpans(t),n=this.textDirectionAt(t.from),s=r[i?r.length-1:0];return $.cursor(s.side(i,n)+t.from,s.forward(!i,n)?1:-1)}moveToLineBoundary(t,i,r=!0){return pw(this,t,i,r)}moveVertically(t,i,r){return aa(this,t,mw(this,t,i,r))}domAtPos(t){return this.docView.domAtPos(t)}posAtDOM(t,i=0){return this.docView.posFromDOM(t,i)}posAtCoords(t,i=!0){return this.readMeasured(),Yf(this,t,i)}coordsAtPos(t,i=1){this.readMeasured();let r=this.docView.coordsAt(t,i);if(!r||r.left==r.right)return r;let n=this.state.doc.lineAt(t),s=this.bidiSpans(n),o=s[Ft.find(s,t-n.from,-1,i)];return _a(r,o.dir==ee.LTR==i>0)}coordsForChar(t){return this.readMeasured(),this.docView.coordsForChar(t)}get defaultCharacterWidth(){return this.viewState.heightOracle.charWidth}get defaultLineHeight(){return this.viewState.heightOracle.lineHeight}get textDirection(){return this.viewState.defaultTextDirection}textDirectionAt(t){return!this.state.facet(Cf)||t<this.viewport.from||t>this.viewport.to?this.textDirection:(this.readMeasured(),this.docView.textDirectionAt(t))}get lineWrapping(){return this.viewState.heightOracle.lineWrapping}bidiSpans(t){if(t.length>nv)return vf(t.length);let i=this.textDirectionAt(t.from),r;for(let s of this.bidiCache)if(s.from==t.from&&s.dir==i&&(s.fresh||wf(s.isolates,r=cd(this,t))))return s.order;r||(r=cd(this,t));let n=Hb(t.text,i,r);return this.bidiCache.push(new Wd(t.from,t.to,i,r,!0,n)),n}get hasFocus(){var t;return(this.dom.ownerDocument.hasFocus()||A.safari&&((t=this.inputState)===null||t===void 0?void 0:t.lastContextMenu)>Date.now()-3e4)&&this.root.activeElement==this.contentDOM}focus(){this.observer.ignore(()=>{Kd(this.contentDOM),this.docView.updateSelection()})}setRoot(t){this._root!=t&&(this._root=t,this.observer.setWindow((t.nodeType==9?t:t.ownerDocument).defaultView||window),this.mountStyles())}destroy(){for(let t of this.plugins)t.destroy(this);this.plugins=[],this.inputState.destroy(),this.docView.destroy(),this.dom.remove(),this.observer.destroy(),this.measureScheduled>-1&&this.win.cancelAnimationFrame(this.measureScheduled),this.destroyed=!0}static scrollIntoView(t,i={}){return _n.of(new na(typeof t=="number"?$.cursor(t):t,i.y,i.x,i.yMargin,i.xMargin))}scrollSnapshot(){let{scrollTop:t,scrollLeft:i}=this.scrollDOM,r=this.viewState.scrollAnchorAt(t);return _n.of(new na($.cursor(r.from),"start","start",r.top-t,i,!0))}static domEventHandlers(t){return ve.define(()=>({}),{eventHandlers:t})}static domEventObservers(t){return ve.define(()=>({}),{eventObservers:t})}static theme(t,i){let r=xt.newName(),n=[Hn.of(r),Tr.of(Ia(`.${r}`,t))];return i&&i.dark&&n.push(qa.of(!0)),n}static baseTheme(t){return _e.lowest(Tr.of(Ia("."+Ya,t,Jf)))}static findFromDOM(t){var i;let r=t.querySelector(".cm-content");return((i=(r&&ne.get(r)||ne.get(t))?.rootView)===null||i===void 0?void 0:i.view)||null}};W.styleModule=Tr;W.inputHandler=$f;W.scrollHandler=Af;W.focusChangeEffect=Tf;W.perLineTextDirection=Cf;W.exceptionSink=Qf;W.updateListener=Aa;W.editable=ms;W.mouseSelectionStyle=kf;W.dragMovesSelection=Pf;W.clickAddsSelectionRange=xf;W.decorations=Xr;W.outerDecorations=Ef;W.atomicRanges=Ka;W.bidiIsolatedRanges=Rf;W.scrollMargins=Xf;W.darkTheme=qa;W.cspNonce=E.define({combine:e=>e.length?e[0]:""});W.contentAttributes=Ha;W.editorAttributes=Zf;W.lineWrapping=W.contentAttributes.of({class:"cm-lineWrapping"});W.announce=z.define();var nv=4096,Md={},Wd=class tp{constructor(t,i,r,n,s,o){this.from=t,this.to=i,this.dir=r,this.isolates=n,this.fresh=s,this.order=o}static update(t,i){if(i.empty&&!t.some(s=>s.fresh))return t;let r=[],n=t.length?t[t.length-1].dir:ee.LTR;for(let s=Math.max(0,t.length-10);s<t.length;s++){let o=t[s];o.dir==n&&!i.touchesRange(o.from,o.to)&&r.push(new tp(i.mapPos(o.from,1),i.mapPos(o.to,-1),o.dir,o.isolates,!1,o.order))}return r}};function qd(e,t,i){for(let r=e.state.facet(t),n=r.length-1;n>=0;n--){let s=r[n],o=typeof s=="function"?s(e):s;o&&Pa(o,i)}return i}var sv=A.mac?"mac":A.windows?"win":A.linux?"linux":"key";function ov(e,t){let i=e.split(/-(?!$)/),r=i[i.length-1];r=="Space"&&(r=" ");let n,s,o,a;for(let l=0;l<i.length-1;++l){let h=i[l];if(/^(cmd|meta|m)$/i.test(h))a=!0;else if(/^a(lt)?$/i.test(h))n=!0;else if(/^(c|ctrl|control)$/i.test(h))s=!0;else if(/^s(hift)?$/i.test(h))o=!0;else if(/^mod$/i.test(h))t=="mac"?a=!0:s=!0;else throw new Error("Unrecognized modifier name: "+h)}return n&&(r="Alt-"+r),s&&(r="Ctrl-"+r),a&&(r="Meta-"+r),o&&(r="Shift-"+r),r}function Kn(e,t,i){return t.altKey&&(e="Alt-"+e),t.ctrlKey&&(e="Ctrl-"+e),t.metaKey&&(e="Meta-"+e),i!==!1&&t.shiftKey&&(e="Shift-"+e),e}var av=_e.default(W.domEventHandlers({keydown(e,t){return uv(lv(t.state),e,t,"editor")}})),_i=E.define({enables:av}),Yd=new WeakMap;function lv(e){let t=e.facet(_i),i=Yd.get(t);return i||Yd.set(t,i=cv(t.reduce((r,n)=>r.concat(n),[]))),i}var Gt=null,hv=4e3;function cv(e,t=sv){let i=Object.create(null),r=Object.create(null),n=(o,a)=>{let l=r[o];if(l==null)r[o]=a;else if(l!=a)throw new Error("Key binding "+o+" is used both as a regular binding and as a multi-stroke prefix")},s=(o,a,l,h,c)=>{var u,d;let f=i[o]||(i[o]=Object.create(null)),p=a.split(/ (?!$)/).map(y=>ov(y,t));for(let y=1;y<p.length;y++){let b=p.slice(0,y).join(" ");n(b,!0),f[b]||(f[b]={preventDefault:!0,stopPropagation:!1,run:[S=>{let w=Gt={view:S,prefix:b,scope:o};return setTimeout(()=>{Gt==w&&(Gt=null)},hv),!0}]})}let O=p.join(" ");n(O,!1);let g=f[O]||(f[O]={preventDefault:!1,stopPropagation:!1,run:((d=(u=f._any)===null||u===void 0?void 0:u.run)===null||d===void 0?void 0:d.slice())||[]});l&&g.run.push(l),h&&(g.preventDefault=!0),c&&(g.stopPropagation=!0)};for(let o of e){let a=o.scope?o.scope.split(" "):["editor"];if(o.any)for(let h of a){let c=i[h]||(i[h]=Object.create(null));c._any||(c._any={preventDefault:!1,stopPropagation:!1,run:[]});for(let u in c)c[u].run.push(o.any)}let l=o[t]||o.key;if(l)for(let h of a)s(h,l,o.run,o.preventDefault,o.stopPropagation),o.shift&&s(h,"Shift-"+l,o.shift,o.preventDefault,o.stopPropagation)}return i}function uv(e,t,i,r){let n=Ju(t),s=Qe(n,0),o=nt(s)==n.length&&n!=" ",a="",l=!1,h=!1,c=!1;Gt&&Gt.view==i&&Gt.scope==r&&(a=Gt.prefix+" ",Lf.indexOf(t.keyCode)<0&&(h=!0,Gt=null));let u=new Set,d=g=>{if(g){for(let y of g.run)if(!u.has(y)&&(u.add(y),y(i,t)))return g.stopPropagation&&(c=!0),!0;g.preventDefault&&(g.stopPropagation&&(c=!0),h=!0)}return!1},f=e[r],p,O;return f&&(d(f[a+Kn(n,t,!o)])?l=!0:o&&(t.altKey||t.metaKey||t.ctrlKey)&&!(A.windows&&t.ctrlKey&&t.altKey)&&(p=Mt[t.keyCode])&&p!=n?(d(f[a+Kn(p,t,!0)])||t.shiftKey&&(O=Yi[t.keyCode])!=n&&O!=p&&d(f[a+Kn(O,t,!1)]))&&(l=!0):o&&t.shiftKey&&d(f[a+Kn(n,t,!0)])&&(l=!0),!l&&d(f._any)&&(l=!0)),h&&(l=!0),l&&c&&t.stopPropagation(),l}var Ja=class ip{constructor(t,i,r,n,s){this.className=t,this.left=i,this.top=r,this.width=n,this.height=s}draw(){let t=document.createElement("div");return t.className=this.className,this.adjust(t),t}update(t,i){return i.className!=this.className?!1:(this.adjust(t),!0)}adjust(t){t.style.left=this.left+"px",t.style.top=this.top+"px",this.width!=null&&(t.style.width=this.width+"px"),t.style.height=this.height+"px"}eq(t){return this.left==t.left&&this.top==t.top&&this.width==t.width&&this.height==t.height&&this.className==t.className}static forRange(t,i,r){if(r.empty){let n=t.coordsAtPos(r.head,r.assoc||1);if(!n)return[];let s=rp(t);return[new ip(i,n.left-s.left,n.top-s.top,null,n.bottom-n.top)]}else return dv(t,i,r)}};function rp(e){let t=e.scrollDOM.getBoundingClientRect();return{left:(e.textDirection==ee.LTR?t.left:t.right-e.scrollDOM.clientWidth*e.scaleX)-e.scrollDOM.scrollLeft*e.scaleX,top:t.top-e.scrollDOM.scrollTop*e.scaleY}}function Id(e,t,i){let r=$.cursor(t);return{from:Math.max(i.from,e.moveToLineBoundary(r,!1,!0).from),to:Math.min(i.to,e.moveToLineBoundary(r,!0,!0).from),type:Ce.Text}}function dv(e,t,i){if(i.to<=e.viewport.from||i.from>=e.viewport.to)return[];let r=Math.max(i.from,e.viewport.from),n=Math.min(i.to,e.viewport.to),s=e.textDirection==ee.LTR,o=e.contentDOM,a=o.getBoundingClientRect(),l=rp(e),h=o.querySelector(".cm-line"),c=h&&window.getComputedStyle(h),u=a.left+(c?parseInt(c.paddingLeft)+Math.min(0,parseInt(c.textIndent)):0),d=a.right-(c?parseInt(c.paddingRight):0),f=Xa(e,r),p=Xa(e,n),O=f.type==Ce.Text?f:null,g=p.type==Ce.Text?p:null;if(O&&(e.lineWrapping||f.widgetLineBreaks)&&(O=Id(e,r,O)),g&&(e.lineWrapping||p.widgetLineBreaks)&&(g=Id(e,n,g)),O&&g&&O.from==g.from)return b(S(i.from,i.to,O));{let k=O?S(i.from,null,O):w(f,!1),Z=g?S(null,i.to,g):w(p,!0),T=[];return(O||f).to<(g||p).from-(O&&g?1:0)||f.widgetLineBreaks>1&&k.bottom+e.defaultLineHeight/2<Z.top?T.push(y(u,k.bottom,d,Z.top)):k.bottom<Z.top&&e.elementAtHeight((k.bottom+Z.top)/2).type==Ce.Text&&(k.bottom=Z.top=(k.bottom+Z.top)/2),b(k).concat(T).concat(b(Z))}function y(k,Z,T,q){return new Ja(t,k-l.left,Z-l.top-.01,T-k,q-Z+.01)}function b({top:k,bottom:Z,horizontal:T}){let q=[];for(let N=0;N<T.length;N+=2)q.push(y(T[N],k,T[N+1],Z));return q}function S(k,Z,T){let q=1e9,N=-1e9,D=[];function I(U,se,Ze,Ee,je){let Ke=e.coordsAtPos(U,U==T.to?-2:2),fe=e.coordsAtPos(Ze,Ze==T.from?2:-2);!Ke||!fe||(q=Math.min(Ke.top,fe.top,q),N=Math.max(Ke.bottom,fe.bottom,N),je==ee.LTR?D.push(s&&se?u:Ke.left,s&&Ee?d:fe.right):D.push(!s&&Ee?u:fe.left,!s&&se?d:Ke.right))}let Y=k??T.from,H=Z??T.to;for(let U of e.visibleRanges)if(U.to>Y&&U.from<H)for(let se=Math.max(U.from,Y),Ze=Math.min(U.to,H);;){let Ee=e.state.doc.lineAt(se);for(let je of e.bidiSpans(Ee)){let Ke=je.from+Ee.from,fe=je.to+Ee.from;if(Ke>=Ze)break;fe>se&&I(Math.max(Ke,se),k==null&&Ke<=Y,Math.min(fe,Ze),Z==null&&fe>=H,je.dir)}if(se=Ee.to+1,se>=Ze)break}return D.length==0&&I(Y,k==null,H,Z==null,e.textDirection),{top:q,bottom:N,horizontal:D}}function w(k,Z){let T=a.top+(Z?k.top:k.bottom);return{top:T,bottom:T,horizontal:[]}}}function fv(e,t){return e.constructor==t.constructor&&e.eq(t)}var pv=class{constructor(e,t){this.view=e,this.layer=t,this.drawn=[],this.scaleX=1,this.scaleY=1,this.measureReq={read:this.measure.bind(this),write:this.draw.bind(this)},this.dom=e.scrollDOM.appendChild(document.createElement("div")),this.dom.classList.add("cm-layer"),t.above&&this.dom.classList.add("cm-layer-above"),t.class&&this.dom.classList.add(t.class),this.scale(),this.dom.setAttribute("aria-hidden","true"),this.setOrder(e.state),e.requestMeasure(this.measureReq),t.mount&&t.mount(this.dom,e)}update(e){e.startState.facet(hs)!=e.state.facet(hs)&&this.setOrder(e.state),(this.layer.update(e,this.dom)||e.geometryChanged)&&(this.scale(),e.view.requestMeasure(this.measureReq))}docViewUpdate(e){this.layer.updateOnDocViewUpdate!==!1&&e.requestMeasure(this.measureReq)}setOrder(e){let t=0,i=e.facet(hs);for(;t<i.length&&i[t]!=this.layer;)t++;this.dom.style.zIndex=String((this.layer.above?150:-1)-t)}measure(){return this.layer.markers(this.view)}scale(){let{scaleX:e,scaleY:t}=this.view;(e!=this.scaleX||t!=this.scaleY)&&(this.scaleX=e,this.scaleY=t,this.dom.style.transform=`scale(${1/e}, ${1/t})`)}draw(e){if(e.length!=this.drawn.length||e.some((t,i)=>!fv(t,this.drawn[i]))){let t=this.dom.firstChild,i=0;for(let r of e)r.update&&t&&r.constructor&&this.drawn[i].constructor&&r.update(t,this.drawn[i])?(t=t.nextSibling,i++):this.dom.insertBefore(r.draw(),t);for(;t;){let r=t.nextSibling;t.remove(),t=r}this.drawn=e}}destroy(){this.layer.destroy&&this.layer.destroy(this.dom,this.view),this.dom.remove()}},hs=E.define();function np(e){return[ve.define(t=>new pv(t,e)),hs.of(e)]}var sp=!A.ios,ps=E.define({combine(e){return Xt(e,{cursorBlinkRate:1200,drawRangeCursor:!0},{cursorBlinkRate:(t,i)=>Math.min(t,i),drawRangeCursor:(t,i)=>t||i})}});function op(e){return e.startState.facet(ps)!=e.state.facet(ps)}var oZ=np({above:!0,markers(e){let{state:t}=e,i=t.facet(ps),r=[];for(let n of t.selection.ranges){let s=n==t.selection.main;if(n.empty?!s||sp:i.drawRangeCursor){let o=s?"cm-cursor cm-cursor-primary":"cm-cursor cm-cursor-secondary",a=n.empty?n:$.cursor(n.head,n.head>n.anchor?-1:1);for(let l of Ja.forRange(e,o,a))r.push(l)}}return r},update(e,t){e.transactions.some(r=>r.selection)&&(t.style.animationName=t.style.animationName=="cm-blink"?"cm-blink2":"cm-blink");let i=op(e);return i&&Ld(e.state,t),e.docChanged||e.selectionSet||i},mount(e,t){Ld(t.state,e)},class:"cm-cursorLayer"});function Ld(e,t){t.style.animationDuration=e.facet(ps).cursorBlinkRate+"ms"}var aZ=np({above:!1,markers(e){return e.state.selection.ranges.map(t=>t.empty?[]:Ja.forRange(e,"cm-selectionBackground",t)).reduce((t,i)=>t.concat(i))},update(e,t){return e.docChanged||e.selectionSet||e.viewportChanged||op(e)},class:"cm-selectionLayer"}),Va={".cm-line":{"& ::selection":{backgroundColor:"transparent !important"},"&::selection":{backgroundColor:"transparent !important"}}};sp&&(Va[".cm-line"].caretColor="transparent !important",Va[".cm-content"]={caretColor:"transparent !important"});var lZ=_e.highest(W.theme(Va)),ap=z.define({map(e,t){return e==null?null:t.mapPos(e)}}),Jn=We.define({create(){return null},update(e,t){return e!=null&&(e=t.changes.mapPos(e)),t.effects.reduce((i,r)=>r.is(ap)?r.value:i,e)}}),hZ=ve.fromClass(class{constructor(e){this.view=e,this.cursor=null,this.measureReq={read:this.readPos.bind(this),write:this.drawCursor.bind(this)}}update(e){var t;let i=e.state.field(Jn);i==null?this.cursor!=null&&((t=this.cursor)===null||t===void 0||t.remove(),this.cursor=null):(this.cursor||(this.cursor=this.view.scrollDOM.appendChild(document.createElement("div")),this.cursor.className="cm-dropCursor"),(e.startState.field(Jn)!=i||e.docChanged||e.geometryChanged)&&this.view.requestMeasure(this.measureReq))}readPos(){let{view:e}=this,t=e.state.field(Jn),i=t!=null&&e.coordsAtPos(t);if(!i)return null;let r=e.scrollDOM.getBoundingClientRect();return{left:i.left-r.left+e.scrollDOM.scrollLeft*e.scaleX,top:i.top-r.top+e.scrollDOM.scrollTop*e.scaleY,height:i.bottom-i.top}}drawCursor(e){if(this.cursor){let{scaleX:t,scaleY:i}=this.view;e?(this.cursor.style.left=e.left/t+"px",this.cursor.style.top=e.top/i+"px",this.cursor.style.height=e.height/i+"px"):this.cursor.style.left="-100000px"}}destroy(){this.cursor&&this.cursor.remove()}setDropPos(e){this.view.state.field(Jn)!=e&&this.view.dispatch({effects:ap.of(e)})}},{eventObservers:{dragover(e){this.setDropPos(this.view.posAtCoords({x:e.clientX,y:e.clientY}))},dragleave(e){(e.target==this.view.contentDOM||!this.view.contentDOM.contains(e.relatedTarget))&&this.setDropPos(null)},dragend(){this.setDropPos(null)},drop(){this.setDropPos(null)}}});function Vd(e,t,i,r,n){t.lastIndex=0;for(let s=e.iterRange(i,r),o=i,a;!s.next().done;o+=s.value.length)if(!s.lineBreak)for(;a=t.exec(s.value);)n(o+a.index,a)}function Ov(e,t){let i=e.visibleRanges;if(i.length==1&&i[0].from==e.viewport.from&&i[0].to==e.viewport.to)return i;let r=[];for(let{from:n,to:s}of i)n=Math.max(e.state.doc.lineAt(n).from,n-t),s=Math.min(e.state.doc.lineAt(s).to,s+t),r.length&&r[r.length-1].to>=n?r[r.length-1].to=s:r.push({from:n,to:s});return r}var lp=class{constructor(e){let{regexp:t,decoration:i,decorate:r,boundary:n,maxLength:s=1e3}=e;if(!t.global)throw new RangeError("The regular expression given to MatchDecorator should have its 'g' flag set");if(this.regexp=t,r)this.addMatch=(o,a,l,h)=>r(h,l,l+o[0].length,o,a);else if(typeof i=="function")this.addMatch=(o,a,l,h)=>{let c=i(o,a,l);c&&h(l,l+o[0].length,c)};else if(i)this.addMatch=(o,a,l,h)=>h(l,l+o[0].length,i);else throw new RangeError("Either 'decorate' or 'decoration' should be provided to MatchDecorator");this.boundary=n,this.maxLength=s}createDeco(e){let t=new yi,i=t.add.bind(t);for(let{from:r,to:n}of Ov(e,this.maxLength))Vd(e.state.doc,this.regexp,r,n,(s,o)=>this.addMatch(o,e,s,i));return t.finish()}updateDeco(e,t){let i=1e9,r=-1;return e.docChanged&&e.changes.iterChanges((n,s,o,a)=>{a>e.view.viewport.from&&o<e.view.viewport.to&&(i=Math.min(o,i),r=Math.max(a,r))}),e.viewportChanged||r-i>1e3?this.createDeco(e.view):r>-1?this.updateRange(e.view,t.map(e.changes),i,r):t}updateRange(e,t,i,r){for(let n of e.visibleRanges){let s=Math.max(n.from,i),o=Math.min(n.to,r);if(o>s){let a=e.state.doc.lineAt(s),l=a.to<o?e.state.doc.lineAt(o):a,h=Math.max(n.from,a.from),c=Math.min(n.to,l.to);if(this.boundary){for(;s>a.from;s--)if(this.boundary.test(a.text[s-1-a.from])){h=s;break}for(;o<l.to;o++)if(this.boundary.test(l.text[o-l.from])){c=o;break}}let u=[],d,f=(p,O,g)=>u.push(g.range(p,O));if(a==l)for(this.regexp.lastIndex=h-a.from;(d=this.regexp.exec(a.text))&&d.index<c-a.from;)this.addMatch(d,e,d.index+a.from,f);else Vd(e.state.doc,this.regexp,h,c,(p,O)=>this.addMatch(O,e,p,f));t=t.update({filterFrom:h,filterTo:c,filter:(p,O)=>p<h||O>c,add:u})}}return t}},Na=/x/.unicode!=null?"gu":"g",mv=new RegExp(`[\0-\b
--\x7F-\x9F\xAD\u061C\u200B\u200E\u200F\u2028\u2029\u202D\u202E\u2066\u2067\u2069\uFEFF\uFFF9-\uFFFC]`,Na);var ca=null;function gv(){var e;if(ca==null&&typeof document<"u"&&document.body){let t=document.body.style;ca=((e=t.tabSize)!==null&&e!==void 0?e:t.MozTabSize)!=null}return ca||!1}var cZ=E.define({combine(e){let t=Xt(e,{render:null,specialChars:mv,addSpecialChars:null});return(t.replaceTabs=!gv())&&(t.specialChars=new RegExp("	|"+t.specialChars.source,Na)),t.addSpecialChars&&(t.specialChars=new RegExp(t.specialChars.source+"|"+t.addSpecialChars.source,Na)),t}});var uZ=ve.fromClass(class{constructor(){this.height=1e3,this.attrs={style:"padding-bottom: 1000px"}}update(e){let{view:t}=e,i=t.viewState.editorHeight-t.defaultLineHeight-t.documentPadding.top-.5;i>=0&&i!=this.height&&(this.height=i,this.attrs={style:`padding-bottom: ${i}px`})}});var yv=j.line({class:"cm-activeLine"}),dZ=ve.fromClass(class{constructor(e){this.decorations=this.getDeco(e)}update(e){(e.docChanged||e.selectionSet)&&(this.decorations=this.getDeco(e.view))}getDeco(e){let t=-1,i=[];for(let r of e.state.selection.ranges){let n=e.lineBlockAt(r.head);n.from>t&&(i.push(yv.range(n.from)),t=n.from)}return j.set(i)}},{decorations:e=>e.decorations});var kr="-10000px",hp=class{constructor(e,t,i,r){this.facet=t,this.createTooltipView=i,this.removeTooltipView=r,this.input=e.state.facet(t),this.tooltips=this.input.filter(s=>s);let n=null;this.tooltipViews=this.tooltips.map(s=>n=i(s,n))}update(e,t){var i;let r=e.state.facet(this.facet),n=r.filter(a=>a);if(r===this.input){for(let a of this.tooltipViews)a.update&&a.update(e);return!1}let s=[],o=t?[]:null;for(let a=0;a<n.length;a++){let l=n[a],h=-1;if(l){for(let c=0;c<this.tooltips.length;c++){let u=this.tooltips[c];u&&u.create==l.create&&(h=c)}if(h<0)s[a]=this.createTooltipView(l,a?s[a-1]:null),o&&(o[a]=!!l.above);else{let c=s[a]=this.tooltipViews[h];o&&(o[a]=t[h]),c.update&&c.update(e)}}}for(let a of this.tooltipViews)s.indexOf(a)<0&&(this.removeTooltipView(a),(i=a.destroy)===null||i===void 0||i.call(a));return t&&(o.forEach((a,l)=>t[l]=a),t.length=o.length),this.input=r,this.tooltips=n,this.tooltipViews=s,!0}};function bv(e){let{win:t}=e;return{top:0,left:0,bottom:t.innerHeight,right:t.innerWidth}}var ua=E.define({combine:e=>{var t,i,r;return{position:A.ios?"absolute":((t=e.find(n=>n.position))===null||t===void 0?void 0:t.position)||"fixed",parent:((i=e.find(n=>n.parent))===null||i===void 0?void 0:i.parent)||null,tooltipSpace:((r=e.find(n=>n.tooltipSpace))===null||r===void 0?void 0:r.tooltipSpace)||bv}}}),Nd=new WeakMap,cp=ve.fromClass(class{constructor(e){this.view=e,this.above=[],this.inView=!0,this.madeAbsolute=!1,this.lastTransaction=0,this.measureTimeout=-1;let t=e.state.facet(ua);this.position=t.position,this.parent=t.parent,this.classes=e.themeClasses,this.createContainer(),this.measureReq={read:this.readMeasure.bind(this),write:this.writeMeasure.bind(this),key:this},this.resizeObserver=typeof ResizeObserver=="function"?new ResizeObserver(()=>this.measureSoon()):null,this.manager=new hp(e,gs,(i,r)=>this.createTooltip(i,r),i=>{this.resizeObserver&&this.resizeObserver.unobserve(i.dom),i.dom.remove()}),this.above=this.manager.tooltips.map(i=>!!i.above),this.intersectionObserver=typeof IntersectionObserver=="function"?new IntersectionObserver(i=>{Date.now()>this.lastTransaction-50&&i.length>0&&i[i.length-1].intersectionRatio<1&&this.measureSoon()},{threshold:[1]}):null,this.observeIntersection(),e.win.addEventListener("resize",this.measureSoon=this.measureSoon.bind(this)),this.maybeMeasure()}createContainer(){this.parent?(this.container=document.createElement("div"),this.container.style.position="relative",this.container.className=this.view.themeClasses,this.parent.appendChild(this.container)):this.container=this.view.dom}observeIntersection(){if(this.intersectionObserver){this.intersectionObserver.disconnect();for(let e of this.manager.tooltipViews)this.intersectionObserver.observe(e.dom)}}measureSoon(){this.measureTimeout<0&&(this.measureTimeout=setTimeout(()=>{this.measureTimeout=-1,this.maybeMeasure()},50))}update(e){e.transactions.length&&(this.lastTransaction=Date.now());let t=this.manager.update(e,this.above);t&&this.observeIntersection();let i=t||e.geometryChanged,r=e.state.facet(ua);if(r.position!=this.position&&!this.madeAbsolute){this.position=r.position;for(let n of this.manager.tooltipViews)n.dom.style.position=this.position;i=!0}if(r.parent!=this.parent){this.parent&&this.container.remove(),this.parent=r.parent,this.createContainer();for(let n of this.manager.tooltipViews)this.container.appendChild(n.dom);i=!0}else this.parent&&this.view.themeClasses!=this.classes&&(this.classes=this.container.className=this.view.themeClasses);i&&this.maybeMeasure()}createTooltip(e,t){let i=e.create(this.view),r=t?t.dom:null;if(i.dom.classList.add("cm-tooltip"),e.arrow&&!i.dom.querySelector(".cm-tooltip > .cm-tooltip-arrow")){let n=document.createElement("div");n.className="cm-tooltip-arrow",i.dom.appendChild(n)}return i.dom.style.position=this.position,i.dom.style.top=kr,i.dom.style.left="0px",this.container.insertBefore(i.dom,r),i.mount&&i.mount(this.view),this.resizeObserver&&this.resizeObserver.observe(i.dom),i}destroy(){var e,t,i;this.view.win.removeEventListener("resize",this.measureSoon);for(let r of this.manager.tooltipViews)r.dom.remove(),(e=r.destroy)===null||e===void 0||e.call(r);this.parent&&this.container.remove(),(t=this.resizeObserver)===null||t===void 0||t.disconnect(),(i=this.intersectionObserver)===null||i===void 0||i.disconnect(),clearTimeout(this.measureTimeout)}readMeasure(){let e=this.view.dom.getBoundingClientRect(),t=1,i=1,r=!1;if(this.position=="fixed"&&this.manager.tooltipViews.length){let{dom:n}=this.manager.tooltipViews[0];if(A.gecko)r=n.offsetParent!=this.container.ownerDocument.body;else if(n.style.top==kr&&n.style.left=="0px"){let s=n.getBoundingClientRect();r=Math.abs(s.top+1e4)>1||Math.abs(s.left)>1}}if(r||this.position=="absolute")if(this.parent){let n=this.parent.getBoundingClientRect();n.width&&n.height&&(t=n.width/this.parent.offsetWidth,i=n.height/this.parent.offsetHeight)}else({scaleX:t,scaleY:i}=this.view.viewState);return{editor:e,parent:this.parent?this.container.getBoundingClientRect():e,pos:this.manager.tooltips.map((n,s)=>{let o=this.manager.tooltipViews[s];return o.getCoords?o.getCoords(n.pos):this.view.coordsAtPos(n.pos)}),size:this.manager.tooltipViews.map(({dom:n})=>n.getBoundingClientRect()),space:this.view.state.facet(ua).tooltipSpace(this.view),scaleX:t,scaleY:i,makeAbsolute:r}}writeMeasure(e){var t;if(e.makeAbsolute){this.madeAbsolute=!0,this.position="absolute";for(let a of this.manager.tooltipViews)a.dom.style.position="absolute"}let{editor:i,space:r,scaleX:n,scaleY:s}=e,o=[];for(let a=0;a<this.manager.tooltips.length;a++){let l=this.manager.tooltips[a],h=this.manager.tooltipViews[a],{dom:c}=h,u=e.pos[a],d=e.size[a];if(!u||u.bottom<=Math.max(i.top,r.top)||u.top>=Math.min(i.bottom,r.bottom)||u.right<Math.max(i.left,r.left)-.1||u.left>Math.min(i.right,r.right)+.1){c.style.top=kr;continue}let f=l.arrow?h.dom.querySelector(".cm-tooltip-arrow"):null,p=f?7:0,O=d.right-d.left,g=(t=Nd.get(h))!==null&&t!==void 0?t:d.bottom-d.top,y=h.offset||vv,b=this.view.textDirection==ee.LTR,S=d.width>r.right-r.left?b?r.left:r.right-d.width:b?Math.min(u.left-(f?14:0)+y.x,r.right-O):Math.max(r.left,u.left-O+(f?14:0)-y.x),w=this.above[a];!l.strictSide&&(w?u.top-(d.bottom-d.top)-y.y<r.top:u.bottom+(d.bottom-d.top)+y.y>r.bottom)&&w==r.bottom-u.bottom>u.top-r.top&&(w=this.above[a]=!w);let k=(w?u.top-r.top:r.bottom-u.bottom)-p;if(k<g&&h.resize!==!1){if(k<this.view.defaultLineHeight){c.style.top=kr;continue}Nd.set(h,g),c.style.height=(g=k)/s+"px"}else c.style.height&&(c.style.height="");let Z=w?u.top-g-p-y.y:u.bottom+p+y.y,T=S+O;if(h.overlap!==!0)for(let q of o)q.left<T&&q.right>S&&q.top<Z+g&&q.bottom>Z&&(Z=w?q.top-g-2-p:q.bottom+p+2);if(this.position=="absolute"?(c.style.top=(Z-e.parent.top)/s+"px",c.style.left=(S-e.parent.left)/n+"px"):(c.style.top=Z/s+"px",c.style.left=S/n+"px"),f){let q=u.left+(b?y.x:-y.x)-(S+14-7);f.style.left=q/n+"px"}h.overlap!==!0&&o.push({left:S,top:Z,right:T,bottom:Z+g}),c.classList.toggle("cm-tooltip-above",w),c.classList.toggle("cm-tooltip-below",!w),h.positioned&&h.positioned(e.space)}}maybeMeasure(){if(this.manager.tooltips.length&&(this.view.inView&&this.view.requestMeasure(this.measureReq),this.inView!=this.view.inView&&(this.inView=this.view.inView,!this.inView)))for(let e of this.manager.tooltipViews)e.dom.style.top=kr}},{eventObservers:{scroll(){this.maybeMeasure()}}}),wv=W.baseTheme({".cm-tooltip":{zIndex:100,boxSizing:"border-box"},"&light .cm-tooltip":{border:"1px solid #bbb",backgroundColor:"#f5f5f5"},"&light .cm-tooltip-section:not(:first-child)":{borderTop:"1px solid #bbb"},"&dark .cm-tooltip":{backgroundColor:"#333338",color:"white"},".cm-tooltip-arrow":{height:"7px",width:`${7*2}px`,position:"absolute",zIndex:-1,overflow:"hidden","&:before, &:after":{content:"''",position:"absolute",width:0,height:0,borderLeft:"7px solid transparent",borderRight:"7px solid transparent"},".cm-tooltip-above &":{bottom:"-7px","&:before":{borderTop:"7px solid #bbb"},"&:after":{borderTop:"7px solid #f5f5f5",bottom:"1px"}},".cm-tooltip-below &":{top:"-7px","&:before":{borderBottom:"7px solid #bbb"},"&:after":{borderBottom:"7px solid #f5f5f5",top:"1px"}}},"&dark .cm-tooltip .cm-tooltip-arrow":{"&:before":{borderTopColor:"#333338",borderBottomColor:"#333338"},"&:after":{borderTopColor:"transparent",borderBottomColor:"transparent"}}}),vv={x:0,y:0},gs=E.define({enables:[cp,wv]}),ja=E.define({combine:e=>e.reduce((t,i)=>t.concat(i),[])}),Sv=class up{static create(t){return new up(t)}constructor(t){this.view=t,this.mounted=!1,this.dom=document.createElement("div"),this.dom.classList.add("cm-tooltip-hover"),this.manager=new hp(t,ja,(i,r)=>this.createHostedView(i,r),i=>i.dom.remove())}createHostedView(t,i){let r=t.create(this.view);return r.dom.classList.add("cm-tooltip-section"),this.dom.insertBefore(r.dom,i?i.dom.nextSibling:this.dom.firstChild),this.mounted&&r.mount&&r.mount(this.view),r}mount(t){for(let i of this.manager.tooltipViews)i.mount&&i.mount(t);this.mounted=!0}positioned(t){for(let i of this.manager.tooltipViews)i.positioned&&i.positioned(t)}update(t){this.manager.update(t)}destroy(){var t;for(let i of this.manager.tooltipViews)(t=i.destroy)===null||t===void 0||t.call(i)}passProp(t){let i;for(let r of this.manager.tooltipViews){let n=r[t];if(n!==void 0){if(i===void 0)i=n;else if(i!==n)return}}return i}get offset(){return this.passProp("offset")}get getCoords(){return this.passProp("getCoords")}get overlap(){return this.passProp("overlap")}get resize(){return this.passProp("resize")}},fZ=gs.compute([ja],e=>{let t=e.facet(ja);return t.length===0?null:{pos:Math.min(...t.map(i=>i.pos)),end:Math.max(...t.map(i=>{var r;return(r=i.end)!==null&&r!==void 0?r:i.pos})),create:Sv.create,above:t[0].above,arrow:t.some(i=>i.arrow)}});function el(e,t){let i=e.plugin(cp);if(!i)return null;let r=i.manager.tooltips.indexOf(t);return r<0?null:i.manager.tooltipViews[r]}var xv=z.define(),pZ=xv.of(null);var jd=E.define({combine(e){let t,i;for(let r of e)t=t||r.topContainer,i=i||r.bottomContainer;return{topContainer:t,bottomContainer:i}}});var Pv=ve.fromClass(class{constructor(e){this.input=e.state.facet(_d),this.specs=this.input.filter(i=>i),this.panels=this.specs.map(i=>i(e));let t=e.state.facet(jd);this.top=new es(e,!0,t.topContainer),this.bottom=new es(e,!1,t.bottomContainer),this.top.sync(this.panels.filter(i=>i.top)),this.bottom.sync(this.panels.filter(i=>!i.top));for(let i of this.panels)i.dom.classList.add("cm-panel"),i.mount&&i.mount()}update(e){let t=e.state.facet(jd);this.top.container!=t.topContainer&&(this.top.sync([]),this.top=new es(e.view,!0,t.topContainer)),this.bottom.container!=t.bottomContainer&&(this.bottom.sync([]),this.bottom=new es(e.view,!1,t.bottomContainer)),this.top.syncClasses(),this.bottom.syncClasses();let i=e.state.facet(_d);if(i!=this.input){let r=i.filter(l=>l),n=[],s=[],o=[],a=[];for(let l of r){let h=this.specs.indexOf(l),c;h<0?(c=l(e.view),a.push(c)):(c=this.panels[h],c.update&&c.update(e)),n.push(c),(c.top?s:o).push(c)}this.specs=r,this.panels=n,this.top.sync(s),this.bottom.sync(o);for(let l of a)l.dom.classList.add("cm-panel"),l.mount&&l.mount()}else for(let r of this.panels)r.update&&r.update(e)}destroy(){this.top.sync([]),this.bottom.sync([])}},{provide:e=>W.scrollMargins.of(t=>{let i=t.plugin(e);return i&&{top:i.top.scrollMargin(),bottom:i.bottom.scrollMargin()}})}),es=class{constructor(e,t,i){this.view=e,this.top=t,this.container=i,this.dom=void 0,this.classes="",this.panels=[],this.syncClasses()}sync(e){for(let t of this.panels)t.destroy&&e.indexOf(t)<0&&t.destroy();this.panels=e,this.syncDOM()}syncDOM(){if(this.panels.length==0){this.dom&&(this.dom.remove(),this.dom=void 0);return}if(!this.dom){this.dom=document.createElement("div"),this.dom.className=this.top?"cm-panels cm-panels-top":"cm-panels cm-panels-bottom",this.dom.style[this.top?"top":"bottom"]="0";let t=this.container||this.view.dom;t.insertBefore(this.dom,this.top?t.firstChild:null)}let e=this.dom.firstChild;for(let t of this.panels)if(t.dom.parentNode==this.dom){for(;e!=t.dom;)e=Dd(e);e=e.nextSibling}else this.dom.insertBefore(t.dom,e);for(;e;)e=Dd(e)}scrollMargin(){return!this.dom||this.container?0:Math.max(0,this.top?this.dom.getBoundingClientRect().bottom-Math.max(0,this.view.scrollDOM.getBoundingClientRect().top):Math.min(innerHeight,this.view.scrollDOM.getBoundingClientRect().bottom)-this.dom.getBoundingClientRect().top)}syncClasses(){if(!(!this.container||this.classes==this.view.themeClasses)){for(let e of this.classes.split(" "))e&&this.container.classList.remove(e);for(let e of(this.classes=this.view.themeClasses).split(" "))e&&this.container.classList.add(e)}}};function Dd(e){let t=e.nextSibling;return e.remove(),t}var _d=E.define({enables:Pv}),qt=class extends Et{compare(e){return this==e||this.constructor==e.constructor&&this.eq(e)}eq(e){return!1}destroy(e){}};qt.prototype.elementClass="";qt.prototype.toDOM=void 0;qt.prototype.mapMode=ge.TrackBefore;qt.prototype.startSide=qt.prototype.endSide=-1;qt.prototype.point=!0;var cs=E.define();var us=E.define();var Ud=E.define({combine:e=>e.some(t=>t)});var OZ=ve.fromClass(class{constructor(e){this.view=e,this.prevViewport=e.viewport,this.dom=document.createElement("div"),this.dom.className="cm-gutters",this.dom.setAttribute("aria-hidden","true"),this.dom.style.minHeight=this.view.contentHeight/this.view.scaleY+"px",this.gutters=e.state.facet(us).map(t=>new Bd(e,t));for(let t of this.gutters)this.dom.appendChild(t.dom);this.fixed=!e.state.facet(Ud),this.fixed&&(this.dom.style.position="sticky"),this.syncGutters(!1),e.scrollDOM.insertBefore(this.dom,e.contentDOM)}update(e){if(this.updateGutters(e)){let t=this.prevViewport,i=e.view.viewport,r=Math.min(t.to,i.to)-Math.max(t.from,i.from);this.syncGutters(r<(i.to-i.from)*.8)}e.geometryChanged&&(this.dom.style.minHeight=this.view.contentHeight/this.view.scaleY+"px"),this.view.state.facet(Ud)!=!this.fixed&&(this.fixed=!this.fixed,this.dom.style.position=this.fixed?"sticky":""),this.prevViewport=e.view.viewport}syncGutters(e){let t=this.dom.nextSibling;e&&this.dom.remove();let i=ie.iter(this.view.state.facet(cs),this.view.viewport.from),r=[],n=this.gutters.map(s=>new kv(s,this.view.viewport,-this.view.documentPadding.top));for(let s of this.view.viewportLineBlocks)if(r.length&&(r=[]),Array.isArray(s.type)){let o=!0;for(let a of s.type)if(a.type==Ce.Text&&o){Da(i,r,a.from);for(let l of n)l.line(this.view,a,r);o=!1}else if(a.widget)for(let l of n)l.widget(this.view,a)}else if(s.type==Ce.Text){Da(i,r,s.from);for(let o of n)o.line(this.view,s,r)}else if(s.widget)for(let o of n)o.widget(this.view,s);for(let s of n)s.finish();e&&this.view.scrollDOM.insertBefore(this.dom,t)}updateGutters(e){let t=e.startState.facet(us),i=e.state.facet(us),r=e.docChanged||e.heightChanged||e.viewportChanged||!ie.eq(e.startState.facet(cs),e.state.facet(cs),e.view.viewport.from,e.view.viewport.to);if(t==i)for(let n of this.gutters)n.update(e)&&(r=!0);else{r=!0;let n=[];for(let s of i){let o=t.indexOf(s);o<0?n.push(new Bd(this.view,s)):(this.gutters[o].update(e),n.push(this.gutters[o]))}for(let s of this.gutters)s.dom.remove(),n.indexOf(s)<0&&s.destroy();for(let s of n)this.dom.appendChild(s.dom);this.gutters=n}return r}destroy(){for(let e of this.gutters)e.destroy();this.dom.remove()}},{provide:e=>W.scrollMargins.of(t=>{let i=t.plugin(e);return!i||i.gutters.length==0||!i.fixed?null:t.textDirection==ee.LTR?{left:i.dom.offsetWidth*t.scaleX}:{right:i.dom.offsetWidth*t.scaleX}})});function zd(e){return Array.isArray(e)?e:[e]}function Da(e,t,i){for(;e.value&&e.from<=i;)e.from==i&&t.push(e.value),e.next()}var kv=class{constructor(e,t,i){this.gutter=e,this.height=i,this.i=0,this.cursor=ie.iter(e.markers,t.from)}addElement(e,t,i){let{gutter:r}=this,n=(t.top-this.height)/e.scaleY,s=t.height/e.scaleY;if(this.i==r.elements.length){let o=new dp(e,s,n,i);r.elements.push(o),r.dom.appendChild(o.dom)}else r.elements[this.i].update(e,s,n,i);this.height=t.bottom,this.i++}line(e,t,i){let r=[];Da(this.cursor,r,t.from),i.length&&(r=r.concat(i));let n=this.gutter.config.lineMarker(e,t,r);n&&r.unshift(n);let s=this.gutter;r.length==0&&!s.config.renderEmptyElements||this.addElement(e,t,r)}widget(e,t){let i=this.gutter.config.widgetMarker(e,t.widget,t);i&&this.addElement(e,t,[i])}finish(){let e=this.gutter;for(;e.elements.length>this.i;){let t=e.elements.pop();e.dom.removeChild(t.dom),t.destroy()}}},Bd=class{constructor(e,t){this.view=e,this.config=t,this.elements=[],this.spacer=null,this.dom=document.createElement("div"),this.dom.className="cm-gutter"+(this.config.class?" "+this.config.class:"");for(let i in t.domEventHandlers)this.dom.addEventListener(i,r=>{let n=r.target,s;if(n!=this.dom&&this.dom.contains(n)){for(;n.parentNode!=this.dom;)n=n.parentNode;let a=n.getBoundingClientRect();s=(a.top+a.bottom)/2}else s=r.clientY;let o=e.lineBlockAtHeight(s-e.documentTop);t.domEventHandlers[i](e,o,r)&&r.preventDefault()});this.markers=zd(t.markers(e)),t.initialSpacer&&(this.spacer=new dp(e,0,0,[t.initialSpacer(e)]),this.dom.appendChild(this.spacer.dom),this.spacer.dom.style.cssText+="visibility: hidden; pointer-events: none")}update(e){let t=this.markers;if(this.markers=zd(this.config.markers(e.view)),this.spacer&&this.config.updateSpacer){let r=this.config.updateSpacer(this.spacer.markers[0],e);r!=this.spacer.markers[0]&&this.spacer.update(e.view,0,0,[r])}let i=e.view.viewport;return!ie.eq(this.markers,t,i.from,i.to)||(this.config.lineMarkerChange?this.config.lineMarkerChange(e):!1)}destroy(){for(let e of this.elements)e.destroy()}},dp=class{constructor(e,t,i,r){this.height=-1,this.above=0,this.markers=[],this.dom=document.createElement("div"),this.dom.className="cm-gutterElement",this.update(e,t,i,r)}update(e,t,i,r){this.height!=t&&(this.height=t,this.dom.style.height=t+"px"),this.above!=i&&(this.dom.style.marginTop=(this.above=i)?i+"px":""),Qv(this.markers,r)||this.setMarkers(e,r)}setMarkers(e,t){let i="cm-gutterElement",r=this.dom.firstChild;for(let n=0,s=0;;){let o=s,a=n<t.length?t[n++]:null,l=!1;if(a){let h=a.elementClass;h&&(i+=" "+h);for(let c=s;c<this.markers.length;c++)if(this.markers[c].compare(a)){o=c,l=!0;break}}else o=this.markers.length;for(;s<o;){let h=this.markers[s++];if(h.toDOM){h.destroy(r);let c=r.nextSibling;r.remove(),r=c}}if(!a)break;a.toDOM&&(l?r=r.nextSibling:this.dom.insertBefore(a.toDOM(e),r)),l&&s++}this.dom.className=i,this.markers=t}destroy(){this.setMarkers(null,[])}};function Qv(e,t){if(e.length!=t.length)return!1;for(let i=0;i<e.length;i++)if(!e[i].compare(t[i]))return!1;return!0}var $v=E.define(),Zr=E.define({combine(e){return Xt(e,{formatNumber:String,domEventHandlers:{}},{domEventHandlers(t,i){let r=Object.assign({},t);for(let n in i){let s=r[n],o=i[n];r[n]=s?(a,l,h)=>s(a,l,h)||o(a,l,h):o}return r}})}}),da=class extends qt{constructor(e){super(),this.number=e}eq(e){return this.number==e.number}toDOM(){return document.createTextNode(this.number)}};function fa(e,t){return e.state.facet(Zr).formatNumber(t,e.state)}var mZ=us.compute([Zr],e=>({class:"cm-lineNumbers",renderEmptyElements:!1,markers(t){return t.state.facet($v)},lineMarker(t,i,r){return r.some(n=>n.toDOM)?null:new da(fa(t,t.state.doc.lineAt(i.from).number))},widgetMarker:()=>null,lineMarkerChange:t=>t.startState.facet(Zr)!=t.state.facet(Zr),initialSpacer(t){return new da(fa(t,Gd(t.state.doc.lines)))},updateSpacer(t,i){let r=fa(i.view,Gd(i.view.state.doc.lines));return r==t.number?t:new da(r)},domEventHandlers:e.facet(Zr).domEventHandlers}));function Gd(e){let t=9;for(;t<e;)t=t*10+9;return t}var Tv=new class extends qt{constructor(){super(...arguments),this.elementClass="cm-activeLineGutter"}},gZ=cs.compute(["selection"],e=>{let t=[],i=-1;for(let r of e.selection.ranges){let n=e.doc.lineAt(r.head).from;n>i&&(i=n,t.push(Tv.range(n)))}return ie.of(t)});var Fd=new Map;function Cv(e){let t=Fd.get(e);return t||Fd.set(e,t=j.mark({attributes:e==="	"?{class:"cm-highlightTab"}:{class:"cm-highlightSpace","data-display":e.replace(/ /g,"\xB7")}})),t}function fp(e){return ve.define(t=>({decorations:e.createDeco(t),update(i){this.decorations=e.updateDeco(i,this.decorations)}}),{decorations:t=>t.decorations})}var yZ=fp(new lp({regexp:/\t| +/g,decoration:e=>Cv(e[0]),boundary:/\S/}));var bZ=fp(new lp({regexp:/\s+$/g,decoration:j.mark({class:"cm-trailingSpace"}),boundary:/\S/}));var tl,Yt=new M;function zi(e){return E.define({combine:e?t=>t.concat(e):void 0})}var bs=new M,qe=class{constructor(e,t,i=[],r=""){this.data=e,this.name=r,he.prototype.hasOwnProperty("tree")||Object.defineProperty(he.prototype,"tree",{get(){return te(this)}}),this.parser=t,this.extension=[Ui.of(this),he.languageData.of((n,s,o)=>{let a=pp(n,s,o),l=a.type.prop(Yt);if(!l)return[];let h=n.facet(l),c=a.type.prop(bs);if(c){let u=a.resolve(s-a.from,o);for(let d of c)if(d.test(u,n)){let f=n.facet(d.facet);return d.type=="replace"?f:f.concat(h)}}return h})].concat(i)}isActiveAt(e,t,i=-1){return pp(e,t,i).type.prop(Yt)==this.data}findRegions(e){let t=e.facet(Ui);if(t?.data==this.data)return[{from:0,to:e.doc.length}];if(!t||!t.allowsNesting)return[];let i=[],r=(n,s)=>{if(n.prop(Yt)==this.data){i.push({from:s,to:s+n.length});return}let o=n.prop(M.mounted);if(o){if(o.tree.prop(Yt)==this.data){if(o.overlay)for(let a of o.overlay)i.push({from:a.from+s,to:a.to+s});else i.push({from:s,to:s+n.length});return}else if(o.overlay){let a=i.length;if(r(o.tree,o.overlay[0].from+s),i.length>a)return}}for(let a=0;a<n.children.length;a++){let l=n.children[a];l instanceof L&&r(l,n.positions[a]+s)}};return r(te(e),0),i}get allowsNesting(){return!0}};qe.setState=z.define();function pp(e,t,i){let r=e.facet(Ui),n=te(e).topNode;if(!r||r.allowsNesting)for(let s=n;s;s=s.enter(t,i,B.ExcludeBuffers))s.type.isTop&&(n=s);return n}var Bi=class sl extends qe{constructor(t,i,r){super(t,i,[],r),this.parser=i}static define(t){let i=zi(t.languageData);return new sl(i,t.parser.configure({props:[Yt.add(r=>r.isTop?i:void 0)]}),t.name)}configure(t,i){return new sl(this.data,this.parser.configure(t),i||this.name)}get allowsNesting(){return this.parser.hasWrappers()}};function te(e){let t=e.field(qe.state,!1);return t?t.tree:L.empty}var Av=class{constructor(e){this.doc=e,this.cursorPos=0,this.string="",this.cursor=e.iter()}get length(){return this.doc.length}syncTo(e){return this.string=this.cursor.next(e-this.cursorPos).value,this.cursorPos=e+this.string.length,this.cursorPos-this.string.length}chunk(e){return this.syncTo(e),this.string}get lineChunks(){return!0}read(e,t){let i=this.cursorPos-this.string.length;return e<i||t>=this.cursorPos?this.doc.sliceString(e,t):this.string.slice(e-i,t-i)}},Mr=null,Wr=class ol{constructor(t,i,r=[],n,s,o,a,l){this.parser=t,this.state=i,this.fragments=r,this.tree=n,this.treeLen=s,this.viewport=o,this.skipped=a,this.scheduleOn=l,this.parse=null,this.tempSkipped=[]}static create(t,i,r){return new ol(t,i,[],L.empty,0,r,[],null)}startParse(){return this.parser.startParse(new Av(this.state.doc),this.fragments)}work(t,i){return i!=null&&i>=this.state.doc.length&&(i=void 0),this.tree!=L.empty&&this.isDone(i??this.state.doc.length)?(this.takeTree(),!0):this.withContext(()=>{var r;if(typeof t=="number"){let n=Date.now()+t;t=()=>Date.now()>n}for(this.parse||(this.parse=this.startParse()),i!=null&&(this.parse.stoppedAt==null||this.parse.stoppedAt>i)&&i<this.state.doc.length&&this.parse.stopAt(i);;){let n=this.parse.advance();if(n)if(this.fragments=this.withoutTempSkipped(di.addTree(n,this.fragments,this.parse.stoppedAt!=null)),this.treeLen=(r=this.parse.stoppedAt)!==null&&r!==void 0?r:this.state.doc.length,this.tree=n,this.parse=null,this.treeLen<(i??this.state.doc.length))this.parse=this.startParse();else return!0;if(t())return!1}})}takeTree(){let t,i;this.parse&&(t=this.parse.parsedPos)>=this.treeLen&&((this.parse.stoppedAt==null||this.parse.stoppedAt>t)&&this.parse.stopAt(t),this.withContext(()=>{for(;!(i=this.parse.advance()););}),this.treeLen=t,this.tree=i,this.fragments=this.withoutTempSkipped(di.addTree(this.tree,this.fragments,!0)),this.parse=null)}withContext(t){let i=Mr;Mr=this;try{return t()}finally{Mr=i}}withoutTempSkipped(t){for(let i;i=this.tempSkipped.pop();)t=Op(t,i.from,i.to);return t}changes(t,i){let{fragments:r,tree:n,treeLen:s,viewport:o,skipped:a}=this;if(this.takeTree(),!t.empty){let l=[];if(t.iterChangedRanges((h,c,u,d)=>l.push({fromA:h,toA:c,fromB:u,toB:d})),r=di.applyChanges(r,l),n=L.empty,s=0,o={from:t.mapPos(o.from,-1),to:t.mapPos(o.to,1)},this.skipped.length){a=[];for(let h of this.skipped){let c=t.mapPos(h.from,1),u=t.mapPos(h.to,-1);c<u&&a.push({from:c,to:u})}}}return new ol(this.parser,i,r,n,s,o,a,this.scheduleOn)}updateViewport(t){if(this.viewport.from==t.from&&this.viewport.to==t.to)return!1;this.viewport=t;let i=this.skipped.length;for(let r=0;r<this.skipped.length;r++){let{from:n,to:s}=this.skipped[r];n<t.to&&s>t.from&&(this.fragments=Op(this.fragments,n,s),this.skipped.splice(r--,1))}return this.skipped.length>=i?!1:(this.reset(),!0)}reset(){this.parse&&(this.takeTree(),this.parse=null)}skipUntilInView(t,i){this.skipped.push({from:t,to:i})}static getSkippingParser(t){return new class extends pi{createParse(i,r,n){let s=n[0].from,o=n[n.length-1].to;return{parsedPos:s,advance(){let a=Mr;if(a){for(let l of n)a.tempSkipped.push(l);t&&(a.scheduleOn=a.scheduleOn?Promise.all([a.scheduleOn,t]):t)}return this.parsedPos=o,new L(le.none,[],[],o-s)},stoppedAt:null,stopAt(){}}}}}isDone(t){t=Math.min(t,this.state.doc.length);let i=this.fragments;return this.treeLen>=t&&i.length&&i[0].from==0&&i[0].to>=t}static get(){return Mr}};function Op(e,t,i){return di.applyChanges(e,[{fromA:t,toA:i,fromB:t,toB:i}])}var al=class ll{constructor(t){this.context=t,this.tree=t.tree}apply(t){if(!t.docChanged&&this.tree==this.context.tree)return this;let i=this.context.changes(t.changes,t.state),r=this.context.treeLen==t.startState.doc.length?void 0:Math.max(t.changes.mapPos(this.context.treeLen),i.viewport.to);return i.work(20,r)||i.takeTree(),new ll(i)}static init(t){let i=Math.min(3e3,t.doc.length),r=Wr.create(t.facet(Ui).parser,t,{from:0,to:i});return r.work(20,i)||r.takeTree(),new ll(r)}};qe.state=We.define({create:al.init,update(e,t){for(let i of t.effects)if(i.is(qe.setState))return i.value;return t.startState.facet(Ui)!=t.state.facet(Ui)?al.init(t.state):e.apply(t)}});var xp=e=>{let t=setTimeout(()=>e(),500);return()=>clearTimeout(t)};typeof requestIdleCallback<"u"&&(xp=e=>{let t=-1,i=setTimeout(()=>{t=requestIdleCallback(e,{timeout:400})},100);return()=>t<0?clearTimeout(i):cancelIdleCallback(t)});var il=typeof navigator<"u"&&!((tl=navigator.scheduling)===null||tl===void 0)&&tl.isInputPending?()=>navigator.scheduling.isInputPending():null,Zv=ve.fromClass(class{constructor(e){this.view=e,this.working=null,this.workScheduled=0,this.chunkEnd=-1,this.chunkBudget=-1,this.work=this.work.bind(this),this.scheduleWork()}update(e){let t=this.view.state.field(qe.state).context;(t.updateViewport(e.view.viewport)||this.view.viewport.to>t.treeLen)&&this.scheduleWork(),(e.docChanged||e.selectionSet)&&(this.view.hasFocus&&(this.chunkBudget+=50),this.scheduleWork()),this.checkAsyncSchedule(t)}scheduleWork(){if(this.working)return;let{state:e}=this.view,t=e.field(qe.state);(t.tree!=t.context.tree||!t.context.isDone(e.doc.length))&&(this.working=xp(this.work))}work(e){this.working=null;let t=Date.now();if(this.chunkEnd<t&&(this.chunkEnd<0||this.view.hasFocus)&&(this.chunkEnd=t+3e4,this.chunkBudget=3e3),this.chunkBudget<=0)return;let{state:i,viewport:{to:r}}=this.view,n=i.field(qe.state);if(n.tree==n.context.tree&&n.context.isDone(r+1e5))return;let s=Date.now()+Math.min(this.chunkBudget,100,e&&!il?Math.max(25,e.timeRemaining()-5):1e9),o=n.context.treeLen<r&&i.doc.length>r+1e3,a=n.context.work(()=>il&&il()||Date.now()>s,r+(o?0:1e5));this.chunkBudget-=Date.now()-t,(a||this.chunkBudget<=0)&&(n.context.takeTree(),this.view.dispatch({effects:qe.setState.of(new al(n.context))})),this.chunkBudget>0&&!(a&&!o)&&this.scheduleWork(),this.checkAsyncSchedule(n.context)}checkAsyncSchedule(e){e.scheduleOn&&(this.workScheduled++,e.scheduleOn.then(()=>this.scheduleWork()).catch(t=>Te(this.view.state,t)).then(()=>this.workScheduled--),e.scheduleOn=null)}destroy(){this.working&&this.working()}isWorking(){return!!(this.working||this.workScheduled>0)}},{eventHandlers:{focus(){this.scheduleWork()}}}),Ui=E.define({combine(e){return e.length?e[0]:null},enables:e=>[qe.state,Zv,W.contentAttributes.compute([e],t=>{let i=t.facet(e);return i&&i.name?{"data-language":i.name}:{}})]}),It=class{constructor(e,t=[]){this.language=e,this.support=t,this.extension=[e,t]}},dl=class Pp{constructor(t,i,r,n,s,o=void 0){this.name=t,this.alias=i,this.extensions=r,this.filename=n,this.loadFunc=s,this.support=o,this.loading=null}load(){return this.loading||(this.loading=this.loadFunc().then(t=>this.support=t,t=>{throw this.loading=null,t}))}static of(t){let{load:i,support:r}=t;if(!i){if(!r)throw new RangeError("Must pass either 'load' or 'support' to LanguageDescription.of");i=()=>Promise.resolve(r)}return new Pp(t.name,(t.alias||[]).concat(t.name).map(n=>n.toLowerCase()),t.extensions||[],t.filename,i,r)}static matchFilename(t,i){for(let n of t)if(n.filename&&n.filename.test(i))return n;let r=/\.([^.]+)$/.exec(i);if(r){for(let n of t)if(n.extensions.indexOf(r[1])>-1)return n}return null}static matchLanguageName(t,i,r=!0){i=i.toLowerCase();for(let n of t)if(n.alias.some(s=>s==i))return n;if(r)for(let n of t)for(let s of n.alias){let o=i.indexOf(s);if(o>-1&&(s.length>2||!/\w/.test(i[o-1])&&!/\w/.test(i[o+s.length])))return n}return null}},Ev=E.define(),Yr=E.define({combine:e=>{if(!e.length)return"  ";let t=e[0];if(!t||/\S/.test(t)||Array.from(t).some(i=>i!=t[0]))throw new Error("Invalid indent unit: "+JSON.stringify(e[0]));return t}});function hl(e){let t=e.facet(Yr);return t.charCodeAt(0)==9?e.tabSize*t.length:t.length}var ei=new M;function Rv(e){let t=e.node,i=t.childAfter(t.from),r=t.lastChild;if(!i)return null;let n=e.options.simulateBreak,s=e.state.doc.lineAt(i.from),o=n==null||n<=s.from?s.to:Math.min(s.to,n);for(let a=i.to;;){let l=t.childAfter(a);if(!l||l==r)return null;if(!l.type.isSkipped)return l.from<o?i:null;a=l.to}}function kp({closing:e,align:t=!0,units:i=1}){return r=>Xv(r,t,i,e)}function Xv(e,t,i,r,n){let s=e.textAfter,o=s.match(/^\s*/)[0].length,a=r&&s.slice(o,o+r.length)==r||n==e.pos+o,l=t?Rv(e):null;return l?a?e.column(l.from):e.column(l.to):e.baseIndent+(a?0:e.unit*i)}var Qp=e=>e.baseIndent;function Gi({except:e,units:t=1}={}){return i=>{let r=e&&e.test(i.textAfter);return i.baseIndent+(r?0:t*i.unit)}}var $p=E.define(),pt=new M;function ws(e){let t=e.firstChild,i=e.lastChild;return t&&t.to<i.from?{from:t.to,to:i.type.isError?e.to:i.from}:null}function Tp(e,t){let i=t.mapPos(e.from,1),r=t.mapPos(e.to,-1);return i>=r?void 0:{from:i,to:r}}var Mv=z.define({map:Tp}),Cp=z.define({map:Tp});var Wv=We.define({create(){return j.none},update(e,t){e=e.map(t.changes);for(let i of t.effects)if(i.is(Mv)&&!Yv(e,i.value.from,i.value.to)){let{preparePlaceholder:r}=t.state.facet(Ap),n=r?j.replace({widget:new Lv(r(t.state,i.value))}):mp;e=e.update({add:[n.range(i.value.from,i.value.to)]})}else i.is(Cp)&&(e=e.update({filter:(r,n)=>i.value.from!=r||i.value.to!=n,filterFrom:i.value.from,filterTo:i.value.to}));if(t.selection){let i=!1,{head:r}=t.selection.main;e.between(r,r,(n,s)=>{n<r&&s>r&&(i=!0)}),i&&(e=e.update({filterFrom:r,filterTo:r,filter:(n,s)=>s<=r||n>=r}))}return e},provide:e=>W.decorations.from(e),toJSON(e,t){let i=[];return e.between(0,t.doc.length,(r,n)=>{i.push(r,n)}),i},fromJSON(e){if(!Array.isArray(e)||e.length%2)throw new RangeError("Invalid JSON for fold state");let t=[];for(let i=0;i<e.length;){let r=e[i++],n=e[i++];if(typeof r!="number"||typeof n!="number")throw new RangeError("Invalid JSON for fold state");t.push(mp.range(r,n))}return j.set(t,!0)}});function qv(e,t,i){var r;let n=null;return(r=e.field(Wv,!1))===null||r===void 0||r.between(t,i,(s,o)=>{(!n||n.from>s)&&(n={from:s,to:o})}),n}function Yv(e,t,i){let r=!1;return e.between(t,t,(n,s)=>{n==t&&s==i&&(r=!0)}),r}var Iv={placeholderDOM:null,preparePlaceholder:null,placeholderText:"\u2026"},Ap=E.define({combine(e){return Xt(e,Iv)}});function Zp(e,t){let{state:i}=e,r=i.facet(Ap),n=o=>{let a=e.lineBlockAt(e.posAtDOM(o.target)),l=qv(e.state,a.from,a.to);l&&e.dispatch({effects:Cp.of(l)}),o.preventDefault()};if(r.placeholderDOM)return r.placeholderDOM(e,n,t);let s=document.createElement("span");return s.textContent=r.placeholderText,s.setAttribute("aria-label",i.phrase("folded code")),s.title=i.phrase("unfold"),s.className="cm-foldPlaceholder",s.onclick=n,s}var mp=j.replace({widget:new class extends Jt{toDOM(e){return Zp(e,null)}}}),Lv=class extends Jt{constructor(e){super(),this.value=e}eq(e){return this.value==e.value}toDOM(e){return Zp(e,this.value)}};var y2=W.baseTheme({".cm-foldPlaceholder":{backgroundColor:"#eee",border:"1px solid #ddd",color:"#888",borderRadius:".2em",margin:"0 1px",padding:"0 1px",cursor:"pointer"},".cm-foldGutter span":{padding:"0 1px",cursor:"pointer"}}),Vv=class Ep{constructor(t,i){this.specs=t;let r;function n(a){let l=xt.newName();return(r||(r=Object.create(null)))["."+l]=a,l}let s=typeof i.all=="string"?i.all:i.all?n(i.all):void 0,o=i.scope;this.scope=o instanceof qe?a=>a.prop(Yt)==o.data:o?a=>a==o:void 0,this.style=Po(t.map(a=>({tag:a.tag,class:a.class||n(Object.assign({},a,{tag:null}))})),{all:s}).style,this.module=r?new xt(r):null,this.themeType=i.themeType}static define(t,i){return new Ep(t,i||{})}},Nv=E.define(),jv=E.define({combine(e){return e.length?[e[0]]:null}});function rl(e){let t=e.facet(Nv);return t.length?t:e.facet(jv)}var Dv=class{constructor(e){this.markCache=Object.create(null),this.tree=te(e.state),this.decorations=this.buildDeco(e,rl(e.state)),this.decoratedTo=e.viewport.to}update(e){let t=te(e.state),i=rl(e.state),r=i!=rl(e.startState),{viewport:n}=e.view,s=e.changes.mapPos(this.decoratedTo,1);t.length<n.to&&!r&&t.type==this.tree.type&&s>=n.to?(this.decorations=this.decorations.map(e.changes),this.decoratedTo=s):(t!=this.tree||e.viewportChanged||r)&&(this.tree=t,this.decorations=this.buildDeco(e.view,i),this.decoratedTo=n.to)}buildDeco(e,t){if(!t||!this.tree.length)return j.none;let i=new yi;for(let{from:r,to:n}of e.visibleRanges)Tc(this.tree,t,(s,o,a)=>{i.add(s,o,this.markCache[a]||(this.markCache[a]=j.mark({class:a})))},r,n);return i.finish()}},b2=_e.high(ve.fromClass(Dv,{decorations:e=>e.decorations})),w2=Vv.define([{tag:m.meta,color:"#404740"},{tag:m.link,textDecoration:"underline"},{tag:m.heading,textDecoration:"underline",fontWeight:"bold"},{tag:m.emphasis,fontStyle:"italic"},{tag:m.strong,fontWeight:"bold"},{tag:m.strikethrough,textDecoration:"line-through"},{tag:m.keyword,color:"#708"},{tag:[m.atom,m.bool,m.url,m.contentSeparator,m.labelName],color:"#219"},{tag:[m.literal,m.inserted],color:"#164"},{tag:[m.string,m.deleted],color:"#a11"},{tag:[m.regexp,m.escape,m.special(m.string)],color:"#e40"},{tag:m.definition(m.variableName),color:"#00f"},{tag:m.local(m.variableName),color:"#30a"},{tag:[m.typeName,m.namespace],color:"#085"},{tag:m.className,color:"#167"},{tag:[m.special(m.variableName),m.macroName],color:"#256"},{tag:m.definition(m.propertyName),color:"#00c"},{tag:m.comment,color:"#940"},{tag:m.invalid,color:"#f00"}]),v2=W.baseTheme({"&.cm-focused .cm-matchingBracket":{backgroundColor:"#328c8252"},"&.cm-focused .cm-nonmatchingBracket":{backgroundColor:"#bb555544"}}),Rp=1e4,Xp="()[]{}",_v=E.define({combine(e){return Xt(e,{afterCursor:!0,brackets:Xp,maxScanDistance:Rp,renderMatch:Bv})}}),Uv=j.mark({class:"cm-matchingBracket"}),zv=j.mark({class:"cm-nonmatchingBracket"});function Bv(e){let t=[],i=e.matched?Uv:zv;return t.push(i.range(e.start.from,e.start.to)),e.end&&t.push(i.range(e.end.from,e.end.to)),t}var S2=We.define({create(){return j.none},update(e,t){if(!t.docChanged&&!t.selection)return e;let i=[],r=t.state.facet(_v);for(let n of t.state.selection.ranges){if(!n.empty)continue;let s=ys(t.state,n.head,-1,r)||n.head>0&&ys(t.state,n.head-1,1,r)||r.afterCursor&&(ys(t.state,n.head,1,r)||n.head<t.state.doc.length&&ys(t.state,n.head+1,-1,r));s&&(i=i.concat(r.renderMatch(s,t.state)))}return j.set(i,!0)},provide:e=>W.decorations.from(e)});var fl=new M;function cl(e,t,i){let r=e.prop(t<0?M.openedBy:M.closedBy);if(r)return r;if(e.name.length==1){let n=i.indexOf(e.name);if(n>-1&&n%2==(t<0?1:0))return[i[n+t]]}return null}function ul(e){let t=e.type.prop(fl);return t?t(e.node):e}function ys(e,t,i,r={}){let n=r.maxScanDistance||Rp,s=r.brackets||Xp,o=te(e),a=o.resolveInner(t,i);for(let l=a;l;l=l.parent){let h=cl(l.type,i,s);if(h&&l.from<l.to){let c=ul(l);if(c&&(i>0?t>=c.from&&t<c.to:t>c.from&&t<=c.to))return Gv(e,t,i,l,c,h,s)}}return Fv(e,t,i,o,a.type,n,s)}function Gv(e,t,i,r,n,s,o){let a=r.parent,l={from:n.from,to:n.to},h=0,c=a?.cursor();if(c&&(i<0?c.childBefore(r.from):c.childAfter(r.to)))do if(i<0?c.to<=r.from:c.from>=r.to){if(h==0&&s.indexOf(c.type.name)>-1&&c.from<c.to){let u=ul(c);return{start:l,end:u?{from:u.from,to:u.to}:void 0,matched:!0}}else if(cl(c.type,i,o))h++;else if(cl(c.type,-i,o)){if(h==0){let u=ul(c);return{start:l,end:u&&u.from<u.to?{from:u.from,to:u.to}:void 0,matched:!1}}h--}}while(i<0?c.prevSibling():c.nextSibling());return{start:l,matched:!1}}function Fv(e,t,i,r,n,s,o){let a=i<0?e.sliceDoc(t-1,t):e.sliceDoc(t,t+1),l=o.indexOf(a);if(l<0||l%2==0!=i>0)return null;let h={from:i<0?t-1:t,to:i>0?t+1:t},c=e.doc.iterRange(t,i>0?e.doc.length:0),u=0;for(let d=0;!c.next().done&&d<=s;){let f=c.value;i<0&&(d+=f.length);let p=t+d*i;for(let O=i>0?0:f.length-1,g=i>0?f.length:-1;O!=g;O+=i){let y=o.indexOf(f[O]);if(!(y<0||r.resolveInner(p+O,1).type!=n))if(y%2==0==i>0)u++;else{if(u==1)return{start:h,end:{from:p+O,to:p+O+1},matched:y>>1==l>>1};u--}}i>0&&(d+=f.length)}return c.done?{start:h,matched:!1}:null}function gp(e,t,i,r=0,n=0){t==null&&(t=e.search(/[^\s\u00a0]/),t==-1&&(t=e.length));let s=n;for(let o=r;o<t;o++)e.charCodeAt(o)==9?s+=i-s%i:s++;return s}var Mp=class{constructor(e,t,i,r){this.string=e,this.tabSize=t,this.indentUnit=i,this.overrideIndent=r,this.pos=0,this.start=0,this.lastColumnPos=0,this.lastColumnValue=0}eol(){return this.pos>=this.string.length}sol(){return this.pos==0}peek(){return this.string.charAt(this.pos)||void 0}next(){if(this.pos<this.string.length)return this.string.charAt(this.pos++)}eat(e){let t=this.string.charAt(this.pos),i;if(typeof e=="string"?i=t==e:i=t&&(e instanceof RegExp?e.test(t):e(t)),i)return++this.pos,t}eatWhile(e){let t=this.pos;for(;this.eat(e););return this.pos>t}eatSpace(){let e=this.pos;for(;/[\s\u00a0]/.test(this.string.charAt(this.pos));)++this.pos;return this.pos>e}skipToEnd(){this.pos=this.string.length}skipTo(e){let t=this.string.indexOf(e,this.pos);if(t>-1)return this.pos=t,!0}backUp(e){this.pos-=e}column(){return this.lastColumnPos<this.start&&(this.lastColumnValue=gp(this.string,this.start,this.tabSize,this.lastColumnPos,this.lastColumnValue),this.lastColumnPos=this.start),this.lastColumnValue}indentation(){var e;return(e=this.overrideIndent)!==null&&e!==void 0?e:gp(this.string,null,this.tabSize)}match(e,t,i){if(typeof e=="string"){let r=s=>i?s.toLowerCase():s,n=this.string.substr(this.pos,e.length);return r(n)==r(e)?(t!==!1&&(this.pos+=e.length),!0):null}else{let r=this.string.slice(this.pos).match(e);return r&&r.index>0?null:(r&&t!==!1&&(this.pos+=r[0].length),r)}}current(){return this.string.slice(this.start,this.pos)}};function Hv(e){return{name:e.name||"",token:e.token,blankLine:e.blankLine||(()=>{}),startState:e.startState||(()=>!0),copyState:e.copyState||Kv,indent:e.indent||(()=>null),languageData:e.languageData||{},tokenTable:e.tokenTable||Ol}}function Kv(e){if(typeof e!="object")return e;let t={};for(let i in e){let r=e[i];t[i]=r instanceof Array?r.slice():r}return t}var yp=new WeakMap,Wp=class qp extends qe{constructor(t){let i=zi(t.languageData),r=Hv(t),n,s=new class extends pi{createParse(o,a,l){return new eS(n,o,a,l)}};super(i,s,[Ev.of((o,a)=>this.getIndent(o,a))],t.name),this.topNode=rS(i),n=this,this.streamParser=r,this.stateAfter=new M({perNode:!0}),this.tokenTable=t.tokenTable?new Vp(r.tokenTable):iS}static define(t){return new qp(t)}getIndent(t,i){let r=te(t.state),n=r.resolve(i);for(;n&&n.type!=this.topNode;)n=n.parent;if(!n)return null;let s,{overrideIndentation:o}=t.options;o&&(s=yp.get(t.state),s!=null&&s<i-1e4&&(s=void 0));let a=pl(this,r,0,n.from,s??i),l,h;if(a?(h=a.state,l=a.pos+1):(h=this.streamParser.startState(t.unit),l=0),i-l>1e4)return null;for(;l<i;){let u=t.state.doc.lineAt(l),d=Math.min(i,u.to);if(u.length){let f=o?o(u.from):-1,p=new Mp(u.text,t.state.tabSize,t.unit,f<0?void 0:f);for(;p.pos<d-u.from;)Ip(this.streamParser.token,p,h)}else this.streamParser.blankLine(h,t.unit);if(d==i)break;l=u.to+1}let c=t.lineAt(i);return o&&s==null&&yp.set(t.state,c.from),this.streamParser.indent(h,/^\s*(.*)/.exec(c.text)[1],t)}get allowsNesting(){return!1}};function pl(e,t,i,r,n){let s=i>=r&&i+t.length<=n&&t.prop(e.stateAfter);if(s)return{state:e.streamParser.copyState(s),pos:i+t.length};for(let o=t.children.length-1;o>=0;o--){let a=t.children[o],l=i+t.positions[o],h=a instanceof L&&l<n&&pl(e,a,l,r,n);if(h)return h}return null}function Yp(e,t,i,r,n){if(n&&i<=0&&r>=t.length)return t;!n&&t.type==e.topNode&&(n=!0);for(let s=t.children.length-1;s>=0;s--){let o=t.positions[s],a=t.children[s],l;if(o<r&&a instanceof L){if(!(l=Yp(e,a,i-o,r-o,n)))break;return n?new L(t.type,t.children.slice(0,s).concat(l),t.positions.slice(0,s+1),o+l.length):l}}return null}function Jv(e,t,i,r){for(let n of t){let s=n.from+(n.openStart?25:0),o=n.to-(n.openEnd?25:0),a=s<=i&&o>i&&pl(e,n.tree,0-n.offset,i,o),l;if(a&&(l=Yp(e,n.tree,i+n.offset,a.pos+n.offset,!1)))return{state:a.state,tree:l}}return{state:e.streamParser.startState(r?hl(r):4),tree:L.empty}}var eS=class{constructor(e,t,i,r){this.lang=e,this.input=t,this.fragments=i,this.ranges=r,this.stoppedAt=null,this.chunks=[],this.chunkPos=[],this.chunk=[],this.chunkReused=void 0,this.rangeIndex=0,this.to=r[r.length-1].to;let n=Wr.get(),s=r[0].from,{state:o,tree:a}=Jv(e,i,s,n?.state);this.state=o,this.parsedPos=this.chunkStart=s+a.length;for(let l=0;l<a.children.length;l++)this.chunks.push(a.children[l]),this.chunkPos.push(a.positions[l]);n&&this.parsedPos<n.viewport.from-1e5&&(this.state=this.lang.streamParser.startState(hl(n.state)),n.skipUntilInView(this.parsedPos,n.viewport.from),this.parsedPos=n.viewport.from),this.moveRangeIndex()}advance(){let e=Wr.get(),t=this.stoppedAt==null?this.to:Math.min(this.to,this.stoppedAt),i=Math.min(t,this.chunkStart+2048);for(e&&(i=Math.min(i,e.viewport.to));this.parsedPos<i;)this.parseLine(e);return this.chunkStart<this.parsedPos&&this.finishChunk(),this.parsedPos>=t?this.finish():e&&this.parsedPos>=e.viewport.to?(e.skipUntilInView(this.parsedPos,t),this.finish()):null}stopAt(e){this.stoppedAt=e}lineAfter(e){let t=this.input.chunk(e);if(this.input.lineChunks)t==`
-`&&(t="");else{let i=t.indexOf(`
-`);i>-1&&(t=t.slice(0,i))}return e+t.length<=this.to?t:t.slice(0,this.to-e)}nextLine(){let e=this.parsedPos,t=this.lineAfter(e),i=e+t.length;for(let r=this.rangeIndex;;){let n=this.ranges[r].to;if(n>=i||(t=t.slice(0,n-(i-t.length)),r++,r==this.ranges.length))break;let s=this.ranges[r].from,o=this.lineAfter(s);t+=o,i=s+o.length}return{line:t,end:i}}skipGapsTo(e,t,i){for(;;){let r=this.ranges[this.rangeIndex].to,n=e+t;if(i>0?r>n:r>=n)break;let s=this.ranges[++this.rangeIndex].from;t+=s-r}return t}moveRangeIndex(){for(;this.ranges[this.rangeIndex].to<this.parsedPos;)this.rangeIndex++}emitToken(e,t,i,r,n){if(this.ranges.length>1){n=this.skipGapsTo(t,n,1),t+=n;let s=this.chunk.length;n=this.skipGapsTo(i,n,-1),i+=n,r+=this.chunk.length-s}return this.chunk.push(e,t,i,r),n}parseLine(e){let{line:t,end:i}=this.nextLine(),r=0,{streamParser:n}=this.lang,s=new Mp(t,e?e.state.tabSize:4,e?hl(e.state):2);if(s.eol())n.blankLine(this.state,s.indentUnit);else for(;!s.eol();){let o=Ip(n.token,s,this.state);if(o&&(r=this.emitToken(this.lang.tokenTable.resolve(o),this.parsedPos+s.start,this.parsedPos+s.pos,4,r)),s.start>1e4)break}this.parsedPos=i,this.moveRangeIndex(),this.parsedPos<this.to&&this.parsedPos++}finishChunk(){let e=L.build({buffer:this.chunk,start:this.chunkStart,length:this.parsedPos-this.chunkStart,nodeSet:tS,topID:0,maxBufferLength:2048,reused:this.chunkReused});e=new L(e.type,e.children,e.positions,e.length,[[this.lang.stateAfter,this.lang.streamParser.copyState(this.state)]]),this.chunks.push(e),this.chunkPos.push(this.chunkStart-this.ranges[0].from),this.chunk=[],this.chunkReused=void 0,this.chunkStart=this.parsedPos}finish(){return new L(this.lang.topNode,this.chunks,this.chunkPos,this.parsedPos-this.ranges[0].from).balance()}};function Ip(e,t,i){t.start=t.pos;for(let r=0;r<10;r++){let n=e(t,i);if(t.pos>t.start)return n}throw new Error("Stream parser failed to advance stream.")}var Ol=Object.create(null),qr=[le.none],tS=new fi(qr),bp=[],wp=Object.create(null),Lp=Object.create(null);for(let[e,t]of[["variable","variableName"],["variable-2","variableName.special"],["string-2","string.special"],["def","variableName.definition"],["tag","tagName"],["attribute","attributeName"],["type","typeName"],["builtin","variableName.standard"],["qualifier","modifier"],["error","invalid"],["header","heading"],["property","propertyName"]])Lp[e]=Np(Ol,t);var Vp=class{constructor(e){this.extra=e,this.table=Object.assign(Object.create(null),Lp)}resolve(e){return e?this.table[e]||(this.table[e]=Np(this.extra,e)):0}},iS=new Vp(Ol);function nl(e,t){bp.indexOf(e)>-1||(bp.push(e),console.warn(t))}function Np(e,t){let i=[];for(let a of t.split(" ")){let l=[];for(let h of a.split(".")){let c=e[h]||m[h];c?typeof c=="function"?l.length?l=l.map(c):nl(h,`Modifier ${h} used at start of tag`):l.length?nl(h,`Tag ${h} used as modifier`):l=Array.isArray(c)?c:[c]:nl(h,`Unknown highlighting tag ${h}`)}for(let h of l)i.push(h)}if(!i.length)return 0;let r=t.replace(/ /g,"_"),n=r+" "+i.map(a=>a.id),s=wp[n];if(s)return s.id;let o=wp[n]=le.define({id:qr.length,name:r,props:[Re({[r]:i})]});return qr.push(o),o.id}function rS(e){let t=le.define({id:qr.length,name:"Document",props:[Yt.add(()=>e)],top:!0});return qr.push(t),t}function jp(e){return e.length<=4096&&/[\u0590-\u05f4\u0600-\u06ff\u0700-\u08ac\ufb50-\ufdff]/.test(e)}function Dp(e){for(let t=e.iter();!t.next().done;)if(jp(t.value))return!0;return!1}function nS(e){let t=!1;return e.iterChanges((i,r,n,s,o)=>{!t&&Dp(o)&&(t=!0)}),t}var vp=E.define({combine:e=>e.some(t=>t)});var x2=ve.fromClass(class{constructor(e){this.always=e.state.facet(vp)||e.textDirection!=ee.LTR||e.state.facet(W.perLineTextDirection),this.hasRTL=!this.always&&Dp(e.state.doc),this.tree=te(e.state),this.decorations=this.always||this.hasRTL?Sp(e,this.tree,this.always):j.none}update(e){let t=e.state.facet(vp)||e.view.textDirection!=ee.LTR||e.state.facet(W.perLineTextDirection);if(!t&&!this.hasRTL&&nS(e.changes)&&(this.hasRTL=!0),!t&&!this.hasRTL)return;let i=te(e.state);(t!=this.always||i!=this.tree||e.docChanged||e.viewportChanged)&&(this.tree=i,this.always=t,this.decorations=Sp(e.view,i,t))}},{provide:e=>{function t(i){var r,n;return(n=(r=i.plugin(e))===null||r===void 0?void 0:r.decorations)!==null&&n!==void 0?n:j.none}return[W.outerDecorations.of(t),_e.lowest(W.bidiIsolatedRanges.of(t))]}});function Sp(e,t,i){let r=new yi,n=e.visibleRanges;i||(n=sS(n,e.state.doc));for(let{from:s,to:o}of n)t.iterate({enter:a=>{let l=a.type.prop(M.isolate);l&&r.add(a.from,a.to,oS[l])},from:s,to:o});return r.finish()}function sS(e,t){let i=t.iter(),r=0,n=[],s=null;for(let{from:o,to:a}of e)for(o!=r&&(r<o&&i.next(o-r),r=o);;){let l=r,h=r+i.value.length;if(!i.lineBreak&&jp(i.value)&&(s&&s.to>l-10?s.to=Math.min(a,h):n.push(s={from:l,to:Math.min(a,h)})),r>=a)break;r=h,i.next()}return n}var oS={rtl:j.mark({class:"cm-iso",inclusive:!0,attributes:{dir:"rtl"},bidiIsolate:ee.RTL}),ltr:j.mark({class:"cm-iso",inclusive:!0,attributes:{dir:"ltr"},bidiIsolate:ee.LTR}),auto:j.mark({class:"cm-iso",inclusive:!0,attributes:{dir:"auto"},bidiIsolate:null})};var ks=class{constructor(e,t,i){this.state=e,this.pos=t,this.explicit=i,this.abortListeners=[]}tokenBefore(e){let t=te(this.state).resolveInner(this.pos,-1);for(;t&&e.indexOf(t.name)<0;)t=t.parent;return t?{from:t.from,to:this.pos,text:this.state.sliceDoc(t.from,this.pos),type:t.type}:null}matchBefore(e){let t=this.state.doc.lineAt(this.pos),i=Math.max(t.from,this.pos-250),r=t.text.slice(i-t.from,this.pos-t.from),n=r.search(tO(e,!1));return n<0?null:{from:i+n,to:this.pos,text:r.slice(n)}}get aborted(){return this.abortListeners==null}addEventListener(e,t){e=="abort"&&this.abortListeners&&this.abortListeners.push(t)}};function _p(e){let t=Object.keys(e).join(""),i=/\w/.test(t);return i&&(t=t.replace(/\w/g,"")),`[${i?"\\w":""}${t.replace(/[^\w\s]/g,"\\$&")}]`}function aS(e){let t=Object.create(null),i=Object.create(null);for(let{label:n}of e){t[n[0]]=!0;for(let s=1;s<n.length;s++)i[n[s]]=!0}let r=_p(t)+_p(i)+"*$";return[new RegExp("^"+r),new RegExp(r)]}function wl(e){let t=e.map(n=>typeof n=="string"?{label:n}:n),[i,r]=t.every(n=>/^\w+$/.test(n.label))?[/\w*$/,/\w+$/]:aS(t);return n=>{let s=n.matchBefore(r);return s||n.explicit?{from:s?s.from:n.pos,options:t,validFor:i}:null}}function eO(e,t){return i=>{for(let r=te(i.state).resolveInner(i.pos,-1);r;r=r.parent){if(e.indexOf(r.name)>-1)return null;if(r.type.isTop)break}return t(i)}}var Up=class{constructor(e,t,i,r){this.completion=e,this.source=t,this.match=i,this.score=r}};function ii(e){return e.selection.main.from}function tO(e,t){var i;let{source:r}=e,n=t&&r[0]!="^",s=r[r.length-1]!="$";return!n&&!s?e:new RegExp(`${n?"^":""}(?:${r})${s?"$":""}`,(i=e.flags)!==null&&i!==void 0?i:e.ignoreCase?"i":"")}var vl=Rt.define();function lS(e,t,i,r){let{main:n}=e.selection,s=i-n.from,o=r-n.from;return Object.assign(Object.assign({},e.changeByRange(a=>a!=n&&i!=r&&e.sliceDoc(a.from+s,a.from+o)!=e.sliceDoc(i,r)?{range:a}:{changes:{from:a.from+s,to:r==n.from?a.to:a.from+o,insert:t},range:$.cursor(a.from+s+t.length)})),{scrollIntoView:!0,userEvent:"input.complete"})}var zp=new WeakMap;function hS(e){if(!Array.isArray(e))return e;let t=zp.get(e);return t||zp.set(e,t=wl(e)),t}var xs=z.define(),Lr=z.define(),cS=class{constructor(e){this.pattern=e,this.chars=[],this.folded=[],this.any=[],this.precise=[],this.byWord=[],this.score=0,this.matched=[];for(let t=0;t<e.length;){let i=Qe(e,t),r=nt(i);this.chars.push(i);let n=e.slice(t,t+r),s=n.toUpperCase();this.folded.push(Qe(s==n?n.toLowerCase():s,0)),t+=r}this.astral=e.length!=this.chars.length}ret(e,t){return this.score=e,this.matched=t,this}match(e){if(this.pattern.length==0)return this.ret(-100,[]);if(e.length<this.pattern.length)return null;let{chars:t,folded:i,any:r,precise:n,byWord:s}=this;if(t.length==1){let y=Qe(e,0),b=nt(y),S=b==e.length?0:-100;if(y!=t[0])if(y==i[0])S+=-200;else return null;return this.ret(S,[0,b])}let o=e.indexOf(this.pattern);if(o==0)return this.ret(e.length==this.pattern.length?0:-100,[0,this.pattern.length]);let a=t.length,l=0;if(o<0){for(let y=0,b=Math.min(e.length,200);y<b&&l<a;){let S=Qe(e,y);(S==t[l]||S==i[l])&&(r[l++]=y),y+=nt(S)}if(l<a)return null}let h=0,c=0,u=!1,d=0,f=-1,p=-1,O=/[a-z]/.test(e),g=!0;for(let y=0,b=Math.min(e.length,200),S=0;y<b&&c<a;){let w=Qe(e,y);o<0&&(h<a&&w==t[h]&&(n[h++]=y),d<a&&(w==t[d]||w==i[d]?(d==0&&(f=y),p=y+1,d++):d=0));let k,Z=w<255?w>=48&&w<=57||w>=97&&w<=122?2:w>=65&&w<=90?1:0:(k=Ho(w))!=k.toLowerCase()?1:k!=k.toUpperCase()?2:0;(!y||Z==1&&O||S==0&&Z!=0)&&(t[c]==w||i[c]==w&&(u=!0)?s[c++]=y:s.length&&(g=!1)),S=Z,y+=nt(w)}return c==a&&s[0]==0&&g?this.result(-100+(u?-200:0),s,e):d==a&&f==0?this.ret(-200-e.length+(p==e.length?0:-100),[0,p]):o>-1?this.ret(-700-e.length,[o,o+this.pattern.length]):d==a?this.ret(-900-e.length,[f,p]):c==a?this.result(-100+(u?-200:0)+-700+(g?0:-1100),s,e):t.length==2?null:this.result((r[0]?-700:0)+-200+-1100,r,e)}result(e,t,i){let r=[],n=0;for(let s of t){let o=s+(this.astral?nt(Qe(i,s)):1);n&&r[n-1]==s?r[n-1]=o:(r[n++]=s,r[n++]=o)}return this.ret(e-i.length,r)}},uS=class{constructor(e){this.pattern=e,this.matched=[],this.score=0,this.folded=e.toLowerCase()}match(e){if(e.length<this.pattern.length)return null;let t=e.slice(0,this.pattern.length),i=t==this.pattern?0:t.toLowerCase()==this.folded?-200:null;return i==null?null:(this.matched=[0,t.length],this.score=i+(e.length==this.pattern.length?0:-100),this)}},Se=E.define({combine(e){return Xt(e,{activateOnTyping:!0,activateOnCompletion:()=>!1,activateOnTypingDelay:100,selectOnOpen:!0,override:null,closeOnBlur:!0,maxRenderedOptions:100,defaultKeymap:!0,tooltipClass:()=>"",optionClass:()=>"",aboveCursor:!1,icons:!0,addToOptions:[],positionInfo:dS,filterStrict:!1,compareCompletions:(t,i)=>t.label.localeCompare(i.label),interactionDelay:75,updateSyncTime:100},{defaultKeymap:(t,i)=>t&&i,closeOnBlur:(t,i)=>t&&i,icons:(t,i)=>t&&i,tooltipClass:(t,i)=>r=>Bp(t(r),i(r)),optionClass:(t,i)=>r=>Bp(t(r),i(r)),addToOptions:(t,i)=>t.concat(i),filterStrict:(t,i)=>t||i})}});function Bp(e,t){return e?t?e+" "+t:e:t}function dS(e,t,i,r,n,s){let o=e.textDirection==ee.RTL,a=o,l=!1,h="top",c,u,d=t.left-n.left,f=n.right-t.right,p=r.right-r.left,O=r.bottom-r.top;if(a&&d<Math.min(p,f)?a=!1:!a&&f<Math.min(p,d)&&(a=!0),p<=(a?d:f))c=Math.max(n.top,Math.min(i.top,n.bottom-O))-t.top,u=Math.min(400,a?d:f);else{l=!0,u=Math.min(400,(o?t.right:n.right-t.left)-30);let b=n.bottom-t.bottom;b>=O||b>t.top?c=i.bottom-t.top:(h="bottom",c=t.bottom-i.top)}let g=(t.bottom-t.top)/s.offsetHeight,y=(t.right-t.left)/s.offsetWidth;return{style:`${h}: ${c/g}px; max-width: ${u/y}px`,class:"cm-completionInfo-"+(l?o?"left-narrow":"right-narrow":a?"left":"right")}}function fS(e){let t=e.addToOptions.slice();return e.icons&&t.push({render(i){let r=document.createElement("div");return r.classList.add("cm-completionIcon"),i.type&&r.classList.add(...i.type.split(/\s+/g).map(n=>"cm-completionIcon-"+n)),r.setAttribute("aria-hidden","true"),r},position:20}),t.push({render(i,r,n,s){let o=document.createElement("span");o.className="cm-completionLabel";let a=i.displayLabel||i.label,l=0;for(let h=0;h<s.length;){let c=s[h++],u=s[h++];c>l&&o.appendChild(document.createTextNode(a.slice(l,c)));let d=o.appendChild(document.createElement("span"));d.appendChild(document.createTextNode(a.slice(c,u))),d.className="cm-completionMatchedText",l=u}return l<a.length&&o.appendChild(document.createTextNode(a.slice(l))),o},position:50},{render(i){if(!i.detail)return null;let r=document.createElement("span");return r.className="cm-completionDetail",r.textContent=i.detail,r},position:80}),t.sort((i,r)=>i.position-r.position).map(i=>i.render)}function ml(e,t,i){if(e<=i)return{from:0,to:e};if(t<0&&(t=0),t<=e>>1){let n=Math.floor(t/i);return{from:n*i,to:(n+1)*i}}let r=Math.floor((e-t)/i);return{from:e-(r+1)*i,to:e-r*i}}var pS=class{constructor(e,t,i){this.view=e,this.stateField=t,this.applyCompletion=i,this.info=null,this.infoDestroy=null,this.placeInfoReq={read:()=>this.measureInfo(),write:a=>this.placeInfo(a),key:this},this.space=null,this.currentClass="";let r=e.state.field(t),{options:n,selected:s}=r.open,o=e.state.facet(Se);this.optionContent=fS(o),this.optionClass=o.optionClass,this.tooltipClass=o.tooltipClass,this.range=ml(n.length,s,o.maxRenderedOptions),this.dom=document.createElement("div"),this.dom.className="cm-tooltip-autocomplete",this.updateTooltipClass(e.state),this.dom.addEventListener("mousedown",a=>{let{options:l}=e.state.field(t).open;for(let h=a.target,c;h&&h!=this.dom;h=h.parentNode)if(h.nodeName=="LI"&&(c=/-(\d+)$/.exec(h.id))&&+c[1]<l.length){this.applyCompletion(e,l[+c[1]]),a.preventDefault();return}}),this.dom.addEventListener("focusout",a=>{let l=e.state.field(this.stateField,!1);l&&l.tooltip&&e.state.facet(Se).closeOnBlur&&a.relatedTarget!=e.contentDOM&&e.dispatch({effects:Lr.of(null)})}),this.showOptions(n,r.id)}mount(){this.updateSel()}showOptions(e,t){this.list&&this.list.remove(),this.list=this.dom.appendChild(this.createListBox(e,t,this.range)),this.list.addEventListener("scroll",()=>{this.info&&this.view.requestMeasure(this.placeInfoReq)})}update(e){var t;let i=e.state.field(this.stateField),r=e.startState.field(this.stateField);if(this.updateTooltipClass(e.state),i!=r){let{options:n,selected:s,disabled:o}=i.open;(!r.open||r.open.options!=n)&&(this.range=ml(n.length,s,e.state.facet(Se).maxRenderedOptions),this.showOptions(n,i.id)),this.updateSel(),o!=((t=r.open)===null||t===void 0?void 0:t.disabled)&&this.dom.classList.toggle("cm-tooltip-autocomplete-disabled",!!o)}}updateTooltipClass(e){let t=this.tooltipClass(e);if(t!=this.currentClass){for(let i of this.currentClass.split(" "))i&&this.dom.classList.remove(i);for(let i of t.split(" "))i&&this.dom.classList.add(i);this.currentClass=t}}positioned(e){this.space=e,this.info&&this.view.requestMeasure(this.placeInfoReq)}updateSel(){let e=this.view.state.field(this.stateField),t=e.open;if((t.selected>-1&&t.selected<this.range.from||t.selected>=this.range.to)&&(this.range=ml(t.options.length,t.selected,this.view.state.facet(Se).maxRenderedOptions),this.showOptions(t.options,e.id)),this.updateSelectedOption(t.selected)){this.destroyInfo();let{completion:i}=t.options[t.selected],{info:r}=i;if(!r)return;let n=typeof r=="string"?document.createTextNode(r):r(i);if(!n)return;"then"in n?n.then(s=>{s&&this.view.state.field(this.stateField,!1)==e&&this.addInfoPane(s,i)}).catch(s=>Te(this.view.state,s,"completion info")):this.addInfoPane(n,i)}}addInfoPane(e,t){this.destroyInfo();let i=this.info=document.createElement("div");if(i.className="cm-tooltip cm-completionInfo",e.nodeType!=null)i.appendChild(e),this.infoDestroy=null;else{let{dom:r,destroy:n}=e;i.appendChild(r),this.infoDestroy=n||null}this.dom.appendChild(i),this.view.requestMeasure(this.placeInfoReq)}updateSelectedOption(e){let t=null;for(let i=this.list.firstChild,r=this.range.from;i;i=i.nextSibling,r++)i.nodeName!="LI"||!i.id?r--:r==e?i.hasAttribute("aria-selected")||(i.setAttribute("aria-selected","true"),t=i):i.hasAttribute("aria-selected")&&i.removeAttribute("aria-selected");return t&&mS(this.list,t),t}measureInfo(){let e=this.dom.querySelector("[aria-selected]");if(!e||!this.info)return null;let t=this.dom.getBoundingClientRect(),i=this.info.getBoundingClientRect(),r=e.getBoundingClientRect(),n=this.space;if(!n){let s=this.dom.ownerDocument.defaultView||window;n={left:0,top:0,right:s.innerWidth,bottom:s.innerHeight}}return r.top>Math.min(n.bottom,t.bottom)-10||r.bottom<Math.max(n.top,t.top)+10?null:this.view.state.facet(Se).positionInfo(this.view,t,r,i,n,this.dom)}placeInfo(e){this.info&&(e?(e.style&&(this.info.style.cssText=e.style),this.info.className="cm-tooltip cm-completionInfo "+(e.class||"")):this.info.style.cssText="top: -1e6px")}createListBox(e,t,i){let r=document.createElement("ul");r.id=t,r.setAttribute("role","listbox"),r.setAttribute("aria-expanded","true"),r.setAttribute("aria-label",this.view.state.phrase("Completions"));let n=null;for(let s=i.from;s<i.to;s++){let{completion:o,match:a}=e[s],{section:l}=o;if(l){let u=typeof l=="string"?l:l.name;if(u!=n&&(s>i.from||i.from==0))if(n=u,typeof l!="string"&&l.header)r.appendChild(l.header(l));else{let d=r.appendChild(document.createElement("completion-section"));d.textContent=u}}let h=r.appendChild(document.createElement("li"));h.id=t+"-"+s,h.setAttribute("role","option");let c=this.optionClass(o);c&&(h.className=c);for(let u of this.optionContent){let d=u(o,this.view.state,this.view,a);d&&h.appendChild(d)}}return i.from&&r.classList.add("cm-completionListIncompleteTop"),i.to<e.length&&r.classList.add("cm-completionListIncompleteBottom"),r}destroyInfo(){this.info&&(this.infoDestroy&&this.infoDestroy(),this.info.remove(),this.info=null)}destroy(){this.destroyInfo()}};function OS(e,t){return i=>new pS(i,e,t)}function mS(e,t){let i=e.getBoundingClientRect(),r=t.getBoundingClientRect(),n=i.height/e.offsetHeight;r.top<i.top?e.scrollTop-=(i.top-r.top)/n:r.bottom>i.bottom&&(e.scrollTop+=(r.bottom-i.bottom)/n)}function Gp(e){return(e.boost||0)*100+(e.apply?10:0)+(e.info?5:0)+(e.type?1:0)}function gS(e,t){let i=[],r=null,n=h=>{i.push(h);let{section:c}=h.completion;if(c){r||(r=[]);let u=typeof c=="string"?c:c.name;r.some(d=>d.name==u)||r.push(typeof c=="string"?{name:u}:c)}},s=t.facet(Se);for(let h of e)if(h.hasResult()){let c=h.result.getMatch;if(h.result.filter===!1)for(let u of h.result.options)n(new Up(u,h.source,c?c(u):[],1e9-i.length));else{let u=t.sliceDoc(h.from,h.to),d,f=s.filterStrict?new uS(u):new cS(u);for(let p of h.result.options)if(d=f.match(p.label)){let O=p.displayLabel?c?c(p,d.matched):[]:d.matched;n(new Up(p,h.source,O,d.score+(p.boost||0)))}}}if(r){let h=Object.create(null),c=0,u=(d,f)=>{var p,O;return((p=d.rank)!==null&&p!==void 0?p:1e9)-((O=f.rank)!==null&&O!==void 0?O:1e9)||(d.name<f.name?-1:1)};for(let d of r.sort(u))c-=1e5,h[d.name]=c;for(let d of i){let{section:f}=d.completion;f&&(d.score+=h[typeof f=="string"?f:f.name])}}let o=[],a=null,l=s.compareCompletions;for(let h of i.sort((c,u)=>u.score-c.score||l(c.completion,u.completion))){let c=h.completion;!a||a.label!=c.label||a.detail!=c.detail||a.type!=null&&c.type!=null&&a.type!=c.type||a.apply!=c.apply||a.boost!=c.boost?o.push(h):Gp(h.completion)>Gp(a)&&(o[o.length-1]=h),a=h.completion}return o}var yS=class Ir{constructor(t,i,r,n,s,o){this.options=t,this.attrs=i,this.tooltip=r,this.timestamp=n,this.selected=s,this.disabled=o}setSelected(t,i){return t==this.selected||t>=this.options.length?this:new Ir(this.options,Fp(i,t),this.tooltip,this.timestamp,t,this.disabled)}static build(t,i,r,n,s){let o=gS(t,i);if(!o.length)return n&&t.some(l=>l.state==1)?new Ir(n.options,n.attrs,n.tooltip,n.timestamp,n.selected,!0):null;let a=i.facet(Se).selectOnOpen?0:-1;if(n&&n.selected!=a&&n.selected!=-1){let l=n.options[n.selected].completion;for(let h=0;h<o.length;h++)if(o[h].completion==l){a=h;break}}return new Ir(o,Fp(r,a),{pos:t.reduce((l,h)=>h.hasResult()?Math.min(l,h.from):l,1e8),create:PS,above:s.aboveCursor},n?n.timestamp:Date.now(),a,!1)}map(t){return new Ir(this.options,this.attrs,Object.assign(Object.assign({},this.tooltip),{pos:t.mapPos(this.tooltip.pos)}),this.timestamp,this.selected,this.disabled)}},bS=class yl{constructor(t,i,r){this.active=t,this.id=i,this.open=r}static start(){return new yl(SS,"cm-ac-"+Math.floor(Math.random()*2e6).toString(36),null)}update(t){let{state:i}=t,r=i.facet(Se),n=(r.override||i.languageDataAt("autocomplete",ii(i)).map(hS)).map(o=>(this.active.find(a=>a.source==o)||new ti(o,this.active.some(a=>a.state!=0)?1:0)).update(t,r));n.length==this.active.length&&n.every((o,a)=>o==this.active[a])&&(n=this.active);let s=this.open;s&&t.docChanged&&(s=s.map(t.changes)),t.selection||n.some(o=>o.hasResult()&&t.changes.touchesRange(o.from,o.to))||!wS(n,this.active)?s=yS.build(n,i,this.id,s,r):s&&s.disabled&&!n.some(o=>o.state==1)&&(s=null),!s&&n.every(o=>o.state!=1)&&n.some(o=>o.hasResult())&&(n=n.map(o=>o.hasResult()?new ti(o.source,0):o));for(let o of t.effects)o.is(nO)&&(s=s&&s.setSelected(o.value,this.id));return n==this.active&&s==this.open?this:new yl(n,this.id,s)}get tooltip(){return this.open?this.open.tooltip:null}get attrs(){return this.open?this.open.attrs:vS}};function wS(e,t){if(e==t)return!0;for(let i=0,r=0;;){for(;i<e.length&&!e[i].hasResult;)i++;for(;r<t.length&&!t[r].hasResult;)r++;let n=i==e.length,s=r==t.length;if(n||s)return n==s;if(e[i++].result!=t[r++].result)return!1}}var vS={"aria-autocomplete":"list"};function Fp(e,t){let i={"aria-autocomplete":"list","aria-haspopup":"listbox","aria-controls":e};return t>-1&&(i["aria-activedescendant"]=e+"-"+t),i}var SS=[];function bl(e,t){if(e.isUserEvent("input.complete")){let i=e.annotation(vl);if(i&&t.activateOnCompletion(i))return"input"}return e.isUserEvent("input.type")?"input":e.isUserEvent("delete.backward")?"delete":null}var ti=class Si{constructor(t,i,r=-1){this.source=t,this.state=i,this.explicitPos=r}hasResult(){return!1}update(t,i){let r=bl(t,i),n=this;r?n=n.handleUserEvent(t,r,i):t.docChanged?n=n.handleChange(t):t.selection&&n.state!=0&&(n=new Si(n.source,0));for(let s of t.effects)if(s.is(xs))n=new Si(n.source,1,s.value?ii(t.state):-1);else if(s.is(Lr))n=new Si(n.source,0);else if(s.is(rO))for(let o of s.value)o.source==n.source&&(n=o);return n}handleUserEvent(t,i,r){return i=="delete"||!r.activateOnTyping?this.map(t.changes):new Si(this.source,1)}handleChange(t){return t.changes.touchesRange(ii(t.startState))?new Si(this.source,0):this.map(t.changes)}map(t){return t.empty||this.explicitPos<0?this:new Si(this.source,this.state,t.mapPos(this.explicitPos))}},iO=class Ss extends ti{constructor(t,i,r,n,s){super(t,2,i),this.result=r,this.from=n,this.to=s}hasResult(){return!0}handleUserEvent(t,i,r){var n;let s=this.result;s.map&&!t.changes.empty&&(s=s.map(s,t.changes));let o=t.changes.mapPos(this.from),a=t.changes.mapPos(this.to,1),l=ii(t.state);if((this.explicitPos<0?l<=o:l<this.from)||l>a||!s||i=="delete"&&ii(t.startState)==this.from)return new ti(this.source,i=="input"&&r.activateOnTyping?1:0);let h=this.explicitPos<0?-1:t.changes.mapPos(this.explicitPos);return xS(s.validFor,t.state,o,a)?new Ss(this.source,h,s,o,a):s.update&&(s=s.update(s,o,a,new ks(t.state,l,h>=0)))?new Ss(this.source,h,s,s.from,(n=s.to)!==null&&n!==void 0?n:ii(t.state)):new ti(this.source,1,h)}handleChange(t){return t.changes.touchesRange(this.from,this.to)?new ti(this.source,0):this.map(t.changes)}map(t){return t.empty?this:(this.result.map?this.result.map(this.result,t):this.result)?new Ss(this.source,this.explicitPos<0?-1:t.mapPos(this.explicitPos),this.result,t.mapPos(this.from),t.mapPos(this.to,1)):new ti(this.source,0)}};function xS(e,t,i,r){if(!e)return!1;let n=t.sliceDoc(i,r);return typeof e=="function"?e(n,i,r,t):tO(e,!0).test(n)}var rO=z.define({map(e,t){return e.map(i=>i.map(t))}}),nO=z.define(),Be=We.define({create(){return bS.start()},update(e,t){return e.update(t)},provide:e=>[gs.from(e,t=>t.tooltip),W.contentAttributes.from(e,t=>t.attrs)]});function Sl(e,t){let i=t.completion.apply||t.completion.label,r=e.state.field(Be).active.find(n=>n.source==t.source);return r instanceof iO?(typeof i=="string"?e.dispatch(Object.assign(Object.assign({},lS(e.state,i,r.from,r.to)),{annotations:vl.of(t.completion)})):i(e,t.completion,r.from,r.to),!0):!1}var PS=OS(Be,Sl);function vs(e,t="option"){return i=>{let r=i.state.field(Be,!1);if(!r||!r.open||r.open.disabled||Date.now()-r.open.timestamp<i.state.facet(Se).interactionDelay)return!1;let n=1,s;t=="page"&&(s=el(i,r.open.tooltip))&&(n=Math.max(2,Math.floor(s.dom.offsetHeight/s.dom.querySelector("li").offsetHeight)-1));let{length:o}=r.open.options,a=r.open.selected>-1?r.open.selected+n*(e?1:-1):e?0:o-1;return a<0?a=t=="page"?0:o-1:a>=o&&(a=t=="page"?o-1:0),i.dispatch({effects:nO.of(a)}),!0}}var kS=e=>{let t=e.state.field(Be,!1);return e.state.readOnly||!t||!t.open||t.open.selected<0||t.open.disabled||Date.now()-t.open.timestamp<e.state.facet(Se).interactionDelay?!1:Sl(e,t.open.options[t.open.selected])},QS=e=>e.state.field(Be,!1)?(e.dispatch({effects:xs.of(!0)}),!0):!1,$S=e=>{let t=e.state.field(Be,!1);return!t||!t.active.some(i=>i.state!=0)?!1:(e.dispatch({effects:Lr.of(null)}),!0)},TS=class{constructor(e,t){this.active=e,this.context=t,this.time=Date.now(),this.updates=[],this.done=void 0}},CS=50,AS=1e3,j2=ve.fromClass(class{constructor(e){this.view=e,this.debounceUpdate=-1,this.running=[],this.debounceAccept=-1,this.pendingStart=!1,this.composing=0;for(let t of e.state.field(Be).active)t.state==1&&this.startQuery(t)}update(e){let t=e.state.field(Be),i=e.state.facet(Se);if(!e.selectionSet&&!e.docChanged&&e.startState.field(Be)==t)return;let r=e.transactions.some(s=>(s.selection||s.docChanged)&&!bl(s,i));for(let s=0;s<this.running.length;s++){let o=this.running[s];if(r||o.updates.length+e.transactions.length>CS&&Date.now()-o.time>AS){for(let a of o.context.abortListeners)try{a()}catch(l){Te(this.view.state,l)}o.context.abortListeners=null,this.running.splice(s--,1)}else o.updates.push(...e.transactions)}this.debounceUpdate>-1&&clearTimeout(this.debounceUpdate),e.transactions.some(s=>s.effects.some(o=>o.is(xs)))&&(this.pendingStart=!0);let n=this.pendingStart?50:i.activateOnTypingDelay;if(this.debounceUpdate=t.active.some(s=>s.state==1&&!this.running.some(o=>o.active.source==s.source))?setTimeout(()=>this.startUpdate(),n):-1,this.composing!=0)for(let s of e.transactions)bl(s,i)=="input"?this.composing=2:this.composing==2&&s.selection&&(this.composing=3)}startUpdate(){this.debounceUpdate=-1,this.pendingStart=!1;let{state:e}=this.view,t=e.field(Be);for(let i of t.active)i.state==1&&!this.running.some(r=>r.active.source==i.source)&&this.startQuery(i)}startQuery(e){let{state:t}=this.view,i=ii(t),r=new ks(t,i,e.explicitPos==i),n=new TS(e,r);this.running.push(n),Promise.resolve(e.source(r)).then(s=>{n.context.aborted||(n.done=s||null,this.scheduleAccept())},s=>{this.view.dispatch({effects:Lr.of(null)}),Te(this.view.state,s)})}scheduleAccept(){this.running.every(e=>e.done!==void 0)?this.accept():this.debounceAccept<0&&(this.debounceAccept=setTimeout(()=>this.accept(),this.view.state.facet(Se).updateSyncTime))}accept(){var e;this.debounceAccept>-1&&clearTimeout(this.debounceAccept),this.debounceAccept=-1;let t=[],i=this.view.state.facet(Se);for(let r=0;r<this.running.length;r++){let n=this.running[r];if(n.done===void 0)continue;if(this.running.splice(r--,1),n.done){let o=new iO(n.active.source,n.active.explicitPos,n.done,n.done.from,(e=n.done.to)!==null&&e!==void 0?e:ii(n.updates.length?n.updates[0].startState:this.view.state));for(let a of n.updates)o=o.update(a,i);if(o.hasResult()){t.push(o);continue}}let s=this.view.state.field(Be).active.find(o=>o.source==n.active.source);if(s&&s.state==1)if(n.done==null){let o=new ti(n.active.source,0);for(let a of n.updates)o=o.update(a,i);o.state!=1&&t.push(o)}else this.startQuery(s)}t.length&&this.view.dispatch({effects:rO.of(t)})}},{eventHandlers:{blur(e){let t=this.view.state.field(Be,!1);if(t&&t.tooltip&&this.view.state.facet(Se).closeOnBlur){let i=t.open&&el(this.view,t.open.tooltip);(!i||!i.dom.contains(e.relatedTarget))&&setTimeout(()=>this.view.dispatch({effects:Lr.of(null)}),10)}},compositionstart(){this.composing=1},compositionend(){this.composing==3&&setTimeout(()=>this.view.dispatch({effects:xs.of(!1)}),20),this.composing=0}}}),ZS=typeof navigator=="object"&&/Win/.test(navigator.platform),D2=_e.highest(W.domEventHandlers({keydown(e,t){let i=t.state.field(Be,!1);if(!i||!i.open||i.open.disabled||i.open.selected<0||e.key.length>1||e.ctrlKey&&!(ZS&&e.altKey)||e.metaKey)return!1;let r=i.open.options[i.open.selected],n=i.active.find(o=>o.source==r.source),s=r.completion.commitCharacters||n.result.commitCharacters;return s&&s.indexOf(e.key)>-1&&Sl(t,r),!1}})),ES=W.baseTheme({".cm-tooltip.cm-tooltip-autocomplete":{"& > ul":{fontFamily:"monospace",whiteSpace:"nowrap",overflow:"hidden auto",maxWidth_fallback:"700px",maxWidth:"min(700px, 95vw)",minWidth:"250px",maxHeight:"10em",height:"100%",listStyle:"none",margin:0,padding:0,"& > li, & > completion-section":{padding:"1px 3px",lineHeight:1.2},"& > li":{overflowX:"hidden",textOverflow:"ellipsis",cursor:"pointer"},"& > completion-section":{display:"list-item",borderBottom:"1px solid silver",paddingLeft:"0.5em",opacity:.7}}},"&light .cm-tooltip-autocomplete ul li[aria-selected]":{background:"#17c",color:"white"},"&light .cm-tooltip-autocomplete-disabled ul li[aria-selected]":{background:"#777"},"&dark .cm-tooltip-autocomplete ul li[aria-selected]":{background:"#347",color:"white"},"&dark .cm-tooltip-autocomplete-disabled ul li[aria-selected]":{background:"#444"},".cm-completionListIncompleteTop:before, .cm-completionListIncompleteBottom:after":{content:'"\xB7\xB7\xB7"',opacity:.5,display:"block",textAlign:"center"},".cm-tooltip.cm-completionInfo":{position:"absolute",padding:"3px 9px",width:"max-content",maxWidth:"400px",boxSizing:"border-box"},".cm-completionInfo.cm-completionInfo-left":{right:"100%"},".cm-completionInfo.cm-completionInfo-right":{left:"100%"},".cm-completionInfo.cm-completionInfo-left-narrow":{right:"30px"},".cm-completionInfo.cm-completionInfo-right-narrow":{left:"30px"},"&light .cm-snippetField":{backgroundColor:"#00000022"},"&dark .cm-snippetField":{backgroundColor:"#ffffff22"},".cm-snippetFieldPosition":{verticalAlign:"text-top",width:0,height:"1.15em",display:"inline-block",margin:"0 -0.7px -.7em",borderLeft:"1.4px dotted #888"},".cm-completionMatchedText":{textDecoration:"underline"},".cm-completionDetail":{marginLeft:"0.5em",fontStyle:"italic"},".cm-completionIcon":{fontSize:"90%",width:".8em",display:"inline-block",textAlign:"center",paddingRight:".6em",opacity:"0.6",boxSizing:"content-box"},".cm-completionIcon-function, .cm-completionIcon-method":{"&:after":{content:"'\u0192'"}},".cm-completionIcon-class":{"&:after":{content:"'\u25CB'"}},".cm-completionIcon-interface":{"&:after":{content:"'\u25CC'"}},".cm-completionIcon-variable":{"&:after":{content:"'\u{1D465}'"}},".cm-completionIcon-constant":{"&:after":{content:"'\u{1D436}'"}},".cm-completionIcon-type":{"&:after":{content:"'\u{1D461}'"}},".cm-completionIcon-enum":{"&:after":{content:"'\u222A'"}},".cm-completionIcon-property":{"&:after":{content:"'\u25A1'"}},".cm-completionIcon-keyword":{"&:after":{content:"'\u{1F511}\uFE0E'"}},".cm-completionIcon-namespace":{"&:after":{content:"'\u25A2'"}},".cm-completionIcon-text":{"&:after":{content:"'abc'",fontSize:"50%",verticalAlign:"middle"}}}),RS=class{constructor(e,t,i,r){this.field=e,this.line=t,this.from=i,this.to=r}},XS=class sO{constructor(t,i,r){this.field=t,this.from=i,this.to=r}map(t){let i=t.mapPos(this.from,-1,ge.TrackDel),r=t.mapPos(this.to,1,ge.TrackDel);return i==null||r==null?null:new sO(this.field,i,r)}},MS=class oO{constructor(t,i){this.lines=t,this.fieldPositions=i}instantiate(t,i){let r=[],n=[i],s=t.doc.lineAt(i),o=/^\s*/.exec(s.text)[0];for(let l of this.lines){if(r.length){let h=o,c=/^\t*/.exec(l)[0].length;for(let u=0;u<c;u++)h+=t.facet(Yr);n.push(i+h.length-c),l=h+l.slice(c)}r.push(l),i+=l.length+1}let a=this.fieldPositions.map(l=>new XS(l.field,n[l.line]+l.from,n[l.line]+l.to));return{text:r,ranges:a}}static parse(t){let i=[],r=[],n=[],s;for(let o of t.split(/\r\n?|\n/)){for(;s=/[#$]\{(?:(\d+)(?::([^}]*))?|([^}]*))\}/.exec(o);){let a=s[1]?+s[1]:null,l=s[2]||s[3]||"",h=-1;for(let c=0;c<i.length;c++)(a!=null?i[c].seq==a:l&&i[c].name==l)&&(h=c);if(h<0){let c=0;for(;c<i.length&&(a==null||i[c].seq!=null&&i[c].seq<a);)c++;i.splice(c,0,{seq:a,name:l}),h=c;for(let u of n)u.field>=h&&u.field++}n.push(new RS(h,r.length,s.index,s.index+l.length)),o=o.slice(0,s.index)+l+o.slice(s.index+s[0].length)}for(let a;a=/\\([{}])/.exec(o);){o=o.slice(0,a.index)+a[1]+o.slice(a.index+a[0].length);for(let l of n)l.line==r.length&&l.from>a.index&&(l.from--,l.to--)}r.push(o)}return new oO(r,n)}},WS=j.widget({widget:new class extends Jt{toDOM(){let e=document.createElement("span");return e.className="cm-snippetFieldPosition",e}ignoreEvent(){return!1}}}),qS=j.mark({class:"cm-snippetField"}),Qs=class aO{constructor(t,i){this.ranges=t,this.active=i,this.deco=j.set(t.map(r=>(r.from==r.to?WS:qS).range(r.from,r.to)))}map(t){let i=[];for(let r of this.ranges){let n=r.map(t);if(!n)return null;i.push(n)}return new aO(i,this.active)}selectionInsideField(t){return t.ranges.every(i=>this.ranges.some(r=>r.field==this.active&&r.from<=i.from&&r.to>=i.to))}},Nr=z.define({map(e,t){return e&&e.map(t)}}),YS=z.define(),Vr=We.define({create(){return null},update(e,t){for(let i of t.effects){if(i.is(Nr))return i.value;if(i.is(YS)&&e)return new Qs(e.ranges,i.value)}return e&&t.docChanged&&(e=e.map(t.changes)),e&&t.selection&&!e.selectionInsideField(t.selection)&&(e=null),e},provide:e=>W.decorations.from(e,t=>t?t.deco:j.none)});function xl(e,t){return $.create(e.filter(i=>i.field==t).map(i=>$.range(i.from,i.to)))}function IS(e){let t=MS.parse(e);return(i,r,n,s)=>{let{text:o,ranges:a}=t.instantiate(i.state,n),l={changes:{from:n,to:s,insert:G.of(o)},scrollIntoView:!0,annotations:r?[vl.of(r),Me.userEvent.of("input.complete")]:void 0};if(a.length&&(l.selection=xl(a,0)),a.some(h=>h.field>0)){let h=new Qs(a,0),c=l.effects=[Nr.of(h)];i.state.field(Vr,!1)===void 0&&c.push(z.appendConfig.of([Vr,DS,_S,ES]))}i.dispatch(i.state.update(l))}}function lO(e){return({state:t,dispatch:i})=>{let r=t.field(Vr,!1);if(!r||e<0&&r.active==0)return!1;let n=r.active+e,s=e>0&&!r.ranges.some(o=>o.field==n+e);return i(t.update({selection:xl(r.ranges,n),effects:Nr.of(s?null:new Qs(r.ranges,n)),scrollIntoView:!0})),!0}}var LS=({state:e,dispatch:t})=>e.field(Vr,!1)?(t(e.update({effects:Nr.of(null)})),!0):!1,VS=lO(1),NS=lO(-1);var jS=[{key:"Tab",run:VS,shift:NS},{key:"Escape",run:LS}],Hp=E.define({combine(e){return e.length?e[0]:jS}}),DS=_e.highest(_i.compute([Hp],e=>e.facet(Hp)));function Ae(e,t){return Object.assign(Object.assign({},t),{apply:IS(e)})}var _S=W.domEventHandlers({mousedown(e,t){let i=t.state.field(Vr,!1),r;if(!i||(r=t.posAtCoords({x:e.clientX,y:e.clientY}))==null)return!1;let n=i.ranges.find(s=>s.from<=r&&s.to>=r);return!n||n.field==i.active?!1:(t.dispatch({selection:xl(i.ranges,n.field),effects:Nr.of(i.ranges.some(s=>s.field>n.field)?new Qs(i.ranges,n.field):null),scrollIntoView:!0}),!0)}});var Ps={brackets:["(","[","{","'",'"'],before:")]}:;>",stringPrefixes:[]},xi=z.define({map(e,t){return t.mapPos(e,-1,ge.TrackAfter)??void 0}}),Pl=new class extends Et{};Pl.startSide=1;Pl.endSide=-1;var US=We.define({create(){return ie.empty},update(e,t){if(e=e.map(t.changes),t.selection){let i=t.state.doc.lineAt(t.selection.main.head);e=e.update({filter:r=>r>=i.from&&r<=i.to})}for(let i of t.effects)i.is(xi)&&(e=e.update({add:[Pl.range(i.value,i.value+1)]}));return e}});var gl="()[]{}<>";function zS(e){for(let t=0;t<gl.length;t+=2)if(gl.charCodeAt(t)==e)return gl.charAt(t+1);return Ho(e<128?e:e+1)}function BS(e,t){return e.languageDataAt("closeBrackets",t)[0]||Ps}var GS=typeof navigator=="object"&&/Android\b/.test(navigator.userAgent),_2=W.inputHandler.of((e,t,i,r)=>{if((GS?e.composing:e.compositionStarted)||e.state.readOnly)return!1;let n=e.state.selection.main;if(r.length>2||r.length==2&&nt(Qe(r,0))==1||t!=n.from||i!=n.to)return!1;let s=FS(e.state,r);return s?(e.dispatch(s),!0):!1});function FS(e,t){let i=BS(e,e.selection.main.head),r=i.brackets||Ps.brackets;for(let n of r){let s=zS(Qe(n,0));if(t==n)return s==n?JS(e,n,r.indexOf(n+n+n)>-1,i):HS(e,n,s,i.before||Ps.before);if(t==s&&hO(e,e.selection.main.from))return KS(e,n,s)}return null}function hO(e,t){let i=!1;return e.field(US).between(0,e.doc.length,r=>{r==t&&(i=!0)}),i}function kl(e,t){let i=e.sliceString(t,t+2);return i.slice(0,nt(Qe(i,0)))}function HS(e,t,i,r){let n=null,s=e.changeByRange(o=>{if(!o.empty)return{changes:[{insert:t,from:o.from},{insert:i,from:o.to}],effects:xi.of(o.to+t.length),range:$.range(o.anchor+t.length,o.head+t.length)};let a=kl(e.doc,o.head);return!a||/\s/.test(a)||r.indexOf(a)>-1?{changes:{insert:t+i,from:o.head},effects:xi.of(o.head+t.length),range:$.cursor(o.head+t.length)}:{range:n=o}});return n?null:e.update(s,{scrollIntoView:!0,userEvent:"input.type"})}function KS(e,t,i){let r=null,n=e.changeByRange(s=>s.empty&&kl(e.doc,s.head)==i?{changes:{from:s.head,to:s.head+i.length,insert:i},range:$.cursor(s.head+i.length)}:r={range:s});return r?null:e.update(n,{scrollIntoView:!0,userEvent:"input.type"})}function JS(e,t,i,r){let n=r.stringPrefixes||Ps.stringPrefixes,s=null,o=e.changeByRange(a=>{if(!a.empty)return{changes:[{insert:t,from:a.from},{insert:t,from:a.to}],effects:xi.of(a.to+t.length),range:$.range(a.anchor+t.length,a.head+t.length)};let l=a.head,h=kl(e.doc,l),c;if(h==t){if(Kp(e,l))return{changes:{insert:t+t,from:l},effects:xi.of(l+t.length),range:$.cursor(l+t.length)};if(hO(e,l)){let u=i&&e.sliceDoc(l,l+t.length*3)==t+t+t?t+t+t:t;return{changes:{from:l,to:l+u.length,insert:u},range:$.cursor(l+u.length)}}}else{if(i&&e.sliceDoc(l-2*t.length,l)==t+t&&(c=Jp(e,l-2*t.length,n))>-1&&Kp(e,c))return{changes:{insert:t+t+t+t,from:l},effects:xi.of(l+t.length),range:$.cursor(l+t.length)};if(e.charCategorizer(l)(h)!=Xe.Word&&Jp(e,l,n)>-1&&!ex(e,l,t,n))return{changes:{insert:t+t,from:l},effects:xi.of(l+t.length),range:$.cursor(l+t.length)}}return{range:s=a}});return s?null:e.update(o,{scrollIntoView:!0,userEvent:"input.type"})}function Kp(e,t){let i=te(e).resolveInner(t+1);return i.parent&&i.from==t}function ex(e,t,i,r){let n=te(e).resolveInner(t,-1),s=r.reduce((o,a)=>Math.max(o,a.length),0);for(let o=0;o<5;o++){let a=e.sliceDoc(n.from,Math.min(n.to,n.from+i.length+s)),l=a.indexOf(i);if(!l||l>-1&&r.indexOf(a.slice(0,l))>-1){let c=n.firstChild;for(;c&&c.from==n.from&&c.to-c.from>i.length+l;){if(e.sliceDoc(c.to-i.length,c.to)==i)return!1;c=c.firstChild}return!0}let h=n.to==t&&n.parent;if(!h)break;n=h}return!1}function Jp(e,t,i){let r=e.charCategorizer(t);if(r(e.sliceDoc(t-1,t))!=Xe.Word)return t;for(let n of i){let s=t-n.length;if(e.sliceDoc(s,t)==n&&r(e.sliceDoc(s-1,s))!=Xe.Word)return s}return-1}var tx=[{key:"Ctrl-Space",run:QS},{key:"Escape",run:$S},{key:"ArrowDown",run:vs(!0)},{key:"ArrowUp",run:vs(!1)},{key:"PageDown",run:vs(!0,"page")},{key:"PageUp",run:vs(!1,"page")},{key:"Enter",run:kS}],U2=_e.highest(_i.computeN([Se],e=>e.facet(Se).defaultKeymap?[tx]:[]));var Fi=typeof Reflect=="object"?Reflect:null,cO=Fi&&typeof Fi.apply=="function"?Fi.apply:function(e,t,i){return Function.prototype.apply.call(e,t,i)},$s;Fi&&typeof Fi.ownKeys=="function"?$s=Fi.ownKeys:Object.getOwnPropertySymbols?$s=function(e){return Object.getOwnPropertyNames(e).concat(Object.getOwnPropertySymbols(e))}:$s=function(e){return Object.getOwnPropertyNames(e)};function ix(e){console&&console.warn&&console.warn(e)}var OO=Number.isNaN||function(e){return e!==e};function F(){mO.call(this)}F.EventEmitter=F,F.prototype._events=void 0,F.prototype._eventsCount=0,F.prototype._maxListeners=void 0;var uO=10;function Ts(e){if(typeof e!="function")throw new TypeError('The "listener" argument must be of type Function. Received type '+typeof e)}Object.defineProperty(F,"defaultMaxListeners",{enumerable:!0,get:function(){return uO},set:function(e){if(typeof e!="number"||e<0||OO(e))throw new RangeError('The value of "defaultMaxListeners" is out of range. It must be a non-negative number. Received '+e+".");uO=e}});function mO(){(this._events===void 0||this._events===Object.getPrototypeOf(this)._events)&&(this._events=Object.create(null),this._eventsCount=0),this._maxListeners=this._maxListeners||void 0}F.init=mO,F.prototype.setMaxListeners=function(e){if(typeof e!="number"||e<0||OO(e))throw new RangeError('The value of "n" is out of range. It must be a non-negative number. Received '+e+".");return this._maxListeners=e,this};function gO(e){return e._maxListeners===void 0?F.defaultMaxListeners:e._maxListeners}F.prototype.getMaxListeners=function(){return gO(this)},F.prototype.emit=function(e){for(var t=[],i=1;i<arguments.length;i++)t.push(arguments[i]);var r=e==="error",n=this._events;if(n!==void 0)r=r&&n.error===void 0;else if(!r)return!1;if(r){var s;if(t.length>0&&(s=t[0]),s instanceof Error)throw s;var o=new Error("Unhandled error."+(s?" ("+s.message+")":""));throw o.context=s,o}var a=n[e];if(a===void 0)return!1;if(typeof a=="function")cO(a,this,t);else for(var l=a.length,h=yO(a,l),i=0;i<l;++i)cO(h[i],this,t);return!0};function dO(e,t,i,r){var n,s,o;if(Ts(i),s=e._events,s===void 0?(s=e._events=Object.create(null),e._eventsCount=0):(s.newListener!==void 0&&(e.emit("newListener",t,i.listener?i.listener:i),s=e._events),o=s[t]),o===void 0)o=s[t]=i,++e._eventsCount;else if(typeof o=="function"?o=s[t]=r?[i,o]:[o,i]:r?o.unshift(i):o.push(i),n=gO(e),n>0&&o.length>n&&!o.warned){o.warned=!0;var a=new Error("Possible EventEmitter memory leak detected. "+o.length+" "+String(t)+" listeners added. Use emitter.setMaxListeners() to increase limit");a.name="MaxListenersExceededWarning",a.emitter=e,a.type=t,a.count=o.length,ix(a)}return e}F.prototype.addListener=function(e,t){return dO(this,e,t,!1)},F.prototype.on=F.prototype.addListener,F.prototype.prependListener=function(e,t){return dO(this,e,t,!0)};function rx(){if(!this.fired)return this.target.removeListener(this.type,this.wrapFn),this.fired=!0,arguments.length===0?this.listener.call(this.target):this.listener.apply(this.target,arguments)}function fO(e,t,i){var r={fired:!1,wrapFn:void 0,target:e,type:t,listener:i},n=rx.bind(r);return n.listener=i,r.wrapFn=n,n}F.prototype.once=function(e,t){return Ts(t),this.on(e,fO(this,e,t)),this},F.prototype.prependOnceListener=function(e,t){return Ts(t),this.prependListener(e,fO(this,e,t)),this},F.prototype.removeListener=function(e,t){var i,r,n,s,o;if(Ts(t),r=this._events,r===void 0)return this;if(i=r[e],i===void 0)return this;if(i===t||i.listener===t)--this._eventsCount===0?this._events=Object.create(null):(delete r[e],r.removeListener&&this.emit("removeListener",e,i.listener||t));else if(typeof i!="function"){for(n=-1,s=i.length-1;s>=0;s--)if(i[s]===t||i[s].listener===t){o=i[s].listener,n=s;break}if(n<0)return this;n===0?i.shift():sx(i,n),i.length===1&&(r[e]=i[0]),r.removeListener!==void 0&&this.emit("removeListener",e,o||t)}return this},F.prototype.off=F.prototype.removeListener,F.prototype.removeAllListeners=function(e){var t,i,r;if(i=this._events,i===void 0)return this;if(i.removeListener===void 0)return arguments.length===0?(this._events=Object.create(null),this._eventsCount=0):i[e]!==void 0&&(--this._eventsCount===0?this._events=Object.create(null):delete i[e]),this;if(arguments.length===0){var n=Object.keys(i),s;for(r=0;r<n.length;++r)s=n[r],s!=="removeListener"&&this.removeAllListeners(s);return this.removeAllListeners("removeListener"),this._events=Object.create(null),this._eventsCount=0,this}if(t=i[e],typeof t=="function")this.removeListener(e,t);else if(t!==void 0)for(r=t.length-1;r>=0;r--)this.removeListener(e,t[r]);return this};function pO(e,t,i){var r=e._events;if(r===void 0)return[];var n=r[t];return n===void 0?[]:typeof n=="function"?i?[n.listener||n]:[n]:i?ox(n):yO(n,n.length)}F.prototype.listeners=function(e){return pO(this,e,!0)},F.prototype.rawListeners=function(e){return pO(this,e,!1)};function nx(e,t){return typeof e.listenerCount=="function"?e.listenerCount(t):F.prototype.listenerCount.call(e,t)}F.listenerCount=nx,F.prototype.listenerCount=function(e){var t=this._events;if(t!==void 0){var i=t[e];if(typeof i=="function")return 1;if(i!==void 0)return i.length}return 0},F.prototype.eventNames=function(){return this._eventsCount>0?$s(this._events):[]};function yO(e,t){for(var i=new Array(t),r=0;r<t;++r)i[r]=e[r];return i}function sx(e,t){for(;t+1<e.length;t++)e[t]=e[t+1];e.pop()}function ox(e){for(var t=new Array(e.length),i=0;i<t.length;++i)t[i]=e[i].listener||e[i];return t}function Ql(e){let t=performance.now(),i=Math.floor(t/1e3),r=Math.floor(t*1e6-i*1e9);if(!e)return[i,r];let[n,s]=e;return[i-n,r-s]}Ql.bigint=function(){let[e,t]=Ql();return BigInt(e)*1000000000n+BigInt(t)};var $l=class extends F{title="browser";browser=!0;env={};argv=[];pid=0;arch="unknown";platform="browser";version="";versions={};emitWarning=()=>{throw new Error("process.emitWarning is not supported")};binding=()=>{throw new Error("process.binding is not supported")};cwd=()=>{throw new Error("process.cwd is not supported")};chdir=t=>{throw new Error("process.chdir is not supported")};umask=()=>18;nextTick=(t,...i)=>queueMicrotask(()=>t(...i));hrtime=Ql;constructor(){super()}},Ye=new $l;if(typeof Deno<"u"){Ye.name="deno",Ye.browser=!1,Ye.pid=Deno.pid,Ye.cwd=()=>Deno.cwd(),Ye.chdir=t=>Deno.chdir(t),Ye.arch=Deno.build.arch,Ye.platform=Deno.build.os,Ye.version="v18.12.1",Ye.versions={node:"18.12.1",uv:"1.43.0",zlib:"1.2.11",brotli:"1.0.9",ares:"1.18.1",modules:"108",nghttp2:"1.47.0",napi:"8",llhttp:"6.0.10",openssl:"3.0.7+quic",cldr:"41.0",icu:"71.1",tz:"2022b",unicode:"14.0",ngtcp2:"0.8.1",nghttp3:"0.7.0",...Deno.version},Ye.env=new Proxy({},{get(t,i){return Deno.env.get(String(i))},ownKeys:()=>Reflect.ownKeys(Deno.env.toObject()),getOwnPropertyDescriptor:(t,i)=>{let r=Deno.env.toObject();if(i in Deno.env.toObject()){let n={enumerable:!0,configurable:!0};return typeof i=="string"&&(n.value=r[i]),n}},set(t,i,r){return Deno.env.set(String(i),String(r)),r}});let e=["","",...Deno.args];Object.defineProperty(e,"0",{get:Deno.execPath}),Object.defineProperty(e,"1",{get:()=>Deno.mainModule.startsWith("file:")?new URL(Deno.mainModule).pathname:join(Deno.cwd(),"$deno$node.js")}),Ye.argv=e}else{let e="/";Ye.cwd=()=>e,Ye.chdir=t=>e=t}var Cs=Ye;var ax=class Al{constructor(t,i,r,n,s,o,a,l,h,c=0,u){this.p=t,this.stack=i,this.state=r,this.reducePos=n,this.pos=s,this.score=o,this.buffer=a,this.bufferBase=l,this.curContext=h,this.lookAhead=c,this.parent=u}toString(){return`[${this.stack.filter((t,i)=>i%3==0).concat(this.state)}]@${this.pos}${this.score?"!"+this.score:""}`}static start(t,i,r=0){let n=t.parser.context;return new Al(t,[],i,r,r,0,[],0,n?new bO(n,n.start):null,0,null)}get context(){return this.curContext?this.curContext.context:null}pushState(t,i){this.stack.push(this.state,i,this.bufferBase+this.buffer.length),this.state=t}reduce(t){var i;let r=t>>19,n=t&65535,{parser:s}=this.p,o=s.dynamicPrecedence(n);if(o&&(this.score+=o),r==0){this.pushState(s.getGoto(this.state,n,!0),this.reducePos),n<s.minRepeatTerm&&this.storeNode(n,this.reducePos,this.reducePos,4,!0),this.reduceContext(n,this.reducePos);return}let a=this.stack.length-(r-1)*3-(t&262144?6:0),l=a?this.stack[a-2]:this.p.ranges[0].from,h=this.reducePos-l;h>=2e3&&!(!((i=this.p.parser.nodeSet.types[n])===null||i===void 0)&&i.isAnonymous)&&(l==this.p.lastBigReductionStart?(this.p.bigReductionCount++,this.p.lastBigReductionSize=h):this.p.lastBigReductionSize<h&&(this.p.bigReductionCount=1,this.p.lastBigReductionStart=l,this.p.lastBigReductionSize=h));let c=a?this.stack[a-1]:0,u=this.bufferBase+this.buffer.length-c;if(n<s.minRepeatTerm||t&131072){let d=s.stateFlag(this.state,1)?this.pos:this.reducePos;this.storeNode(n,l,d,u+4,!0)}if(t&262144)this.state=this.stack[a];else{let d=this.stack[a-3];this.state=s.getGoto(d,n,!0)}for(;this.stack.length>a;)this.stack.pop();this.reduceContext(n,l)}storeNode(t,i,r,n=4,s=!1){if(t==0&&(!this.stack.length||this.stack[this.stack.length-1]<this.buffer.length+this.bufferBase)){let o=this,a=this.buffer.length;if(a==0&&o.parent&&(a=o.bufferBase-o.parent.bufferBase,o=o.parent),a>0&&o.buffer[a-4]==0&&o.buffer[a-1]>-1){if(i==r)return;if(o.buffer[a-2]>=i){o.buffer[a-2]=r;return}}}if(!s||this.pos==r)this.buffer.push(t,i,r,n);else{let o=this.buffer.length;if(o>0&&this.buffer[o-4]!=0)for(;o>0&&this.buffer[o-2]>r;)this.buffer[o]=this.buffer[o-4],this.buffer[o+1]=this.buffer[o-3],this.buffer[o+2]=this.buffer[o-2],this.buffer[o+3]=this.buffer[o-1],o-=4,n>4&&(n-=4);this.buffer[o]=t,this.buffer[o+1]=i,this.buffer[o+2]=r,this.buffer[o+3]=n}}shift(t,i,r,n){if(t&131072)this.pushState(t&65535,this.pos);else if(t&262144)this.pos=n,this.shiftContext(i,r),i<=this.p.parser.maxNode&&this.buffer.push(i,r,n,4);else{let s=t,{parser:o}=this.p;(n>this.pos||i<=o.maxNode)&&(this.pos=n,o.stateFlag(s,1)||(this.reducePos=n)),this.pushState(s,r),this.shiftContext(i,r),i<=o.maxNode&&this.buffer.push(i,r,n,4)}}apply(t,i,r,n){t&65536?this.reduce(t):this.shift(t,i,r,n)}useNode(t,i){let r=this.p.reused.length-1;(r<0||this.p.reused[r]!=t)&&(this.p.reused.push(t),r++);let n=this.pos;this.reducePos=this.pos=n+t.length,this.pushState(i,n),this.buffer.push(r,n,this.reducePos,-1),this.curContext&&this.updateContext(this.curContext.tracker.reuse(this.curContext.context,t,this,this.p.stream.reset(this.pos-t.length)))}split(){let t=this,i=t.buffer.length;for(;i>0&&t.buffer[i-2]>t.reducePos;)i-=4;let r=t.buffer.slice(i),n=t.bufferBase+i;for(;t&&n==t.bufferBase;)t=t.parent;return new Al(this.p,this.stack.slice(),this.state,this.reducePos,this.pos,this.score,r,n,this.curContext,this.lookAhead,t)}recoverByDelete(t,i){let r=t<=this.p.parser.maxNode;r&&this.storeNode(t,this.pos,i,4),this.storeNode(0,this.pos,i,r?8:4),this.pos=this.reducePos=i,this.score-=190}canShift(t){for(let i=new lx(this);;){let r=this.p.parser.stateSlot(i.state,4)||this.p.parser.hasAction(i.state,t);if(r==0)return!1;if(!(r&65536))return!0;i.reduce(r)}}recoverByInsert(t){if(this.stack.length>=300)return[];let i=this.p.parser.nextStates(this.state);if(i.length>8||this.stack.length>=120){let n=[];for(let s=0,o;s<i.length;s+=2)(o=i[s+1])!=this.state&&this.p.parser.hasAction(o,t)&&n.push(i[s],o);if(this.stack.length<120)for(let s=0;n.length<8&&s<i.length;s+=2){let o=i[s+1];n.some((a,l)=>l&1&&a==o)||n.push(i[s],o)}i=n}let r=[];for(let n=0;n<i.length&&r.length<4;n+=2){let s=i[n+1];if(s==this.state)continue;let o=this.split();o.pushState(s,this.pos),o.storeNode(0,o.pos,o.pos,4,!0),o.shiftContext(i[n],this.pos),o.reducePos=this.pos,o.score-=200,r.push(o)}return r}forceReduce(){let{parser:t}=this.p,i=t.stateSlot(this.state,5);if(!(i&65536))return!1;if(!t.validAction(this.state,i)){let r=i>>19,n=i&65535,s=this.stack.length-r*3;if(s<0||t.getGoto(this.stack[s],n,!1)<0){let o=this.findForcedReduction();if(o==null)return!1;i=o}this.storeNode(0,this.pos,this.pos,4,!0),this.score-=100}return this.reducePos=this.pos,this.reduce(i),!0}findForcedReduction(){let{parser:t}=this.p,i=[],r=(n,s)=>{if(!i.includes(n))return i.push(n),t.allActions(n,o=>{if(!(o&393216))if(o&65536){let a=(o>>19)-s;if(a>1){let l=o&65535,h=this.stack.length-a*3;if(h>=0&&t.getGoto(this.stack[h],l,!1)>=0)return a<<19|65536|l}}else{let a=r(o,s+1);if(a!=null)return a}})};return r(this.state,0)}forceAll(){for(;!this.p.parser.stateFlag(this.state,2);)if(!this.forceReduce()){this.storeNode(0,this.pos,this.pos,4,!0);break}return this}get deadEnd(){if(this.stack.length!=3)return!1;let{parser:t}=this.p;return t.data[t.stateSlot(this.state,1)]==65535&&!t.stateSlot(this.state,4)}restart(){this.storeNode(0,this.pos,this.pos,4,!0),this.state=this.stack[0],this.stack.length=0}sameState(t){if(this.state!=t.state||this.stack.length!=t.stack.length)return!1;for(let i=0;i<this.stack.length;i+=3)if(this.stack[i]!=t.stack[i])return!1;return!0}get parser(){return this.p.parser}dialectEnabled(t){return this.p.parser.dialect.flags[t]}shiftContext(t,i){this.curContext&&this.updateContext(this.curContext.tracker.shift(this.curContext.context,t,this,this.p.stream.reset(i)))}reduceContext(t,i){this.curContext&&this.updateContext(this.curContext.tracker.reduce(this.curContext.context,t,this,this.p.stream.reset(i)))}emitContext(){let t=this.buffer.length-1;(t<0||this.buffer[t]!=-3)&&this.buffer.push(this.curContext.hash,this.pos,this.pos,-3)}emitLookAhead(){let t=this.buffer.length-1;(t<0||this.buffer[t]!=-4)&&this.buffer.push(this.lookAhead,this.pos,this.pos,-4)}updateContext(t){if(t!=this.curContext.context){let i=new bO(this.curContext.tracker,t);i.hash!=this.curContext.hash&&this.emitContext(),this.curContext=i}}setLookAhead(t){t>this.lookAhead&&(this.emitLookAhead(),this.lookAhead=t)}close(){this.curContext&&this.curContext.tracker.strict&&this.emitContext(),this.lookAhead>0&&this.emitLookAhead()}},bO=class{constructor(e,t){this.tracker=e,this.context=t,this.hash=e.strict?e.hash(t):0}},lx=class{constructor(e){this.start=e,this.state=e.state,this.stack=e.stack,this.base=this.stack.length}reduce(e){let t=e&65535,i=e>>19;i==0?(this.stack==this.start.stack&&(this.stack=this.stack.slice()),this.stack.push(this.state,0,0),this.base+=3):this.base-=(i-1)*3;let r=this.start.p.parser.getGoto(this.stack[this.base-3],t,!0);this.state=r}},hx=class Zl{constructor(t,i,r){this.stack=t,this.pos=i,this.index=r,this.buffer=t.buffer,this.index==0&&this.maybeNext()}static create(t,i=t.bufferBase+t.buffer.length){return new Zl(t,i,i-t.bufferBase)}maybeNext(){let t=this.stack.parent;t!=null&&(this.index=this.stack.bufferBase-t.bufferBase,this.stack=t,this.buffer=t.buffer)}get id(){return this.buffer[this.index-4]}get start(){return this.buffer[this.index-3]}get end(){return this.buffer[this.index-2]}get size(){return this.buffer[this.index-1]}next(){this.index-=4,this.pos-=4,this.index==0&&this.maybeNext()}fork(){return new Zl(this.stack,this.pos,this.index)}};function jr(e,t=Uint16Array){if(typeof e!="string")return e;let i=null;for(let r=0,n=0;r<e.length;){let s=0;for(;;){let o=e.charCodeAt(r++),a=!1;if(o==126){s=65535;break}o>=92&&o--,o>=34&&o--;let l=o-32;if(l>=46&&(l-=46,a=!0),s+=l,a)break;s*=46}i?i[n++]=s:i=new t(s)}return i}var As=class{constructor(){this.start=-1,this.value=-1,this.end=-1,this.extended=-1,this.lookAhead=0,this.mask=0,this.context=0}},wO=new As,cx=class{constructor(e,t){this.input=e,this.ranges=t,this.chunk="",this.chunkOff=0,this.chunk2="",this.chunk2Pos=0,this.next=-1,this.token=wO,this.rangeIndex=0,this.pos=this.chunkPos=t[0].from,this.range=t[0],this.end=t[t.length-1].to,this.readNext()}resolveOffset(e,t){let i=this.range,r=this.rangeIndex,n=this.pos+e;for(;n<i.from;){if(!r)return null;let s=this.ranges[--r];n-=i.from-s.to,i=s}for(;t<0?n>i.to:n>=i.to;){if(r==this.ranges.length-1)return null;let s=this.ranges[++r];n+=s.from-i.to,i=s}return n}clipPos(e){if(e>=this.range.from&&e<this.range.to)return e;for(let t of this.ranges)if(t.to>e)return Math.max(e,t.from);return this.end}peek(e){let t=this.chunkOff+e,i,r;if(t>=0&&t<this.chunk.length)i=this.pos+e,r=this.chunk.charCodeAt(t);else{let n=this.resolveOffset(e,1);if(n==null)return-1;if(i=n,i>=this.chunk2Pos&&i<this.chunk2Pos+this.chunk2.length)r=this.chunk2.charCodeAt(i-this.chunk2Pos);else{let s=this.rangeIndex,o=this.range;for(;o.to<=i;)o=this.ranges[++s];this.chunk2=this.input.chunk(this.chunk2Pos=i),i+this.chunk2.length>o.to&&(this.chunk2=this.chunk2.slice(0,o.to-i)),r=this.chunk2.charCodeAt(0)}}return i>=this.token.lookAhead&&(this.token.lookAhead=i+1),r}acceptToken(e,t=0){let i=t?this.resolveOffset(t,-1):this.pos;if(i==null||i<this.token.start)throw new RangeError("Token end out of bounds");this.token.value=e,this.token.end=i}acceptTokenTo(e,t){this.token.value=e,this.token.end=t}getChunk(){if(this.pos>=this.chunk2Pos&&this.pos<this.chunk2Pos+this.chunk2.length){let{chunk:e,chunkPos:t}=this;this.chunk=this.chunk2,this.chunkPos=this.chunk2Pos,this.chunk2=e,this.chunk2Pos=t,this.chunkOff=this.pos-this.chunkPos}else{this.chunk2=this.chunk,this.chunk2Pos=this.chunkPos;let e=this.input.chunk(this.pos),t=this.pos+e.length;this.chunk=t>this.range.to?e.slice(0,this.range.to-this.pos):e,this.chunkPos=this.pos,this.chunkOff=0}}readNext(){return this.chunkOff>=this.chunk.length&&(this.getChunk(),this.chunkOff==this.chunk.length)?this.next=-1:this.next=this.chunk.charCodeAt(this.chunkOff)}advance(e=1){for(this.chunkOff+=e;this.pos+e>=this.range.to;){if(this.rangeIndex==this.ranges.length-1)return this.setDone();e-=this.range.to-this.pos,this.range=this.ranges[++this.rangeIndex],this.pos=this.range.from}return this.pos+=e,this.pos>=this.token.lookAhead&&(this.token.lookAhead=this.pos+1),this.readNext()}setDone(){return this.pos=this.chunkPos=this.end,this.range=this.ranges[this.rangeIndex=this.ranges.length-1],this.chunk="",this.next=-1}reset(e,t){if(t?(this.token=t,t.start=e,t.lookAhead=e+1,t.value=t.extended=-1):this.token=wO,this.pos!=e){if(this.pos=e,e==this.end)return this.setDone(),this;for(;e<this.range.from;)this.range=this.ranges[--this.rangeIndex];for(;e>=this.range.to;)this.range=this.ranges[++this.rangeIndex];e>=this.chunkPos&&e<this.chunkPos+this.chunk.length?this.chunkOff=e-this.chunkPos:(this.chunk="",this.chunkOff=0),this.readNext()}return this}read(e,t){if(e>=this.chunkPos&&t<=this.chunkPos+this.chunk.length)return this.chunk.slice(e-this.chunkPos,t-this.chunkPos);if(e>=this.chunk2Pos&&t<=this.chunk2Pos+this.chunk2.length)return this.chunk2.slice(e-this.chunk2Pos,t-this.chunk2Pos);if(e>=this.range.from&&t<=this.range.to)return this.input.read(e,t);let i="";for(let r of this.ranges){if(r.from>=t)break;r.to>e&&(i+=this.input.read(Math.max(r.from,e),Math.min(r.to,t)))}return i}},Hi=class{constructor(e,t){this.data=e,this.id=t}token(e,t){let{parser:i}=t.p;kO(this.data,e,t,this.id,i.data,i.tokenPrecTable)}};Hi.prototype.contextual=Hi.prototype.fallback=Hi.prototype.extend=!1;var Ki=class{constructor(e,t,i){this.precTable=t,this.elseToken=i,this.data=typeof e=="string"?jr(e):e}token(e,t){let i=e.pos,r=0;for(;;){let n=e.next<0,s=e.resolveOffset(1,1);if(kO(this.data,e,t,0,this.data,this.precTable),e.token.value>-1)break;if(this.elseToken==null)return;if(n||r++,s==null)break;e.reset(s,e.token)}r&&(e.reset(i,e.token),e.acceptToken(this.elseToken,r))}};Ki.prototype.contextual=Hi.prototype.fallback=Hi.prototype.extend=!1;var Ie=class{constructor(e,t={}){this.token=e,this.contextual=!!t.contextual,this.fallback=!!t.fallback,this.extend=!!t.extend}};function kO(e,t,i,r,n,s){let o=0,a=1<<r,{dialect:l}=i.p.parser;e:for(;a&e[o];){let h=e[o+1];for(let f=o+3;f<h;f+=2)if((e[f+1]&a)>0){let p=e[f];if(l.allows(p)&&(t.token.value==-1||t.token.value==p||ux(p,t.token.value,n,s))){t.acceptToken(p);break}}let c=t.next,u=0,d=e[o+2];if(t.next<0&&d>u&&e[h+d*3-3]==65535){o=e[h+d*3-1];continue e}for(;u<d;){let f=u+d>>1,p=h+f+(f<<1),O=e[p],g=e[p+1]||65536;if(c<O)d=f;else if(c>=g)u=f+1;else{o=e[p+2],t.advance();continue e}}break}}function vO(e,t,i){for(let r=t,n;(n=e[r])!=65535;r++)if(n==i)return r-t;return-1}function ux(e,t,i,r){let n=vO(i,r,t);return n<0||vO(i,r,e)<n}var Ge=typeof Cs<"u"&&Cs.env&&/\bparse\b/.test(Cs.env.LOG),Tl=null;function SO(e,t,i){let r=e.cursor(B.IncludeAnonymous);for(r.moveTo(t);;)if(!(i<0?r.childBefore(t):r.childAfter(t)))for(;;){if((i<0?r.to<t:r.from>t)&&!r.type.isError)return i<0?Math.max(0,Math.min(r.to-1,t-25)):Math.min(e.length,Math.max(r.from+1,t+25));if(i<0?r.prevSibling():r.nextSibling())break;if(!r.parent())return i<0?0:e.length}}var dx=class{constructor(e,t){this.fragments=e,this.nodeSet=t,this.i=0,this.fragment=null,this.safeFrom=-1,this.safeTo=-1,this.trees=[],this.start=[],this.index=[],this.nextFragment()}nextFragment(){let e=this.fragment=this.i==this.fragments.length?null:this.fragments[this.i++];if(e){for(this.safeFrom=e.openStart?SO(e.tree,e.from+e.offset,1)-e.offset:e.from,this.safeTo=e.openEnd?SO(e.tree,e.to+e.offset,-1)-e.offset:e.to;this.trees.length;)this.trees.pop(),this.start.pop(),this.index.pop();this.trees.push(e.tree),this.start.push(-e.offset),this.index.push(0),this.nextStart=this.safeFrom}else this.nextStart=1e9}nodeAt(e){if(e<this.nextStart)return null;for(;this.fragment&&this.safeTo<=e;)this.nextFragment();if(!this.fragment)return null;for(;;){let t=this.trees.length-1;if(t<0)return this.nextFragment(),null;let i=this.trees[t],r=this.index[t];if(r==i.children.length){this.trees.pop(),this.start.pop(),this.index.pop();continue}let n=i.children[r],s=this.start[t]+i.positions[r];if(s>e)return this.nextStart=s,null;if(n instanceof L){if(s==e){if(s<this.safeFrom)return null;let o=s+n.length;if(o<=this.safeTo){let a=n.prop(M.lookAhead);if(!a||o+a<this.fragment.to)return n}}this.index[t]++,s+n.length>=Math.max(this.safeFrom,e)&&(this.trees.push(n),this.start.push(s),this.index.push(0))}else this.index[t]++,this.nextStart=s+n.length}}},fx=class{constructor(e,t){this.stream=t,this.tokens=[],this.mainToken=null,this.actions=[],this.tokens=e.tokenizers.map(i=>new As)}getActions(e){let t=0,i=null,{parser:r}=e.p,{tokenizers:n}=r,s=r.stateSlot(e.state,3),o=e.curContext?e.curContext.hash:0,a=0;for(let l=0;l<n.length;l++){if(!(1<<l&s))continue;let h=n[l],c=this.tokens[l];if(!(i&&!h.fallback)&&((h.contextual||c.start!=e.pos||c.mask!=s||c.context!=o)&&(this.updateCachedToken(c,h,e),c.mask=s,c.context=o),c.lookAhead>c.end+25&&(a=Math.max(c.lookAhead,a)),c.value!=0)){let u=t;if(c.extended>-1&&(t=this.addActions(e,c.extended,c.end,t)),t=this.addActions(e,c.value,c.end,t),!h.extend&&(i=c,t>u))break}}for(;this.actions.length>t;)this.actions.pop();return a&&e.setLookAhead(a),!i&&e.pos==this.stream.end&&(i=new As,i.value=e.p.parser.eofTerm,i.start=i.end=e.pos,t=this.addActions(e,i.value,i.end,t)),this.mainToken=i,this.actions}getMainToken(e){if(this.mainToken)return this.mainToken;let t=new As,{pos:i,p:r}=e;return t.start=i,t.end=Math.min(i+1,r.stream.end),t.value=i==r.stream.end?r.parser.eofTerm:0,t}updateCachedToken(e,t,i){let r=this.stream.clipPos(i.pos);if(t.token(this.stream.reset(r,e),i),e.value>-1){let{parser:n}=i.p;for(let s=0;s<n.specialized.length;s++)if(n.specialized[s]==e.value){let o=n.specializers[s](this.stream.read(e.start,e.end),i);if(o>=0&&i.p.parser.dialect.allows(o>>1)){o&1?e.extended=o>>1:e.value=o>>1;break}}}else e.value=0,e.end=this.stream.clipPos(r+1)}putAction(e,t,i,r){for(let n=0;n<r;n+=3)if(this.actions[n]==e)return r;return this.actions[r++]=e,this.actions[r++]=t,this.actions[r++]=i,r}addActions(e,t,i,r){let{state:n}=e,{parser:s}=e.p,{data:o}=s;for(let a=0;a<2;a++)for(let l=s.stateSlot(n,a?2:1);;l+=3){if(o[l]==65535)if(o[l+1]==1)l=Lt(o,l+2);else{r==0&&o[l+1]==2&&(r=this.putAction(Lt(o,l+2),t,i,r));break}o[l]==t&&(r=this.putAction(Lt(o,l+1),t,i,r))}return r}},px=class{constructor(e,t,i,r){this.parser=e,this.input=t,this.ranges=r,this.recovering=0,this.nextStackID=9812,this.minStackPos=0,this.reused=[],this.stoppedAt=null,this.lastBigReductionStart=-1,this.lastBigReductionSize=0,this.bigReductionCount=0,this.stream=new cx(t,r),this.tokens=new fx(e,this.stream),this.topTerm=e.top[1];let{from:n}=r[0];this.stacks=[ax.start(this,e.top[0],n)],this.fragments=i.length&&this.stream.end-n>e.bufferLength*4?new dx(i,e.nodeSet):null}get parsedPos(){return this.minStackPos}advance(){let e=this.stacks,t=this.minStackPos,i=this.stacks=[],r,n;if(this.bigReductionCount>300&&e.length==1){let[s]=e;for(;s.forceReduce()&&s.stack.length&&s.stack[s.stack.length-2]>=this.lastBigReductionStart;);this.bigReductionCount=this.lastBigReductionSize=0}for(let s=0;s<e.length;s++){let o=e[s];for(;;){if(this.tokens.mainToken=null,o.pos>t)i.push(o);else{if(this.advanceStack(o,i,e))continue;{r||(r=[],n=[]),r.push(o);let a=this.tokens.getMainToken(o);n.push(a.value,a.end)}}break}}if(!i.length){let s=r&&mx(r);if(s)return Ge&&console.log("Finish with "+this.stackID(s)),this.stackToTree(s);if(this.parser.strict)throw Ge&&r&&console.log("Stuck with token "+(this.tokens.mainToken?this.parser.getName(this.tokens.mainToken.value):"none")),new SyntaxError("No parse at "+t);this.recovering||(this.recovering=5)}if(this.recovering&&r){let s=this.stoppedAt!=null&&r[0].pos>this.stoppedAt?r[0]:this.runRecovery(r,n,i);if(s)return Ge&&console.log("Force-finish "+this.stackID(s)),this.stackToTree(s.forceAll())}if(this.recovering){let s=this.recovering==1?1:this.recovering*3;if(i.length>s)for(i.sort((o,a)=>a.score-o.score);i.length>s;)i.pop();i.some(o=>o.reducePos>t)&&this.recovering--}else if(i.length>1){e:for(let s=0;s<i.length-1;s++){let o=i[s];for(let a=s+1;a<i.length;a++){let l=i[a];if(o.sameState(l)||o.buffer.length>500&&l.buffer.length>500)if((o.score-l.score||o.buffer.length-l.buffer.length)>0)i.splice(a--,1);else{i.splice(s--,1);continue e}}}i.length>12&&i.splice(12,i.length-12)}this.minStackPos=i[0].pos;for(let s=1;s<i.length;s++)i[s].pos<this.minStackPos&&(this.minStackPos=i[s].pos);return null}stopAt(e){if(this.stoppedAt!=null&&this.stoppedAt<e)throw new RangeError("Can't move stoppedAt forward");this.stoppedAt=e}advanceStack(e,t,i){let r=e.pos,{parser:n}=this,s=Ge?this.stackID(e)+" -> ":"";if(this.stoppedAt!=null&&r>this.stoppedAt)return e.forceReduce()?e:null;if(this.fragments){let l=e.curContext&&e.curContext.tracker.strict,h=l?e.curContext.hash:0;for(let c=this.fragments.nodeAt(r);c;){let u=this.parser.nodeSet.types[c.type.id]==c.type?n.getGoto(e.state,c.type.id):-1;if(u>-1&&c.length&&(!l||(c.prop(M.contextHash)||0)==h))return e.useNode(c,u),Ge&&console.log(s+this.stackID(e)+` (via reuse of ${n.getName(c.type.id)})`),!0;if(!(c instanceof L)||c.children.length==0||c.positions[0]>0)break;let d=c.children[0];if(d instanceof L&&c.positions[0]==0)c=d;else break}}let o=n.stateSlot(e.state,4);if(o>0)return e.reduce(o),Ge&&console.log(s+this.stackID(e)+` (via always-reduce ${n.getName(o&65535)})`),!0;if(e.stack.length>=8400)for(;e.stack.length>6e3&&e.forceReduce(););let a=this.tokens.getActions(e);for(let l=0;l<a.length;){let h=a[l++],c=a[l++],u=a[l++],d=l==a.length||!i,f=d?e:e.split(),p=this.tokens.mainToken;if(f.apply(h,c,p?p.start:f.pos,u),Ge&&console.log(s+this.stackID(f)+` (via ${h&65536?`reduce of ${n.getName(h&65535)}`:"shift"} for ${n.getName(c)} @ ${r}${f==e?"":", split"})`),d)return!0;f.pos>r?t.push(f):i.push(f)}return!1}advanceFully(e,t){let i=e.pos;for(;;){if(!this.advanceStack(e,null,null))return!1;if(e.pos>i)return xO(e,t),!0}}runRecovery(e,t,i){let r=null,n=!1;for(let s=0;s<e.length;s++){let o=e[s],a=t[s<<1],l=t[(s<<1)+1],h=Ge?this.stackID(o)+" -> ":"";if(o.deadEnd&&(n||(n=!0,o.restart(),Ge&&console.log(h+this.stackID(o)+" (restarted)"),this.advanceFully(o,i))))continue;let c=o.split(),u=h;for(let d=0;c.forceReduce()&&d<10&&(Ge&&console.log(u+this.stackID(c)+" (via force-reduce)"),!this.advanceFully(c,i));d++)Ge&&(u=this.stackID(c)+" -> ");for(let d of o.recoverByInsert(a))Ge&&console.log(h+this.stackID(d)+" (via recover-insert)"),this.advanceFully(d,i);this.stream.end>o.pos?(l==o.pos&&(l++,a=0),o.recoverByDelete(a,l),Ge&&console.log(h+this.stackID(o)+` (via recover-delete ${this.parser.getName(a)})`),xO(o,i)):(!r||r.score<o.score)&&(r=o)}return r}stackToTree(e){return e.close(),L.build({buffer:hx.create(e),nodeSet:this.parser.nodeSet,topID:this.topTerm,maxBufferLength:this.parser.bufferLength,reused:this.reused,start:this.ranges[0].from,length:e.pos-this.ranges[0].from,minRepeatType:this.parser.minRepeatTerm})}stackID(e){let t=(Tl||(Tl=new WeakMap)).get(e);return t||Tl.set(e,t=String.fromCodePoint(this.nextStackID++)),t+e}};function xO(e,t){for(let i=0;i<t.length;i++){let r=t[i];if(r.pos==e.pos&&r.sameState(e)){t[i].score<e.score&&(t[i]=e);return}}t.push(e)}var Ox=class{constructor(e,t,i){this.source=e,this.flags=t,this.disabled=i}allows(e){return!this.disabled||this.disabled[e]==0}},Cl=e=>e,Zs=class{constructor(e){this.start=e.start,this.shift=e.shift||Cl,this.reduce=e.reduce||Cl,this.reuse=e.reuse||Cl,this.hash=e.hash||(()=>0),this.strict=e.strict!==!1}},Qt=class El extends pi{constructor(t){if(super(),this.wrappers=[],t.version!=14)throw new RangeError(`Parser version (${t.version}) doesn't match runtime version (14)`);let i=t.nodeNames.split(" ");this.minRepeatTerm=i.length;for(let a=0;a<t.repeatNodeCount;a++)i.push("");let r=Object.keys(t.topRules).map(a=>t.topRules[a][1]),n=[];for(let a=0;a<i.length;a++)n.push([]);function s(a,l,h){n[a].push([l,l.deserialize(String(h))])}if(t.nodeProps)for(let a of t.nodeProps){let l=a[0];typeof l=="string"&&(l=M[l]);for(let h=1;h<a.length;){let c=a[h++];if(c>=0)s(c,l,a[h++]);else{let u=a[h+-c];for(let d=-c;d>0;d--)s(a[h++],l,u);h++}}}this.nodeSet=new fi(i.map((a,l)=>le.define({name:l>=this.minRepeatTerm?void 0:a,id:l,props:n[l],top:r.indexOf(l)>-1,error:l==0,skipped:t.skippedNodes&&t.skippedNodes.indexOf(l)>-1}))),t.propSources&&(this.nodeSet=this.nodeSet.extend(...t.propSources)),this.strict=!1,this.bufferLength=pc;let o=jr(t.tokenData);this.context=t.context,this.specializerSpecs=t.specialized||[],this.specialized=new Uint16Array(this.specializerSpecs.length);for(let a=0;a<this.specializerSpecs.length;a++)this.specialized[a]=this.specializerSpecs[a].term;this.specializers=this.specializerSpecs.map(PO),this.states=jr(t.states,Uint32Array),this.data=jr(t.stateData),this.goto=jr(t.goto),this.maxTerm=t.maxTerm,this.tokenizers=t.tokenizers.map(a=>typeof a=="number"?new Hi(o,a):a),this.topRules=t.topRules,this.dialects=t.dialects||{},this.dynamicPrecedences=t.dynamicPrecedences||null,this.tokenPrecTable=t.tokenPrec,this.termNames=t.termNames||null,this.maxNode=this.nodeSet.types.length-1,this.dialect=this.parseDialect(),this.top=this.topRules[Object.keys(this.topRules)[0]]}createParse(t,i,r){let n=new px(this,t,i,r);for(let s of this.wrappers)n=s(n,t,i,r);return n}getGoto(t,i,r=!1){let n=this.goto;if(i>=n[0])return-1;for(let s=n[i+1];;){let o=n[s++],a=o&1,l=n[s++];if(a&&r)return l;for(let h=s+(o>>1);s<h;s++)if(n[s]==t)return l;if(a)return-1}}hasAction(t,i){let r=this.data;for(let n=0;n<2;n++)for(let s=this.stateSlot(t,n?2:1),o;;s+=3){if((o=r[s])==65535)if(r[s+1]==1)o=r[s=Lt(r,s+2)];else{if(r[s+1]==2)return Lt(r,s+2);break}if(o==i||o==0)return Lt(r,s+1)}return 0}stateSlot(t,i){return this.states[t*6+i]}stateFlag(t,i){return(this.stateSlot(t,0)&i)>0}validAction(t,i){return!!this.allActions(t,r=>r==i?!0:null)}allActions(t,i){let r=this.stateSlot(t,4),n=r?i(r):void 0;for(let s=this.stateSlot(t,1);n==null;s+=3){if(this.data[s]==65535)if(this.data[s+1]==1)s=Lt(this.data,s+2);else break;n=i(Lt(this.data,s+1))}return n}nextStates(t){let i=[];for(let r=this.stateSlot(t,1);;r+=3){if(this.data[r]==65535)if(this.data[r+1]==1)r=Lt(this.data,r+2);else break;if(!(this.data[r+2]&1)){let n=this.data[r+1];i.some((s,o)=>o&1&&s==n)||i.push(this.data[r],n)}}return i}configure(t){let i=Object.assign(Object.create(El.prototype),this);if(t.props&&(i.nodeSet=this.nodeSet.extend(...t.props)),t.top){let r=this.topRules[t.top];if(!r)throw new RangeError(`Invalid top rule name ${t.top}`);i.top=r}return t.tokenizers&&(i.tokenizers=this.tokenizers.map(r=>{let n=t.tokenizers.find(s=>s.from==r);return n?n.to:r})),t.specializers&&(i.specializers=this.specializers.slice(),i.specializerSpecs=this.specializerSpecs.map((r,n)=>{let s=t.specializers.find(a=>a.from==r.external);if(!s)return r;let o=Object.assign(Object.assign({},r),{external:s.to});return i.specializers[n]=PO(o),o})),t.contextTracker&&(i.context=t.contextTracker),t.dialect&&(i.dialect=this.parseDialect(t.dialect)),t.strict!=null&&(i.strict=t.strict),t.wrap&&(i.wrappers=i.wrappers.concat(t.wrap)),t.bufferLength!=null&&(i.bufferLength=t.bufferLength),i}hasWrappers(){return this.wrappers.length>0}getName(t){return this.termNames?this.termNames[t]:String(t<=this.maxNode&&this.nodeSet.types[t].name||t)}get eofTerm(){return this.maxNode+1}get topNode(){return this.nodeSet.types[this.top[1]]}dynamicPrecedence(t){let i=this.dynamicPrecedences;return i==null?0:i[t]||0}parseDialect(t){let i=Object.keys(this.dialects),r=i.map(()=>!1);if(t)for(let s of t.split(" ")){let o=i.indexOf(s);o>=0&&(r[o]=!0)}let n=null;for(let s=0;s<i.length;s++)if(!r[s])for(let o=this.dialects[i[s]],a;(a=this.data[o++])!=65535;)(n||(n=new Uint8Array(this.maxTerm+1)))[a]=1;return new Ox(t,r,n)}static deserialize(t){return new El(t)}};function Lt(e,t){return e[t]|e[t+1]<<16}function mx(e){let t=null;for(let i of e){let r=i.p.stoppedAt;(i.pos==i.p.stream.end||r!=null&&i.pos>r)&&i.p.parser.stateFlag(i.state,2)&&(!t||t.score<i.score)&&(t=i)}return t}function PO(e){if(e.external){let t=e.extend?1:0;return(i,r)=>e.external(i,r)<<1|t}return e.get}var gx=54,yx=1,bx=55,wx=2,vx=56,Sx=3,QO=4,xx=5,Es=6,XO=7,MO=8,WO=9,qO=10,Px=11,kx=12,Qx=13,Rl=57,$x=14,$O=58,YO=20,Tx=22,IO=23,Cx=24,Ml=26,LO=27,Ax=28,Zx=31,Ex=34,Rx=36,Xx=37,Mx=0,Wx=1,qx={area:!0,base:!0,br:!0,col:!0,command:!0,embed:!0,frame:!0,hr:!0,img:!0,input:!0,keygen:!0,link:!0,meta:!0,param:!0,source:!0,track:!0,wbr:!0,menuitem:!0},Yx={dd:!0,li:!0,optgroup:!0,option:!0,p:!0,rp:!0,rt:!0,tbody:!0,td:!0,tfoot:!0,th:!0,tr:!0},TO={dd:{dd:!0,dt:!0},dt:{dd:!0,dt:!0},li:{li:!0},option:{option:!0,optgroup:!0},optgroup:{optgroup:!0},p:{address:!0,article:!0,aside:!0,blockquote:!0,dir:!0,div:!0,dl:!0,fieldset:!0,footer:!0,form:!0,h1:!0,h2:!0,h3:!0,h4:!0,h5:!0,h6:!0,header:!0,hgroup:!0,hr:!0,menu:!0,nav:!0,ol:!0,p:!0,pre:!0,section:!0,table:!0,ul:!0},rp:{rp:!0,rt:!0},rt:{rp:!0,rt:!0},tbody:{tbody:!0,tfoot:!0},td:{td:!0,th:!0},tfoot:{tbody:!0},th:{td:!0,th:!0},thead:{tbody:!0,tfoot:!0},tr:{tr:!0}};function Ix(e){return e==45||e==46||e==58||e>=65&&e<=90||e==95||e>=97&&e<=122||e>=161}function VO(e){return e==9||e==10||e==13||e==32}var CO=null,AO=null,ZO=0;function Wl(e,t){let i=e.pos+t;if(ZO==i&&AO==e)return CO;let r=e.peek(t);for(;VO(r);)r=e.peek(++t);let n="";for(;Ix(r);)n+=String.fromCharCode(r),r=e.peek(++t);return AO=e,ZO=i,CO=n?n.toLowerCase():r==Lx||r==Vx?void 0:null}var NO=60,Rs=62,ql=47,Lx=63,Vx=33,Nx=45;function EO(e,t){this.name=e,this.parent=t,this.hash=t?t.hash:0;for(let i=0;i<e.length;i++)this.hash+=(this.hash<<4)+e.charCodeAt(i)+(e.charCodeAt(i)<<8)}var jx=[Es,qO,XO,MO,WO],Dx=new Zs({start:null,shift(e,t,i,r){return jx.indexOf(t)>-1?new EO(Wl(r,1)||"",e):e},reduce(e,t){return t==YO&&e?e.parent:e},reuse(e,t,i,r){let n=t.type.id;return n==Es||n==Rx?new EO(Wl(r,1)||"",e):e},hash(e){return e?e.hash:0},strict:!1}),_x=new Ie((e,t)=>{if(e.next!=NO){e.next<0&&t.context&&e.acceptToken(Rl);return}e.advance();let i=e.next==ql;i&&e.advance();let r=Wl(e,0);if(r===void 0)return;if(!r)return e.acceptToken(i?$x:Es);let n=t.context?t.context.name:null;if(i){if(r==n)return e.acceptToken(Px);if(n&&Yx[n])return e.acceptToken(Rl,-2);if(t.dialectEnabled(Mx))return e.acceptToken(kx);for(let s=t.context;s;s=s.parent)if(s.name==r)return;e.acceptToken(Qx)}else{if(r=="script")return e.acceptToken(XO);if(r=="style")return e.acceptToken(MO);if(r=="textarea")return e.acceptToken(WO);if(qx.hasOwnProperty(r))return e.acceptToken(qO);n&&TO[n]&&TO[n][r]?e.acceptToken(Rl,-1):e.acceptToken(Es)}},{contextual:!0}),Ux=new Ie(e=>{for(let t=0,i=0;;i++){if(e.next<0){i&&e.acceptToken($O);break}if(e.next==Nx)t++;else if(e.next==Rs&&t>=2){i>=3&&e.acceptToken($O,-2);break}else t=0;e.advance()}});function zx(e){for(;e;e=e.parent)if(e.name=="svg"||e.name=="math")return!0;return!1}var Bx=new Ie((e,t)=>{if(e.next==ql&&e.peek(1)==Rs){let i=t.dialectEnabled(Wx)||zx(t.context);e.acceptToken(i?xx:QO,2)}else e.next==Rs&&e.acceptToken(QO,1)});function Yl(e,t,i){let r=2+e.length;return new Ie(n=>{for(let s=0,o=0,a=0;;a++){if(n.next<0){a&&n.acceptToken(t);break}if(s==0&&n.next==NO||s==1&&n.next==ql||s>=2&&s<r&&n.next==e.charCodeAt(s-2))s++,o++;else if((s==2||s==r)&&VO(n.next))o++;else if(s==r&&n.next==Rs){a>o?n.acceptToken(t,-o):n.acceptToken(i,-(o-2));break}else if((n.next==10||n.next==13)&&a){n.acceptToken(t,1);break}else s=o=0;n.advance()}})}var Gx=Yl("script",gx,yx),Fx=Yl("style",bx,wx),Hx=Yl("textarea",vx,Sx),Kx=Re({"Text RawText":m.content,"StartTag StartCloseTag SelfClosingEndTag EndTag":m.angleBracket,TagName:m.tagName,"MismatchedCloseTag/TagName":[m.tagName,m.invalid],AttributeName:m.attributeName,"AttributeValue UnquotedAttributeValue":m.attributeValue,Is:m.definitionOperator,"EntityReference CharacterReference":m.character,Comment:m.blockComment,ProcessingInst:m.processingInstruction,DoctypeDecl:m.documentMeta}),jO=Qt.deserialize({version:14,states:",xOVO!rOOO!WQ#tO'#CqO!]Q#tO'#CzO!bQ#tO'#C}O!gQ#tO'#DQO!lQ#tO'#DSO!qOaO'#CpO!|ObO'#CpO#XOdO'#CpO$eO!rO'#CpOOO`'#Cp'#CpO$lO$fO'#DTO$tQ#tO'#DVO$yQ#tO'#DWOOO`'#Dk'#DkOOO`'#DY'#DYQVO!rOOO%OQ&rO,59]O%ZQ&rO,59fO%fQ&rO,59iO%qQ&rO,59lO%|Q&rO,59nOOOa'#D^'#D^O&XOaO'#CxO&dOaO,59[OOOb'#D_'#D_O&lObO'#C{O&wObO,59[OOOd'#D`'#D`O'POdO'#DOO'[OdO,59[OOO`'#Da'#DaO'dO!rO,59[O'kQ#tO'#DROOO`,59[,59[OOOp'#Db'#DbO'pO$fO,59oOOO`,59o,59oO'xQ#|O,59qO'}Q#|O,59rOOO`-E7W-E7WO(SQ&rO'#CsOOQW'#DZ'#DZO(bQ&rO1G.wOOOa1G.w1G.wOOO`1G/Y1G/YO(mQ&rO1G/QOOOb1G/Q1G/QO(xQ&rO1G/TOOOd1G/T1G/TO)TQ&rO1G/WOOO`1G/W1G/WO)`Q&rO1G/YOOOa-E7[-E7[O)kQ#tO'#CyOOO`1G.v1G.vOOOb-E7]-E7]O)pQ#tO'#C|OOOd-E7^-E7^O)uQ#tO'#DPOOO`-E7_-E7_O)zQ#|O,59mOOOp-E7`-E7`OOO`1G/Z1G/ZOOO`1G/]1G/]OOO`1G/^1G/^O*PQ,UO,59_OOQW-E7X-E7XOOOa7+$c7+$cOOO`7+$t7+$tOOOb7+$l7+$lOOOd7+$o7+$oOOO`7+$r7+$rO*[Q#|O,59eO*aQ#|O,59hO*fQ#|O,59kOOO`1G/X1G/XO*kO7[O'#CvO*|OMhO'#CvOOQW1G.y1G.yOOO`1G/P1G/POOO`1G/S1G/SOOO`1G/V1G/VOOOO'#D['#D[O+_O7[O,59bOOQW,59b,59bOOOO'#D]'#D]O+pOMhO,59bOOOO-E7Y-E7YOOQW1G.|1G.|OOOO-E7Z-E7Z",stateData:",]~O!^OS~OUSOVPOWQOXROYTO[]O][O^^O`^Oa^Ob^Oc^Ox^O{_O!dZO~OfaO~OfbO~OfcO~OfdO~OfeO~O!WfOPlP!ZlP~O!XiOQoP!ZoP~O!YlORrP!ZrP~OUSOVPOWQOXROYTOZqO[]O][O^^O`^Oa^Ob^Oc^Ox^O!dZO~O!ZrO~P#dO![sO!euO~OfvO~OfwO~OS|OT}OhyO~OS!POT}OhyO~OS!ROT}OhyO~OS!TOT}OhyO~OS}OT}OhyO~O!WfOPlX!ZlX~OP!WO!Z!XO~O!XiOQoX!ZoX~OQ!ZO!Z!XO~O!YlORrX!ZrX~OR!]O!Z!XO~O!Z!XO~P#dOf!_O~O![sO!e!aO~OS!bO~OS!cO~Oi!dOSgXTgXhgX~OS!fOT!gOhyO~OS!hOT!gOhyO~OS!iOT!gOhyO~OS!jOT!gOhyO~OS!gOT!gOhyO~Of!kO~Of!lO~Of!mO~OS!nO~Ok!qO!`!oO!b!pO~OS!rO~OS!sO~OS!tO~Oa!uOb!uOc!uO!`!wO!a!uO~Oa!xOb!xOc!xO!b!wO!c!xO~Oa!uOb!uOc!uO!`!{O!a!uO~Oa!xOb!xOc!xO!b!{O!c!xO~OT~bac!dx{!d~",goto:"%p!`PPPPPPPPPPPPPPPPPPPP!a!gP!mPP!yP!|#P#S#Y#]#`#f#i#l#r#x!aP!a!aP$O$U$l$r$x%O%U%[%bPPPPPPPP%hX^OX`pXUOX`pezabcde{!O!Q!S!UR!q!dRhUR!XhXVOX`pRkVR!XkXWOX`pRnWR!XnXXOX`pQrXR!XpXYOX`pQ`ORx`Q{aQ!ObQ!QcQ!SdQ!UeZ!e{!O!Q!S!UQ!v!oR!z!vQ!y!pR!|!yQgUR!VgQjVR!YjQmWR![mQpXR!^pQtZR!`tS_O`ToXp",nodeNames:"\u26A0 StartCloseTag StartCloseTag StartCloseTag EndTag SelfClosingEndTag StartTag StartTag StartTag StartTag StartTag StartCloseTag StartCloseTag StartCloseTag IncompleteCloseTag Document Text EntityReference CharacterReference InvalidEntity Element OpenTag TagName Attribute AttributeName Is AttributeValue UnquotedAttributeValue ScriptText CloseTag OpenTag StyleText CloseTag OpenTag TextareaText CloseTag OpenTag CloseTag SelfClosingTag Comment ProcessingInst MismatchedCloseTag CloseTag DoctypeDecl",maxTerm:67,context:Dx,nodeProps:[["closedBy",-10,1,2,3,7,8,9,10,11,12,13,"EndTag",6,"EndTag SelfClosingEndTag",-4,21,30,33,36,"CloseTag"],["openedBy",4,"StartTag StartCloseTag",5,"StartTag",-4,29,32,35,37,"OpenTag"],["group",-9,14,17,18,19,20,39,40,41,42,"Entity",16,"Entity TextContent",-3,28,31,34,"TextContent Entity"],["isolate",-11,21,29,30,32,33,35,36,37,38,41,42,"ltr",-3,26,27,39,""]],propSources:[Kx],skippedNodes:[0],repeatNodeCount:9,tokenData:"!<p!aR!YOX$qXY,QYZ,QZ[$q[]&X]^,Q^p$qpq,Qqr-_rs3_sv-_vw3}wxHYx}-_}!OH{!O!P-_!P!Q$q!Q![-_![!]Mz!]!^-_!^!_!$S!_!`!;x!`!a&X!a!c-_!c!}Mz!}#R-_#R#SMz#S#T1k#T#oMz#o#s-_#s$f$q$f%W-_%W%oMz%o%p-_%p&aMz&a&b-_&b1pMz1p4U-_4U4dMz4d4e-_4e$ISMz$IS$I`-_$I`$IbMz$Ib$Kh-_$Kh%#tMz%#t&/x-_&/x&EtMz&Et&FV-_&FV;'SMz;'S;:j!#|;:j;=`3X<%l?&r-_?&r?AhMz?Ah?BY$q?BY?MnMz?MnO$q!Z$|c`PkW!a`!cpOX$qXZ&XZ[$q[^&X^p$qpq&Xqr$qrs&}sv$qvw+Pwx(tx!^$q!^!_*V!_!a&X!a#S$q#S#T&X#T;'S$q;'S;=`+z<%lO$q!R&bX`P!a`!cpOr&Xrs&}sv&Xwx(tx!^&X!^!_*V!_;'S&X;'S;=`*y<%lO&Xq'UV`P!cpOv&}wx'kx!^&}!^!_(V!_;'S&};'S;=`(n<%lO&}P'pT`POv'kw!^'k!_;'S'k;'S;=`(P<%lO'kP(SP;=`<%l'kp([S!cpOv(Vx;'S(V;'S;=`(h<%lO(Vp(kP;=`<%l(Vq(qP;=`<%l&}a({W`P!a`Or(trs'ksv(tw!^(t!^!_)e!_;'S(t;'S;=`*P<%lO(t`)jT!a`Or)esv)ew;'S)e;'S;=`)y<%lO)e`)|P;=`<%l)ea*SP;=`<%l(t!Q*^V!a`!cpOr*Vrs(Vsv*Vwx)ex;'S*V;'S;=`*s<%lO*V!Q*vP;=`<%l*V!R*|P;=`<%l&XW+UYkWOX+PZ[+P^p+Pqr+Psw+Px!^+P!a#S+P#T;'S+P;'S;=`+t<%lO+PW+wP;=`<%l+P!Z+}P;=`<%l$q!a,]``P!a`!cp!^^OX&XXY,QYZ,QZ]&X]^,Q^p&Xpq,Qqr&Xrs&}sv&Xwx(tx!^&X!^!_*V!_;'S&X;'S;=`*y<%lO&X!_-ljhS`PkW!a`!cpOX$qXZ&XZ[$q[^&X^p$qpq&Xqr-_rs&}sv-_vw/^wx(tx!P-_!P!Q$q!Q!^-_!^!_*V!_!a&X!a#S-_#S#T1k#T#s-_#s$f$q$f;'S-_;'S;=`3X<%l?Ah-_?Ah?BY$q?BY?Mn-_?MnO$q[/ebhSkWOX+PZ[+P^p+Pqr/^sw/^x!P/^!P!Q+P!Q!^/^!a#S/^#S#T0m#T#s/^#s$f+P$f;'S/^;'S;=`1e<%l?Ah/^?Ah?BY+P?BY?Mn/^?MnO+PS0rXhSqr0msw0mx!P0m!Q!^0m!a#s0m$f;'S0m;'S;=`1_<%l?Ah0m?BY?Mn0mS1bP;=`<%l0m[1hP;=`<%l/^!V1vchS`P!a`!cpOq&Xqr1krs&}sv1kvw0mwx(tx!P1k!P!Q&X!Q!^1k!^!_*V!_!a&X!a#s1k#s$f&X$f;'S1k;'S;=`3R<%l?Ah1k?Ah?BY&X?BY?Mn1k?MnO&X!V3UP;=`<%l1k!_3[P;=`<%l-_!Z3hV!`h`P!cpOv&}wx'kx!^&}!^!_(V!_;'S&};'S;=`(n<%lO&}!_4WihSkWc!ROX5uXZ7SZ[5u[^7S^p5uqr8trs7Sst>]tw8twx7Sx!P8t!P!Q5u!Q!]8t!]!^/^!^!a7S!a#S8t#S#T;{#T#s8t#s$f5u$f;'S8t;'S;=`>V<%l?Ah8t?Ah?BY5u?BY?Mn8t?MnO5u!Z5zbkWOX5uXZ7SZ[5u[^7S^p5uqr5urs7Sst+Ptw5uwx7Sx!]5u!]!^7w!^!a7S!a#S5u#S#T7S#T;'S5u;'S;=`8n<%lO5u!R7VVOp7Sqs7St!]7S!]!^7l!^;'S7S;'S;=`7q<%lO7S!R7qOa!R!R7tP;=`<%l7S!Z8OYkWa!ROX+PZ[+P^p+Pqr+Psw+Px!^+P!a#S+P#T;'S+P;'S;=`+t<%lO+P!Z8qP;=`<%l5u!_8{ihSkWOX5uXZ7SZ[5u[^7S^p5uqr8trs7Sst/^tw8twx7Sx!P8t!P!Q5u!Q!]8t!]!^:j!^!a7S!a#S8t#S#T;{#T#s8t#s$f5u$f;'S8t;'S;=`>V<%l?Ah8t?Ah?BY5u?BY?Mn8t?MnO5u!_:sbhSkWa!ROX+PZ[+P^p+Pqr/^sw/^x!P/^!P!Q+P!Q!^/^!a#S/^#S#T0m#T#s/^#s$f+P$f;'S/^;'S;=`1e<%l?Ah/^?Ah?BY+P?BY?Mn/^?MnO+P!V<QchSOp7Sqr;{rs7Sst0mtw;{wx7Sx!P;{!P!Q7S!Q!];{!]!^=]!^!a7S!a#s;{#s$f7S$f;'S;{;'S;=`>P<%l?Ah;{?Ah?BY7S?BY?Mn;{?MnO7S!V=dXhSa!Rqr0msw0mx!P0m!Q!^0m!a#s0m$f;'S0m;'S;=`1_<%l?Ah0m?BY?Mn0m!V>SP;=`<%l;{!_>YP;=`<%l8t!_>dhhSkWOX@OXZAYZ[@O[^AY^p@OqrBwrsAYswBwwxAYx!PBw!P!Q@O!Q!]Bw!]!^/^!^!aAY!a#SBw#S#TE{#T#sBw#s$f@O$f;'SBw;'S;=`HS<%l?AhBw?Ah?BY@O?BY?MnBw?MnO@O!Z@TakWOX@OXZAYZ[@O[^AY^p@Oqr@OrsAYsw@OwxAYx!]@O!]!^Az!^!aAY!a#S@O#S#TAY#T;'S@O;'S;=`Bq<%lO@O!RA]UOpAYq!]AY!]!^Ao!^;'SAY;'S;=`At<%lOAY!RAtOb!R!RAwP;=`<%lAY!ZBRYkWb!ROX+PZ[+P^p+Pqr+Psw+Px!^+P!a#S+P#T;'S+P;'S;=`+t<%lO+P!ZBtP;=`<%l@O!_COhhSkWOX@OXZAYZ[@O[^AY^p@OqrBwrsAYswBwwxAYx!PBw!P!Q@O!Q!]Bw!]!^Dj!^!aAY!a#SBw#S#TE{#T#sBw#s$f@O$f;'SBw;'S;=`HS<%l?AhBw?Ah?BY@O?BY?MnBw?MnO@O!_DsbhSkWb!ROX+PZ[+P^p+Pqr/^sw/^x!P/^!P!Q+P!Q!^/^!a#S/^#S#T0m#T#s/^#s$f+P$f;'S/^;'S;=`1e<%l?Ah/^?Ah?BY+P?BY?Mn/^?MnO+P!VFQbhSOpAYqrE{rsAYswE{wxAYx!PE{!P!QAY!Q!]E{!]!^GY!^!aAY!a#sE{#s$fAY$f;'SE{;'S;=`G|<%l?AhE{?Ah?BYAY?BY?MnE{?MnOAY!VGaXhSb!Rqr0msw0mx!P0m!Q!^0m!a#s0m$f;'S0m;'S;=`1_<%l?Ah0m?BY?Mn0m!VHPP;=`<%lE{!_HVP;=`<%lBw!ZHcW!bx`P!a`Or(trs'ksv(tw!^(t!^!_)e!_;'S(t;'S;=`*P<%lO(t!aIYlhS`PkW!a`!cpOX$qXZ&XZ[$q[^&X^p$qpq&Xqr-_rs&}sv-_vw/^wx(tx}-_}!OKQ!O!P-_!P!Q$q!Q!^-_!^!_*V!_!a&X!a#S-_#S#T1k#T#s-_#s$f$q$f;'S-_;'S;=`3X<%l?Ah-_?Ah?BY$q?BY?Mn-_?MnO$q!aK_khS`PkW!a`!cpOX$qXZ&XZ[$q[^&X^p$qpq&Xqr-_rs&}sv-_vw/^wx(tx!P-_!P!Q$q!Q!^-_!^!_*V!_!`&X!`!aMS!a#S-_#S#T1k#T#s-_#s$f$q$f;'S-_;'S;=`3X<%l?Ah-_?Ah?BY$q?BY?Mn-_?MnO$q!TM_X`P!a`!cp!eQOr&Xrs&}sv&Xwx(tx!^&X!^!_*V!_;'S&X;'S;=`*y<%lO&X!aNZ!ZhSfQ`PkW!a`!cpOX$qXZ&XZ[$q[^&X^p$qpq&Xqr-_rs&}sv-_vw/^wx(tx}-_}!OMz!O!PMz!P!Q$q!Q![Mz![!]Mz!]!^-_!^!_*V!_!a&X!a!c-_!c!}Mz!}#R-_#R#SMz#S#T1k#T#oMz#o#s-_#s$f$q$f$}-_$}%OMz%O%W-_%W%oMz%o%p-_%p&aMz&a&b-_&b1pMz1p4UMz4U4dMz4d4e-_4e$ISMz$IS$I`-_$I`$IbMz$Ib$Je-_$Je$JgMz$Jg$Kh-_$Kh%#tMz%#t&/x-_&/x&EtMz&Et&FV-_&FV;'SMz;'S;:j!#|;:j;=`3X<%l?&r-_?&r?AhMz?Ah?BY$q?BY?MnMz?MnO$q!a!$PP;=`<%lMz!R!$ZY!a`!cpOq*Vqr!$yrs(Vsv*Vwx)ex!a*V!a!b!4t!b;'S*V;'S;=`*s<%lO*V!R!%Q]!a`!cpOr*Vrs(Vsv*Vwx)ex}*V}!O!%y!O!f*V!f!g!']!g#W*V#W#X!0`#X;'S*V;'S;=`*s<%lO*V!R!&QX!a`!cpOr*Vrs(Vsv*Vwx)ex}*V}!O!&m!O;'S*V;'S;=`*s<%lO*V!R!&vV!a`!cp!dPOr*Vrs(Vsv*Vwx)ex;'S*V;'S;=`*s<%lO*V!R!'dX!a`!cpOr*Vrs(Vsv*Vwx)ex!q*V!q!r!(P!r;'S*V;'S;=`*s<%lO*V!R!(WX!a`!cpOr*Vrs(Vsv*Vwx)ex!e*V!e!f!(s!f;'S*V;'S;=`*s<%lO*V!R!(zX!a`!cpOr*Vrs(Vsv*Vwx)ex!v*V!v!w!)g!w;'S*V;'S;=`*s<%lO*V!R!)nX!a`!cpOr*Vrs(Vsv*Vwx)ex!{*V!{!|!*Z!|;'S*V;'S;=`*s<%lO*V!R!*bX!a`!cpOr*Vrs(Vsv*Vwx)ex!r*V!r!s!*}!s;'S*V;'S;=`*s<%lO*V!R!+UX!a`!cpOr*Vrs(Vsv*Vwx)ex!g*V!g!h!+q!h;'S*V;'S;=`*s<%lO*V!R!+xY!a`!cpOr!+qrs!,hsv!+qvw!-Swx!.[x!`!+q!`!a!/j!a;'S!+q;'S;=`!0Y<%lO!+qq!,mV!cpOv!,hvx!-Sx!`!,h!`!a!-q!a;'S!,h;'S;=`!.U<%lO!,hP!-VTO!`!-S!`!a!-f!a;'S!-S;'S;=`!-k<%lO!-SP!-kO{PP!-nP;=`<%l!-Sq!-xS!cp{POv(Vx;'S(V;'S;=`(h<%lO(Vq!.XP;=`<%l!,ha!.aX!a`Or!.[rs!-Ssv!.[vw!-Sw!`!.[!`!a!.|!a;'S!.[;'S;=`!/d<%lO!.[a!/TT!a`{POr)esv)ew;'S)e;'S;=`)y<%lO)ea!/gP;=`<%l!.[!R!/sV!a`!cp{POr*Vrs(Vsv*Vwx)ex;'S*V;'S;=`*s<%lO*V!R!0]P;=`<%l!+q!R!0gX!a`!cpOr*Vrs(Vsv*Vwx)ex#c*V#c#d!1S#d;'S*V;'S;=`*s<%lO*V!R!1ZX!a`!cpOr*Vrs(Vsv*Vwx)ex#V*V#V#W!1v#W;'S*V;'S;=`*s<%lO*V!R!1}X!a`!cpOr*Vrs(Vsv*Vwx)ex#h*V#h#i!2j#i;'S*V;'S;=`*s<%lO*V!R!2qX!a`!cpOr*Vrs(Vsv*Vwx)ex#m*V#m#n!3^#n;'S*V;'S;=`*s<%lO*V!R!3eX!a`!cpOr*Vrs(Vsv*Vwx)ex#d*V#d#e!4Q#e;'S*V;'S;=`*s<%lO*V!R!4XX!a`!cpOr*Vrs(Vsv*Vwx)ex#X*V#X#Y!+q#Y;'S*V;'S;=`*s<%lO*V!R!4{Y!a`!cpOr!4trs!5ksv!4tvw!6Vwx!8]x!a!4t!a!b!:]!b;'S!4t;'S;=`!;r<%lO!4tq!5pV!cpOv!5kvx!6Vx!a!5k!a!b!7W!b;'S!5k;'S;=`!8V<%lO!5kP!6YTO!a!6V!a!b!6i!b;'S!6V;'S;=`!7Q<%lO!6VP!6lTO!`!6V!`!a!6{!a;'S!6V;'S;=`!7Q<%lO!6VP!7QOxPP!7TP;=`<%l!6Vq!7]V!cpOv!5kvx!6Vx!`!5k!`!a!7r!a;'S!5k;'S;=`!8V<%lO!5kq!7yS!cpxPOv(Vx;'S(V;'S;=`(h<%lO(Vq!8YP;=`<%l!5ka!8bX!a`Or!8]rs!6Vsv!8]vw!6Vw!a!8]!a!b!8}!b;'S!8];'S;=`!:V<%lO!8]a!9SX!a`Or!8]rs!6Vsv!8]vw!6Vw!`!8]!`!a!9o!a;'S!8];'S;=`!:V<%lO!8]a!9vT!a`xPOr)esv)ew;'S)e;'S;=`)y<%lO)ea!:YP;=`<%l!8]!R!:dY!a`!cpOr!4trs!5ksv!4tvw!6Vwx!8]x!`!4t!`!a!;S!a;'S!4t;'S;=`!;r<%lO!4t!R!;]V!a`!cpxPOr*Vrs(Vsv*Vwx)ex;'S*V;'S;=`*s<%lO*V!R!;uP;=`<%l!4t!V!<TXiS`P!a`!cpOr&Xrs&}sv&Xwx(tx!^&X!^!_*V!_;'S&X;'S;=`*y<%lO&X",tokenizers:[Gx,Fx,Hx,Bx,_x,Ux,0,1,2,3,4,5],topRules:{Document:[0,15]},dialects:{noMatch:0,selfClosing:509},tokenPrec:511});function DO(e,t){let i=Object.create(null);for(let r of e.getChildren(IO)){let n=r.getChild(Cx),s=r.getChild(Ml)||r.getChild(LO);n&&(i[t.read(n.from,n.to)]=s?s.type.id==Ml?t.read(s.from+1,s.to-1):t.read(s.from,s.to):"")}return i}function RO(e,t){let i=e.getChild(Tx);return i?t.read(i.from,i.to):" "}function Xl(e,t,i){let r;for(let n of i)if(!n.attrs||n.attrs(r||(r=DO(e.node.parent.firstChild,t))))return{parser:n.parser};return null}function Il(e=[],t=[]){let i=[],r=[],n=[],s=[];for(let a of e)(a.tag=="script"?i:a.tag=="style"?r:a.tag=="textarea"?n:s).push(a);let o=t.length?Object.create(null):null;for(let a of t)(o[a.name]||(o[a.name]=[])).push(a);return Qn((a,l)=>{let h=a.type.id;if(h==Ax)return Xl(a,l,i);if(h==Zx)return Xl(a,l,r);if(h==Ex)return Xl(a,l,n);if(h==YO&&s.length){let c=a.node,u=c.firstChild,d=u&&RO(u,l),f;if(d){for(let p of s)if(p.tag==d&&(!p.attrs||p.attrs(f||(f=DO(c,l))))){let O=c.lastChild,g=O.type.id==Xx?O.from:c.to;if(g>u.to)return{parser:p.parser,overlay:[{from:u.to,to:g}]}}}}if(o&&h==IO){let c=a.node,u;if(u=c.firstChild){let d=o[l.read(u.from,u.to)];if(d)for(let f of d){if(f.tagName&&f.tagName!=RO(c.parent,l))continue;let p=c.lastChild;if(p.type.id==Ml){let O=p.from+1,g=p.lastChild,y=p.to-(g&&g.isError?0:1);if(y>O)return{parser:f.parser,overlay:[{from:O,to:y}]}}else if(p.type.id==LO)return{parser:f.parser,overlay:[{from:p.from,to:p.to}]}}}}return null})}var Jx=99,_O=1,eP=100,tP=101,UO=2,zO=[9,10,11,12,13,32,133,160,5760,8192,8193,8194,8195,8196,8197,8198,8199,8200,8201,8202,8232,8233,8239,8287,12288],iP=58,rP=40,BO=95,nP=91,Xs=45,sP=46,oP=35,aP=37,lP=38,hP=92,cP=10;function Dr(e){return e>=65&&e<=90||e>=97&&e<=122||e>=161}function GO(e){return e>=48&&e<=57}var uP=new Ie((e,t)=>{for(let i=!1,r=0,n=0;;n++){let{next:s}=e;if(Dr(s)||s==Xs||s==BO||i&&GO(s))!i&&(s!=Xs||n>0)&&(i=!0),r===n&&s==Xs&&r++,e.advance();else if(s==hP&&e.peek(1)!=cP)e.advance(),e.next>-1&&e.advance(),i=!0;else{i&&e.acceptToken(s==rP?eP:r==2&&t.canShift(UO)?UO:tP);break}}}),dP=new Ie(e=>{if(zO.includes(e.peek(-1))){let{next:t}=e;(Dr(t)||t==BO||t==oP||t==sP||t==nP||t==iP&&Dr(e.peek(1))||t==Xs||t==lP)&&e.acceptToken(Jx)}}),fP=new Ie(e=>{if(!zO.includes(e.peek(-1))){let{next:t}=e;if(t==aP&&(e.advance(),e.acceptToken(_O)),Dr(t)){do e.advance();while(Dr(e.next)||GO(e.next));e.acceptToken(_O)}}}),pP=Re({"AtKeyword import charset namespace keyframes media supports":m.definitionKeyword,"from to selector":m.keyword,NamespaceName:m.namespace,KeyframeName:m.labelName,KeyframeRangeName:m.operatorKeyword,TagName:m.tagName,ClassName:m.className,PseudoClassName:m.constant(m.className),IdName:m.labelName,"FeatureName PropertyName":m.propertyName,AttributeName:m.attributeName,NumberLiteral:m.number,KeywordQuery:m.keyword,UnaryQueryOp:m.operatorKeyword,"CallTag ValueName":m.atom,VariableName:m.variableName,Callee:m.operatorKeyword,Unit:m.unit,"UniversalSelector NestingSelector":m.definitionOperator,MatchOp:m.compareOperator,"ChildOp SiblingOp, LogicOp":m.logicOperator,BinOp:m.arithmeticOperator,Important:m.modifier,Comment:m.blockComment,ColorLiteral:m.color,"ParenthesizedContent StringLiteral":m.string,":":m.punctuation,"PseudoOp #":m.derefOperator,"; ,":m.separator,"( )":m.paren,"[ ]":m.squareBracket,"{ }":m.brace}),OP={__proto__:null,lang:32,"nth-child":32,"nth-last-child":32,"nth-of-type":32,"nth-last-of-type":32,dir:32,"host-context":32,url:60,"url-prefix":60,domain:60,regexp:60,selector:138},mP={__proto__:null,"@import":118,"@media":142,"@charset":146,"@namespace":150,"@keyframes":156,"@supports":168},gP={__proto__:null,not:132,only:132},FO=Qt.deserialize({version:14,states:":^QYQ[OOO#_Q[OOP#fOWOOOOQP'#Cd'#CdOOQP'#Cc'#CcO#kQ[O'#CfO$_QXO'#CaO$fQ[O'#ChO$qQ[O'#DTO$vQ[O'#DWOOQP'#Em'#EmO${QdO'#DgO%jQ[O'#DtO${QdO'#DvO%{Q[O'#DxO&WQ[O'#D{O&`Q[O'#ERO&nQ[O'#ETOOQS'#El'#ElOOQS'#EW'#EWQYQ[OOO&uQXO'#CdO'jQWO'#DcO'oQWO'#EsO'zQ[O'#EsQOQWOOP(UO#tO'#C_POOO)C@[)C@[OOQP'#Cg'#CgOOQP,59Q,59QO#kQ[O,59QO(aQ[O'#E[O({QWO,58{O)TQ[O,59SO$qQ[O,59oO$vQ[O,59rO(aQ[O,59uO(aQ[O,59wO(aQ[O,59xO)`Q[O'#DbOOQS,58{,58{OOQP'#Ck'#CkOOQO'#DR'#DROOQP,59S,59SO)gQWO,59SO)lQWO,59SOOQP'#DV'#DVOOQP,59o,59oOOQO'#DX'#DXO)qQ`O,59rOOQS'#Cp'#CpO${QdO'#CqO)yQvO'#CsO+ZQtO,5:ROOQO'#Cx'#CxO)lQWO'#CwO+oQWO'#CyO+tQ[O'#DOOOQS'#Ep'#EpOOQO'#Dj'#DjO+|Q[O'#DqO,[QWO'#EtO&`Q[O'#DoO,jQWO'#DrOOQO'#Eu'#EuO)OQWO,5:`O,oQpO,5:bOOQS'#Dz'#DzO,wQWO,5:dO,|Q[O,5:dOOQO'#D}'#D}O-UQWO,5:gO-ZQWO,5:mO-cQWO,5:oOOQS-E8U-E8UO${QdO,59}O-kQ[O'#E^O-xQWO,5;_O-xQWO,5;_POOO'#EV'#EVP.TO#tO,58yPOOO,58y,58yOOQP1G.l1G.lO.zQXO,5:vOOQO-E8Y-E8YOOQS1G.g1G.gOOQP1G.n1G.nO)gQWO1G.nO)lQWO1G.nOOQP1G/Z1G/ZO/XQ`O1G/^O/rQXO1G/aO0YQXO1G/cO0pQXO1G/dO1WQWO,59|O1]Q[O'#DSO1dQdO'#CoOOQP1G/^1G/^O${QdO1G/^O1kQpO,59]OOQS,59_,59_O${QdO,59aO1sQWO1G/mOOQS,59c,59cO1xQ!bO,59eOOQS'#DP'#DPOOQS'#EY'#EYO2QQ[O,59jOOQS,59j,59jO2YQWO'#DjO2eQWO,5:VO2jQWO,5:]O&`Q[O,5:XO&`Q[O'#E_O2rQWO,5;`O2}QWO,5:ZO(aQ[O,5:^OOQS1G/z1G/zOOQS1G/|1G/|OOQS1G0O1G0OO3`QWO1G0OO3eQdO'#EOOOQS1G0R1G0ROOQS1G0X1G0XOOQS1G0Z1G0ZO3pQtO1G/iOOQO,5:x,5:xO4WQ[O,5:xOOQO-E8[-E8[O4eQWO1G0yPOOO-E8T-E8TPOOO1G.e1G.eOOQP7+$Y7+$YOOQP7+$x7+$xO${QdO7+$xOOQS1G/h1G/hO4pQXO'#ErO4wQWO,59nO4|QtO'#EXO5tQdO'#EoO6OQWO,59ZO6TQpO7+$xOOQS1G.w1G.wOOQS1G.{1G.{OOQS7+%X7+%XO6]QWO1G/POOQS-E8W-E8WOOQS1G/U1G/UO${QdO1G/qOOQO1G/w1G/wOOQO1G/s1G/sO6bQWO,5:yOOQO-E8]-E8]O6pQXO1G/xOOQS7+%j7+%jO6wQYO'#CsOOQO'#EQ'#EQO7SQ`O'#EPOOQO'#EP'#EPO7_QWO'#E`O7gQdO,5:jOOQS,5:j,5:jO7rQtO'#E]O${QdO'#E]O8sQdO7+%TOOQO7+%T7+%TOOQO1G0d1G0dO9WQpO<<HdO9`QWO,5;^OOQP1G/Y1G/YOOQS-E8V-E8VO${QdO'#EZO9hQWO,5;ZOOQT1G.u1G.uOOQP<<Hd<<HdOOQS7+$k7+$kO9pQdO7+%]OOQO7+%d7+%dOOQO,5:k,5:kO3hQdO'#EaO7_QWO,5:zOOQS,5:z,5:zOOQS-E8^-E8^OOQS1G0U1G0UO9wQtO,5:wOOQS-E8Z-E8ZOOQO<<Ho<<HoOOQPAN>OAN>OO:xQdO,5:uOOQO-E8X-E8XOOQO<<Hw<<HwOOQO,5:{,5:{OOQO-E8_-E8_OOQS1G0f1G0f",stateData:";[~O#ZOS#[QQ~OUYOXYO]VO^VOqXOxWO![aO!]ZO!i[O!k]O!m^O!p_O!v`O#XRO#bTO~OQfOUYOXYO]VO^VOqXOxWO![aO!]ZO!i[O!k]O!m^O!p_O!v`O#XeO#bTO~O#U#gP~P!ZO#[jO~O#XlO~O]qO^qOqsOtoOxrO!OtO!RvO#VuO#bnO~O!TwO~P#pO`}O#WzO#XyO~O#X!OO~O#X!QO~OQ![Ob!TOf![Oh![On!YOq!ZO#W!WO#X!SO#e!UO~Ob!^O!d!`O!g!aO#X!]O!T#hP~Oh!fOn!YO#X!eO~Oh!hO#X!hO~Ob!^O!d!`O!g!aO#X!]O~O!Y#hP~P%jO]WX]!WX^WXqWXtWXxWX!OWX!RWX!TWX#VWX#bWX~O]!mO~O!Y!nO#U#gX!S#gX~O#U#gX!S#gX~P!ZO#]!qO#^!qO#_!sO~OUYOXYO]VO^VOqXOxWO#XRO#bTO~OtoO!TwO~O`!zO#WzO#XyO~O!S#gP~P!ZOb#RO~Ob#SO~Op#TO|#UO~OP#WObgXjgX!YgX!dgX!ggX#XgXagXQgXfgXhgXngXqgXtgX!XgX#UgX#WgX#egXpgX!SgX~Ob!^Oj#XO!d!`O!g!aO#X!]O!Y#hP~Ob#[O~Op#`O#X#]O~Ob!^O!d!`O!g!aO#X#aO~Ot#eO!b#dO!T#hX!Y#hX~Ob#hO~Oj#XO!Y#jO~O!Y#kO~Oh#lOn!YO~O!T#mO~O!TwO!b#dO~O!TwO!Y#pO~O!Y#QX#U#QX!S#QX~P!ZO!Y!nO#U#ga!S#ga~O#]!qO#^!qO#_#wO~O]qO^qOqsOxrO!OtO!RvO#VuO#bnO~Ot#Oa!T#Oaa#Oa~P.`Op#yO|#zO~O]qO^qOqsOxrO#bnO~Ot}i!O}i!R}i!T}i#V}ia}i~P/aOt!Pi!O!Pi!R!Pi!T!Pi#V!Pia!Pi~P/aOt!Qi!O!Qi!R!Qi!T!Qi#V!Qia!Qi~P/aO!S#{O~Oa#fP~P(aOa#cP~P${Oa$SOj#XO~O!Y$UO~Oh$VOo$VO~Op$XO#X#]O~O]!`Xa!^X!b!^X~O]$YO~Oa$ZO!b#dO~Ot#eO!T#ha!Y#ha~O!b#dOt!ca!T!ca!Y!caa!ca~O!Y$`O~O!S$gO#X$bO#e$aO~Oj#XOt$iO!X$kO!Y!Vi#U!Vi!S!Vi~P${O!Y#Qa#U#Qa!S#Qa~P!ZO!Y!nO#U#gi!S#gi~Oa#fX~P#pOa$oO~Oj#XOQ!{Xa!{Xb!{Xf!{Xh!{Xn!{Xq!{Xt!{X#W!{X#X!{X#e!{X~Ot$qOa#cX~P${Oa$sO~Oj#XOp$tO~Oa$uO~O!b#dOt#Ra!T#Ra!Y#Ra~Oa$wO~P.`OP#WOtgX!TgX~O#e$aOt!sX!T!sX~Ot$yO!TwO~O!S$}O#X$bO#e$aO~Oj#XOQ#PXb#PXf#PXh#PXn#PXq#PXt#PX!X#PX!Y#PX#U#PX#W#PX#X#PX#e#PX!S#PX~Ot$iO!X%QO!Y!Vq#U!Vq!S!Vq~P${Oj#XOp%RO~OtoOa#fa~Ot$qOa#ca~Oa%UO~P${Oj#XOQ#Pab#Paf#Pah#Pan#Paq#Pat#Pa!X#Pa!Y#Pa#U#Pa#W#Pa#X#Pa#e#Pa!S#Pa~Oa!}at!}a~P${O#Zo#[#ej!R#e~",goto:"-g#jPPP#kP#nP#w$WP#w$g#wPP$mPPP$s$|$|P%`P$|P$|%z&^PPPP$|&vP&z'Q#wP'W#w'^P#wP#w#wPPP'd'y(WPP#nPP(_(_(i(_P(_P(_(_P#nP#nP#nP(l#nP(o(r(u(|#nP#nP)R)X)h)v)|*S*^*d*n*t*zPPPPPPPPPP+Q+ZP+v+yP,o,r,x-RRkQ_bOPdhw!n#skYOPdhotuvw!n#R#h#skSOPdhotuvw!n#R#h#sQmTR!tnQ{VR!xqQ!x}Q#Z!XR#x!zq![Z]!T!m#S#U#X#q#z$P$Y$i$j$q$v%Sp![Z]!T!m#S#U#X#q#z$P$Y$i$j$q$v%SU$d#m$f$yR$x$cq!XZ]!T!m#S#U#X#q#z$P$Y$i$j$q$v%Sp![Z]!T!m#S#U#X#q#z$P$Y$i$j$q$v%SQ!f^R#l!gT#^!Z#_Q|VR!yqQ!x|R#x!yQ!PWR!{rQ!RXR!|sQxUQ!wpQ#i!cQ#o!jQ#p!kQ${$eR%X$zSgPwQ!phQ#r!nR$l#sZfPhw!n#sa!b[`a!V!^!`#d#eR#b!^R!g^R!i_R#n!iS$e#m$fR%V$yV$c#m$f$yQ!rjR#v!rQdOShPwU!ldh#sR#s!nQ$P#SU$p$P$v%SQ$v$YR%S$qQ#_!ZR$W#_Q$r$PR%T$rQpUS!vp$nR$n#|Q$j#qR%P$jQ!ogS#t!o#uR#u!pQ#f!_R$^#fQ$f#mR$|$fQ$z$eR%W$z_cOPdhw!n#s^UOPdhw!n#sQ!uoQ!}tQ#OuQ#PvQ#|#RR$_#hR$Q#SQ!VZQ!d]Q#V!TQ#q!m[$O#S$P$Y$q$v%SQ$R#UQ$T#XS$h#q$jQ$m#zR%O$iR#}#RQiPR#QwQ!c[Q!kaR#Y!VU!_[a!VQ!j`Q#c!^Q#g!`Q$[#dR$]#e",nodeNames:"\u26A0 Unit VariableName Comment StyleSheet RuleSet UniversalSelector TagSelector TagName NestingSelector ClassSelector ClassName PseudoClassSelector : :: PseudoClassName PseudoClassName ) ( ArgList ValueName ParenthesizedValue ColorLiteral NumberLiteral StringLiteral BinaryExpression BinOp CallExpression Callee CallLiteral CallTag ParenthesizedContent ] [ LineNames LineName , PseudoClassName ArgList IdSelector # IdName AttributeSelector AttributeName MatchOp ChildSelector ChildOp DescendantSelector SiblingSelector SiblingOp } { Block Declaration PropertyName Important ; ImportStatement AtKeyword import KeywordQuery FeatureQuery FeatureName BinaryQuery LogicOp UnaryQuery UnaryQueryOp ParenthesizedQuery SelectorQuery selector MediaStatement media CharsetStatement charset NamespaceStatement namespace NamespaceName KeyframesStatement keyframes KeyframeName KeyframeList KeyframeSelector KeyframeRangeName SupportsStatement supports AtRule Styles",maxTerm:117,nodeProps:[["isolate",-2,3,24,""],["openedBy",17,"(",32,"[",50,"{"],["closedBy",18,")",33,"]",51,"}"]],propSources:[pP],skippedNodes:[0,3,87],repeatNodeCount:11,tokenData:"J^~R!^OX$}X^%u^p$}pq%uqr)Xrs.Rst/utu6duv$}vw7^wx7oxy9^yz9oz{9t{|:_|}?Q}!O?c!O!P@Q!P!Q@i!Q![Ab![!]B]!]!^CX!^!_$}!_!`Cj!`!aC{!a!b$}!b!cDw!c!}$}!}#OFa#O#P$}#P#QFr#Q#R6d#R#T$}#T#UGT#U#c$}#c#dHf#d#o$}#o#pH{#p#q6d#q#rI^#r#sIo#s#y$}#y#z%u#z$f$}$f$g%u$g#BY$}#BY#BZ%u#BZ$IS$}$IS$I_%u$I_$I|$}$I|$JO%u$JO$JT$}$JT$JU%u$JU$KV$}$KV$KW%u$KW&FU$}&FU&FV%u&FV;'S$};'S;=`JW<%lO$}`%QSOy%^z;'S%^;'S;=`%o<%lO%^`%cSo`Oy%^z;'S%^;'S;=`%o<%lO%^`%rP;=`<%l%^~%zh#Z~OX%^X^'f^p%^pq'fqy%^z#y%^#y#z'f#z$f%^$f$g'f$g#BY%^#BY#BZ'f#BZ$IS%^$IS$I_'f$I_$I|%^$I|$JO'f$JO$JT%^$JT$JU'f$JU$KV%^$KV$KW'f$KW&FU%^&FU&FV'f&FV;'S%^;'S;=`%o<%lO%^~'mh#Z~o`OX%^X^'f^p%^pq'fqy%^z#y%^#y#z'f#z$f%^$f$g'f$g#BY%^#BY#BZ'f#BZ$IS%^$IS$I_'f$I_$I|%^$I|$JO'f$JO$JT%^$JT$JU'f$JU$KV%^$KV$KW'f$KW&FU%^&FU&FV'f&FV;'S%^;'S;=`%o<%lO%^l)[UOy%^z#]%^#]#^)n#^;'S%^;'S;=`%o<%lO%^l)sUo`Oy%^z#a%^#a#b*V#b;'S%^;'S;=`%o<%lO%^l*[Uo`Oy%^z#d%^#d#e*n#e;'S%^;'S;=`%o<%lO%^l*sUo`Oy%^z#c%^#c#d+V#d;'S%^;'S;=`%o<%lO%^l+[Uo`Oy%^z#f%^#f#g+n#g;'S%^;'S;=`%o<%lO%^l+sUo`Oy%^z#h%^#h#i,V#i;'S%^;'S;=`%o<%lO%^l,[Uo`Oy%^z#T%^#T#U,n#U;'S%^;'S;=`%o<%lO%^l,sUo`Oy%^z#b%^#b#c-V#c;'S%^;'S;=`%o<%lO%^l-[Uo`Oy%^z#h%^#h#i-n#i;'S%^;'S;=`%o<%lO%^l-uS!X[o`Oy%^z;'S%^;'S;=`%o<%lO%^~.UWOY.RZr.Rrs.ns#O.R#O#P.s#P;'S.R;'S;=`/o<%lO.R~.sOh~~.vRO;'S.R;'S;=`/P;=`O.R~/SXOY.RZr.Rrs.ns#O.R#O#P.s#P;'S.R;'S;=`/o;=`<%l.R<%lO.R~/rP;=`<%l.Rn/zYxQOy%^z!Q%^!Q![0j![!c%^!c!i0j!i#T%^#T#Z0j#Z;'S%^;'S;=`%o<%lO%^l0oYo`Oy%^z!Q%^!Q![1_![!c%^!c!i1_!i#T%^#T#Z1_#Z;'S%^;'S;=`%o<%lO%^l1dYo`Oy%^z!Q%^!Q![2S![!c%^!c!i2S!i#T%^#T#Z2S#Z;'S%^;'S;=`%o<%lO%^l2ZYf[o`Oy%^z!Q%^!Q![2y![!c%^!c!i2y!i#T%^#T#Z2y#Z;'S%^;'S;=`%o<%lO%^l3QYf[o`Oy%^z!Q%^!Q![3p![!c%^!c!i3p!i#T%^#T#Z3p#Z;'S%^;'S;=`%o<%lO%^l3uYo`Oy%^z!Q%^!Q![4e![!c%^!c!i4e!i#T%^#T#Z4e#Z;'S%^;'S;=`%o<%lO%^l4lYf[o`Oy%^z!Q%^!Q![5[![!c%^!c!i5[!i#T%^#T#Z5[#Z;'S%^;'S;=`%o<%lO%^l5aYo`Oy%^z!Q%^!Q![6P![!c%^!c!i6P!i#T%^#T#Z6P#Z;'S%^;'S;=`%o<%lO%^l6WSf[o`Oy%^z;'S%^;'S;=`%o<%lO%^d6gUOy%^z!_%^!_!`6y!`;'S%^;'S;=`%o<%lO%^d7QS|So`Oy%^z;'S%^;'S;=`%o<%lO%^b7cSXQOy%^z;'S%^;'S;=`%o<%lO%^~7rWOY7oZw7owx.nx#O7o#O#P8[#P;'S7o;'S;=`9W<%lO7o~8_RO;'S7o;'S;=`8h;=`O7o~8kXOY7oZw7owx.nx#O7o#O#P8[#P;'S7o;'S;=`9W;=`<%l7o<%lO7o~9ZP;=`<%l7on9cSb^Oy%^z;'S%^;'S;=`%o<%lO%^~9tOa~n9{UUQjWOy%^z!_%^!_!`6y!`;'S%^;'S;=`%o<%lO%^n:fWjW!RQOy%^z!O%^!O!P;O!P!Q%^!Q![>T![;'S%^;'S;=`%o<%lO%^l;TUo`Oy%^z!Q%^!Q![;g![;'S%^;'S;=`%o<%lO%^l;nYo`#e[Oy%^z!Q%^!Q![;g![!g%^!g!h<^!h#X%^#X#Y<^#Y;'S%^;'S;=`%o<%lO%^l<cYo`Oy%^z{%^{|=R|}%^}!O=R!O!Q%^!Q![=j![;'S%^;'S;=`%o<%lO%^l=WUo`Oy%^z!Q%^!Q![=j![;'S%^;'S;=`%o<%lO%^l=qUo`#e[Oy%^z!Q%^!Q![=j![;'S%^;'S;=`%o<%lO%^l>[[o`#e[Oy%^z!O%^!O!P;g!P!Q%^!Q![>T![!g%^!g!h<^!h#X%^#X#Y<^#Y;'S%^;'S;=`%o<%lO%^n?VSt^Oy%^z;'S%^;'S;=`%o<%lO%^l?hWjWOy%^z!O%^!O!P;O!P!Q%^!Q![>T![;'S%^;'S;=`%o<%lO%^n@VU#bQOy%^z!Q%^!Q![;g![;'S%^;'S;=`%o<%lO%^~@nTjWOy%^z{@}{;'S%^;'S;=`%o<%lO%^~AUSo`#[~Oy%^z;'S%^;'S;=`%o<%lO%^lAg[#e[Oy%^z!O%^!O!P;g!P!Q%^!Q![>T![!g%^!g!h<^!h#X%^#X#Y<^#Y;'S%^;'S;=`%o<%lO%^bBbU]QOy%^z![%^![!]Bt!];'S%^;'S;=`%o<%lO%^bB{S^Qo`Oy%^z;'S%^;'S;=`%o<%lO%^nC^S!Y^Oy%^z;'S%^;'S;=`%o<%lO%^dCoS|SOy%^z;'S%^;'S;=`%o<%lO%^bDQU!OQOy%^z!`%^!`!aDd!a;'S%^;'S;=`%o<%lO%^bDkS!OQo`Oy%^z;'S%^;'S;=`%o<%lO%^bDzWOy%^z!c%^!c!}Ed!}#T%^#T#oEd#o;'S%^;'S;=`%o<%lO%^bEk[![Qo`Oy%^z}%^}!OEd!O!Q%^!Q![Ed![!c%^!c!}Ed!}#T%^#T#oEd#o;'S%^;'S;=`%o<%lO%^nFfSq^Oy%^z;'S%^;'S;=`%o<%lO%^nFwSp^Oy%^z;'S%^;'S;=`%o<%lO%^bGWUOy%^z#b%^#b#cGj#c;'S%^;'S;=`%o<%lO%^bGoUo`Oy%^z#W%^#W#XHR#X;'S%^;'S;=`%o<%lO%^bHYS!bQo`Oy%^z;'S%^;'S;=`%o<%lO%^bHiUOy%^z#f%^#f#gHR#g;'S%^;'S;=`%o<%lO%^fIQS!TUOy%^z;'S%^;'S;=`%o<%lO%^nIcS!S^Oy%^z;'S%^;'S;=`%o<%lO%^fItU!RQOy%^z!_%^!_!`6y!`;'S%^;'S;=`%o<%lO%^`JZP;=`<%l$}",tokenizers:[dP,fP,uP,1,2,3,4,new Ki("m~RRYZ[z{a~~g~aO#^~~dP!P!Qg~lO#_~~",28,105)],topRules:{StyleSheet:[0,4],Styles:[1,86]},specialized:[{term:100,get:e=>OP[e]||-1},{term:58,get:e=>mP[e]||-1},{term:101,get:e=>gP[e]||-1}],tokenPrec:1200});var Ll=null;function Vl(){if(!Ll&&typeof document=="object"&&document.body){let{style:e}=document.body,t=[],i=new Set;for(let r in e)r!="cssText"&&r!="cssFloat"&&typeof e[r]=="string"&&(/[A-Z]/.test(r)&&(r=r.replace(/[A-Z]/g,n=>"-"+n.toLowerCase())),i.has(r)||(t.push(r),i.add(r)));Ll=t.sort().map(r=>({type:"property",label:r}))}return Ll||[]}var HO=["active","after","any-link","autofill","backdrop","before","checked","cue","default","defined","disabled","empty","enabled","file-selector-button","first","first-child","first-letter","first-line","first-of-type","focus","focus-visible","focus-within","fullscreen","has","host","host-context","hover","in-range","indeterminate","invalid","is","lang","last-child","last-of-type","left","link","marker","modal","not","nth-child","nth-last-child","nth-last-of-type","nth-of-type","only-child","only-of-type","optional","out-of-range","part","placeholder","placeholder-shown","read-only","read-write","required","right","root","scope","selection","slotted","target","target-text","valid","visited","where"].map(e=>({type:"class",label:e})),KO=["above","absolute","activeborder","additive","activecaption","after-white-space","ahead","alias","all","all-scroll","alphabetic","alternate","always","antialiased","appworkspace","asterisks","attr","auto","auto-flow","avoid","avoid-column","avoid-page","avoid-region","axis-pan","background","backwards","baseline","below","bidi-override","blink","block","block-axis","bold","bolder","border","border-box","both","bottom","break","break-all","break-word","bullets","button","button-bevel","buttonface","buttonhighlight","buttonshadow","buttontext","calc","capitalize","caps-lock-indicator","caption","captiontext","caret","cell","center","checkbox","circle","cjk-decimal","clear","clip","close-quote","col-resize","collapse","color","color-burn","color-dodge","column","column-reverse","compact","condensed","contain","content","contents","content-box","context-menu","continuous","copy","counter","counters","cover","crop","cross","crosshair","currentcolor","cursive","cyclic","darken","dashed","decimal","decimal-leading-zero","default","default-button","dense","destination-atop","destination-in","destination-out","destination-over","difference","disc","discard","disclosure-closed","disclosure-open","document","dot-dash","dot-dot-dash","dotted","double","down","e-resize","ease","ease-in","ease-in-out","ease-out","element","ellipse","ellipsis","embed","end","ethiopic-abegede-gez","ethiopic-halehame-aa-er","ethiopic-halehame-gez","ew-resize","exclusion","expanded","extends","extra-condensed","extra-expanded","fantasy","fast","fill","fill-box","fixed","flat","flex","flex-end","flex-start","footnotes","forwards","from","geometricPrecision","graytext","grid","groove","hand","hard-light","help","hidden","hide","higher","highlight","highlighttext","horizontal","hsl","hsla","hue","icon","ignore","inactiveborder","inactivecaption","inactivecaptiontext","infinite","infobackground","infotext","inherit","initial","inline","inline-axis","inline-block","inline-flex","inline-grid","inline-table","inset","inside","intrinsic","invert","italic","justify","keep-all","landscape","large","larger","left","level","lighter","lighten","line-through","linear","linear-gradient","lines","list-item","listbox","listitem","local","logical","loud","lower","lower-hexadecimal","lower-latin","lower-norwegian","lowercase","ltr","luminosity","manipulation","match","matrix","matrix3d","medium","menu","menutext","message-box","middle","min-intrinsic","mix","monospace","move","multiple","multiple_mask_images","multiply","n-resize","narrower","ne-resize","nesw-resize","no-close-quote","no-drop","no-open-quote","no-repeat","none","normal","not-allowed","nowrap","ns-resize","numbers","numeric","nw-resize","nwse-resize","oblique","opacity","open-quote","optimizeLegibility","optimizeSpeed","outset","outside","outside-shape","overlay","overline","padding","padding-box","painted","page","paused","perspective","pinch-zoom","plus-darker","plus-lighter","pointer","polygon","portrait","pre","pre-line","pre-wrap","preserve-3d","progress","push-button","radial-gradient","radio","read-only","read-write","read-write-plaintext-only","rectangle","region","relative","repeat","repeating-linear-gradient","repeating-radial-gradient","repeat-x","repeat-y","reset","reverse","rgb","rgba","ridge","right","rotate","rotate3d","rotateX","rotateY","rotateZ","round","row","row-resize","row-reverse","rtl","run-in","running","s-resize","sans-serif","saturation","scale","scale3d","scaleX","scaleY","scaleZ","screen","scroll","scrollbar","scroll-position","se-resize","self-start","self-end","semi-condensed","semi-expanded","separate","serif","show","single","skew","skewX","skewY","skip-white-space","slide","slider-horizontal","slider-vertical","sliderthumb-horizontal","sliderthumb-vertical","slow","small","small-caps","small-caption","smaller","soft-light","solid","source-atop","source-in","source-out","source-over","space","space-around","space-between","space-evenly","spell-out","square","start","static","status-bar","stretch","stroke","stroke-box","sub","subpixel-antialiased","svg_masks","super","sw-resize","symbolic","symbols","system-ui","table","table-caption","table-cell","table-column","table-column-group","table-footer-group","table-header-group","table-row","table-row-group","text","text-bottom","text-top","textarea","textfield","thick","thin","threeddarkshadow","threedface","threedhighlight","threedlightshadow","threedshadow","to","top","transform","translate","translate3d","translateX","translateY","translateZ","transparent","ultra-condensed","ultra-expanded","underline","unidirectional-pan","unset","up","upper-latin","uppercase","url","var","vertical","vertical-text","view-box","visible","visibleFill","visiblePainted","visibleStroke","visual","w-resize","wait","wave","wider","window","windowframe","windowtext","words","wrap","wrap-reverse","x-large","x-small","xor","xx-large","xx-small"].map(e=>({type:"keyword",label:e})).concat(["aliceblue","antiquewhite","aqua","aquamarine","azure","beige","bisque","black","blanchedalmond","blue","blueviolet","brown","burlywood","cadetblue","chartreuse","chocolate","coral","cornflowerblue","cornsilk","crimson","cyan","darkblue","darkcyan","darkgoldenrod","darkgray","darkgreen","darkkhaki","darkmagenta","darkolivegreen","darkorange","darkorchid","darkred","darksalmon","darkseagreen","darkslateblue","darkslategray","darkturquoise","darkviolet","deeppink","deepskyblue","dimgray","dodgerblue","firebrick","floralwhite","forestgreen","fuchsia","gainsboro","ghostwhite","gold","goldenrod","gray","grey","green","greenyellow","honeydew","hotpink","indianred","indigo","ivory","khaki","lavender","lavenderblush","lawngreen","lemonchiffon","lightblue","lightcoral","lightcyan","lightgoldenrodyellow","lightgray","lightgreen","lightpink","lightsalmon","lightseagreen","lightskyblue","lightslategray","lightsteelblue","lightyellow","lime","limegreen","linen","magenta","maroon","mediumaquamarine","mediumblue","mediumorchid","mediumpurple","mediumseagreen","mediumslateblue","mediumspringgreen","mediumturquoise","mediumvioletred","midnightblue","mintcream","mistyrose","moccasin","navajowhite","navy","oldlace","olive","olivedrab","orange","orangered","orchid","palegoldenrod","palegreen","paleturquoise","palevioletred","papayawhip","peachpuff","peru","pink","plum","powderblue","purple","rebeccapurple","red","rosybrown","royalblue","saddlebrown","salmon","sandybrown","seagreen","seashell","sienna","silver","skyblue","slateblue","slategray","snow","springgreen","steelblue","tan","teal","thistle","tomato","turquoise","violet","wheat","white","whitesmoke","yellow","yellowgreen"].map(e=>({type:"constant",label:e}))),yP=["a","abbr","address","article","aside","b","bdi","bdo","blockquote","body","br","button","canvas","caption","cite","code","col","colgroup","dd","del","details","dfn","dialog","div","dl","dt","em","figcaption","figure","footer","form","header","hgroup","h1","h2","h3","h4","h5","h6","hr","html","i","iframe","img","input","ins","kbd","label","legend","li","main","meter","nav","ol","output","p","pre","ruby","section","select","small","source","span","strong","sub","summary","sup","table","tbody","td","template","textarea","tfoot","th","thead","tr","u","ul"].map(e=>({type:"type",label:e})),ri=/^(\w[\w-]*|-\w[\w-]*|)$/,bP=/^-(-[\w-]*)?$/;function wP(e,t){var i;if((e.name=="("||e.type.isError)&&(e=e.parent||e),e.name!="ArgList")return!1;let r=(i=e.parent)===null||i===void 0?void 0:i.firstChild;return r?.name!="Callee"?!1:t.sliceString(r.from,r.to)=="var"}var JO=new kn,vP=["Declaration"];function SP(e){for(let t=e;;){if(t.type.isTop)return t;if(!(t=t.parent))return e}}function em(e,t,i){if(t.to-t.from>4096){let r=JO.get(t);if(r)return r;let n=[],s=new Set,o=t.cursor(B.IncludeAnonymous);if(o.firstChild())do for(let a of em(e,o.node,i))s.has(a.label)||(s.add(a.label),n.push(a));while(o.nextSibling());return JO.set(t,n),n}else{let r=[],n=new Set;return t.cursor().iterate(s=>{var o;if(i(s)&&s.matchContext(vP)&&((o=s.node.nextSibling)===null||o===void 0?void 0:o.name)==":"){let a=e.sliceString(s.from,s.to);n.has(a)||(n.add(a),r.push({label:a,type:"variable"}))}}),r}}var xP=e=>t=>{let{state:i,pos:r}=t,n=te(i).resolveInner(r,-1),s=n.type.isError&&n.from==n.to-1&&i.doc.sliceString(n.from,n.to)=="-";if(n.name=="PropertyName"||(s||n.name=="TagName")&&/^(Block|Styles)$/.test(n.resolve(n.to).name))return{from:n.from,options:Vl(),validFor:ri};if(n.name=="ValueName")return{from:n.from,options:KO,validFor:ri};if(n.name=="PseudoClassName")return{from:n.from,options:HO,validFor:ri};if(e(n)||(t.explicit||s)&&wP(n,i.doc))return{from:e(n)||s?n.from:r,options:em(i.doc,SP(n),e),validFor:bP};if(n.name=="TagName"){for(let{parent:l}=n;l;l=l.parent)if(l.name=="Block")return{from:n.from,options:Vl(),validFor:ri};return{from:n.from,options:yP,validFor:ri}}if(!t.explicit)return null;let o=n.resolve(r),a=o.childBefore(r);return a&&a.name==":"&&o.name=="PseudoClassSelector"?{from:r,options:HO,validFor:ri}:a&&a.name==":"&&o.name=="Declaration"||o.name=="ArgList"?{from:r,options:KO,validFor:ri}:o.name=="Block"||o.name=="Styles"?{from:r,options:Vl(),validFor:ri}:null},PP=xP(e=>e.name=="VariableName"),_r=Bi.define({name:"css",parser:FO.configure({props:[ei.add({Declaration:Gi()}),pt.add({"Block KeyframeList":ws})]}),languageData:{commentTokens:{block:{open:"/*",close:"*/"}},indentOnInput:/^\s*\}$/,wordChars:"-"}});function tm(){return new It(_r,_r.data.of({autocomplete:PP}))}var kP=309,im=1,QP=2,$P=3,TP=310,CP=312,AP=313,ZP=4,EP=5,RP=0,jl=[9,10,11,12,13,32,133,160,5760,8192,8193,8194,8195,8196,8197,8198,8199,8200,8201,8202,8232,8233,8239,8287,12288],rm=125,XP=59,Dl=47,MP=42,WP=43,qP=45,YP=60,IP=44,LP=new Zs({start:!1,shift(e,t){return t==ZP||t==EP||t==CP?e:t==AP},strict:!1}),VP=new Ie((e,t)=>{let{next:i}=e;(i==rm||i==-1||t.context)&&e.acceptToken(TP)},{contextual:!0,fallback:!0}),NP=new Ie((e,t)=>{let{next:i}=e,r;jl.indexOf(i)>-1||i==Dl&&((r=e.peek(1))==Dl||r==MP)||i!=rm&&i!=XP&&i!=-1&&!t.context&&e.acceptToken(kP)},{contextual:!0}),jP=new Ie((e,t)=>{let{next:i}=e;if((i==WP||i==qP)&&(e.advance(),i==e.next)){e.advance();let r=!t.context&&t.canShift(im);e.acceptToken(r?im:QP)}},{contextual:!0});function Nl(e,t){return e>=65&&e<=90||e>=97&&e<=122||e==95||e>=192||!t&&e>=48&&e<=57}var DP=new Ie((e,t)=>{if(e.next!=YP||!t.dialectEnabled(RP)||(e.advance(),e.next==Dl))return;let i=0;for(;jl.indexOf(e.next)>-1;)e.advance(),i++;if(Nl(e.next,!0)){for(e.advance(),i++;Nl(e.next,!1);)e.advance(),i++;for(;jl.indexOf(e.next)>-1;)e.advance(),i++;if(e.next==IP)return;for(let r=0;;r++){if(r==7){if(!Nl(e.next,!0))return;break}if(e.next!="extends".charCodeAt(r))break;e.advance(),i++}}e.acceptToken($P,-i)}),_P=Re({"get set async static":m.modifier,"for while do if else switch try catch finally return throw break continue default case":m.controlKeyword,"in of await yield void typeof delete instanceof":m.operatorKeyword,"let var const using function class extends":m.definitionKeyword,"import export from":m.moduleKeyword,"with debugger as new":m.keyword,TemplateString:m.special(m.string),super:m.atom,BooleanLiteral:m.bool,this:m.self,null:m.null,Star:m.modifier,VariableName:m.variableName,"CallExpression/VariableName TaggedTemplateExpression/VariableName":m.function(m.variableName),VariableDefinition:m.definition(m.variableName),Label:m.labelName,PropertyName:m.propertyName,PrivatePropertyName:m.special(m.propertyName),"CallExpression/MemberExpression/PropertyName":m.function(m.propertyName),"FunctionDeclaration/VariableDefinition":m.function(m.definition(m.variableName)),"ClassDeclaration/VariableDefinition":m.definition(m.className),PropertyDefinition:m.definition(m.propertyName),PrivatePropertyDefinition:m.definition(m.special(m.propertyName)),UpdateOp:m.updateOperator,"LineComment Hashbang":m.lineComment,BlockComment:m.blockComment,Number:m.number,String:m.string,Escape:m.escape,ArithOp:m.arithmeticOperator,LogicOp:m.logicOperator,BitOp:m.bitwiseOperator,CompareOp:m.compareOperator,RegExp:m.regexp,Equals:m.definitionOperator,Arrow:m.function(m.punctuation),": Spread":m.punctuation,"( )":m.paren,"[ ]":m.squareBracket,"{ }":m.brace,"InterpolationStart InterpolationEnd":m.special(m.brace),".":m.derefOperator,", ;":m.separator,"@":m.meta,TypeName:m.typeName,TypeDefinition:m.definition(m.typeName),"type enum interface implements namespace module declare":m.definitionKeyword,"abstract global Privacy readonly override":m.modifier,"is keyof unique infer":m.operatorKeyword,JSXAttributeValue:m.attributeValue,JSXText:m.content,"JSXStartTag JSXStartCloseTag JSXSelfCloseEndTag JSXEndTag":m.angleBracket,"JSXIdentifier JSXNameSpacedName":m.tagName,"JSXAttribute/JSXIdentifier JSXAttribute/JSXNameSpacedName":m.attributeName,"JSXBuiltin/JSXIdentifier":m.standard(m.tagName)}),UP={__proto__:null,export:18,as:23,from:31,default:34,async:39,function:40,extends:52,this:56,true:64,false:64,null:76,void:80,typeof:84,super:102,new:136,delete:152,yield:161,await:165,class:170,public:227,private:227,protected:227,readonly:229,instanceof:248,satisfies:251,in:252,const:254,import:286,keyof:339,unique:343,infer:349,is:385,abstract:405,implements:407,type:409,let:412,var:414,using:417,interface:423,enum:427,namespace:433,module:435,declare:439,global:443,for:462,of:471,while:474,with:478,do:482,if:486,else:488,switch:492,case:498,try:504,catch:508,finally:512,return:516,throw:520,break:524,continue:528,debugger:532},zP={__proto__:null,async:123,get:125,set:127,declare:187,public:189,private:189,protected:189,static:191,abstract:193,override:195,readonly:201,accessor:203,new:389},BP={__proto__:null,"<":143},nm=Qt.deserialize({version:14,states:"$=WO%TQ^OOO%[Q^OOO'_Q`OOP(lOWOOO*zQ08SO'#ChO+RO!bO'#CiO+aO#tO'#CiO+oO?MpO'#D^O.QQ^O'#DdO.bQ^O'#DoO%[Q^O'#DyO0fQ^O'#EROOQ07b'#EZ'#EZO1PQWO'#EWOOQO'#El'#ElOOQO'#Ie'#IeO1XQWO'#GmO1dQWO'#EkO1iQWO'#EkO3kQ08SO'#JiO6[Q08SO'#JjO6xQWO'#FZO6}Q&jO'#FqOOQ07b'#Fc'#FcO7YO,YO'#FcO7hQ7[O'#FxO9UQWO'#FwOOQ07b'#Jj'#JjOOQ07`'#Ji'#JiO9ZQWO'#GqOOQU'#KV'#KVO9fQWO'#IRO9kQ07hO'#ISOOQU'#JW'#JWOOQU'#IW'#IWQ`Q^OOO`Q^OOO%[Q^O'#DqO9sQ^O'#D}O9zQ^O'#EPO9aQWO'#GmO:RQ7[O'#CnO:aQWO'#EjO:lQWO'#EuO:qQ7[O'#FbO;`QWO'#GmOOQO'#KW'#KWO;eQWO'#KWO;sQWO'#GuO;sQWO'#GvO;sQWO'#GxO9aQWO'#G{O<jQWO'#HOO>RQWO'#CdO>cQWO'#H[O>kQWO'#HbO>kQWO'#HdO`Q^O'#HfO>kQWO'#HhO>kQWO'#HkO>pQWO'#HqO>uQ07iO'#HwO%[Q^O'#HyO?QQ07iO'#H{O?]Q07iO'#H}O9kQ07hO'#IPO?hQ08SO'#ChO@jQ`O'#DiQOQWOOO%[Q^O'#EPOAQQWO'#ESO:RQ7[O'#EjOA]QWO'#EjOAhQpO'#FbOOQU'#Cf'#CfOOQ07`'#Dn'#DnOOQ07`'#Jm'#JmO%[Q^O'#JmOOQO'#Jq'#JqOOQO'#Ib'#IbOBhQ`O'#EcOOQ07`'#Eb'#EbOOQ07`'#Jt'#JtOCdQ07pO'#EcOCnQ`O'#EVOOQO'#Jp'#JpODSQ`O'#JqOEaQ`O'#EVOCnQ`O'#EcPEnO!0LbO'#CaPOOO)CDu)CDuOOOO'#IX'#IXOEyO!bO,59TOOQ07b,59T,59TOOOO'#IY'#IYOFXO#tO,59TO%[Q^O'#D`OOOO'#I['#I[OFgO?MpO,59xOOQ07b,59x,59xOFuQ^O'#I]OGYQWO'#JkOI[QrO'#JkO+}Q^O'#JkOIcQWO,5:OOIyQWO'#ElOJWQWO'#JzOJcQWO'#JyOJcQWO'#JyOJkQWO,5;YOJpQWO'#JxOOQ07f,5:Z,5:ZOJwQ^O,5:ZOLxQ08SO,5:eOMiQWO,5:mONSQ07hO'#JwONZQWO'#JvO9ZQWO'#JvONoQWO'#JvONwQWO,5;XON|QWO'#JvO!#UQrO'#JjOOQ07b'#Ch'#ChO%[Q^O'#ERO!#tQpO,5:rOOQO'#Jr'#JrOOQO-E<c-E<cO9aQWO,5=XO!$[QWO,5=XO!$aQ^O,5;VO!&dQ7[O'#EgO!'}QWO,5;VO!)mQ7[O'#DsO!)tQ^O'#DxO!*OQ`O,5;`O!*WQ`O,5;`O%[Q^O,5;`OOQU'#FR'#FROOQU'#FT'#FTO%[Q^O,5;aO%[Q^O,5;aO%[Q^O,5;aO%[Q^O,5;aO%[Q^O,5;aO%[Q^O,5;aO%[Q^O,5;aO%[Q^O,5;aO%[Q^O,5;aO%[Q^O,5;aO%[Q^O,5;aOOQU'#FX'#FXO!*fQ^O,5;rOOQ07b,5;w,5;wOOQ07b,5;x,5;xO!,iQWO,5;xOOQ07b,5;y,5;yO%[Q^O'#IiO!,qQ07hO,5<eO!&dQ7[O,5;aO!-`Q7[O,5;aO%[Q^O,5;uO!-gQ&jO'#FgO!.dQ&jO'#KOO!.OQ&jO'#KOO!.kQ&jO'#KOOOQO'#KO'#KOO!/PQ&jO,5<POOOS,5<],5<]O!/bQ^O'#FsOOOS'#Ih'#IhO7YO,YO,5;}O!/iQ&jO'#FuOOQ07b,5;},5;}O!0YQMhO'#CuOOQ07b'#Cy'#CyO!0mQWO'#CyO!0rO?MpO'#C}O!1`Q7[O,5<bO!1gQWO,5<dO!3SQ!LQO'#GSO!3aQWO'#GTO!3fQWO'#GTO!5UQ!LQO'#GXO!6QQ`O'#G]OOQO'#Gh'#GhO!(SQ7[O'#GgOOQO'#Gj'#GjO!(SQ7[O'#GiO!6sQMhO'#JdOOQ07b'#Jd'#JdO!6}QWO'#JcO!7]QWO'#JbO!7eQWO'#CtOOQ07b'#Cw'#CwOOQ07b'#DR'#DROOQ07b'#DT'#DTO1SQWO'#DVO!(SQ7[O'#FzO!(SQ7[O'#F|O!7mQWO'#GOO!7rQWO'#GPO!3fQWO'#GVO!(SQ7[O'#G[O!7wQWO'#EmO!8fQWO,5<cOOQ07`'#Cq'#CqO!8nQWO'#EnO!9hQ`O'#EoOOQ07`'#Jx'#JxO!9oQ07hO'#KXO9kQ07hO,5=]O`Q^O,5>mOOQU'#J`'#J`OOQU,5>n,5>nOOQU-E<U-E<UO!;qQ08SO,5:]O!>_Q08SO,5:iO%[Q^O,5:iO!@xQ08SO,5:kOOQO,5@r,5@rO!AiQ7[O,5=XO!AwQ07hO'#JaO9UQWO'#JaO!BYQ07hO,59YO!BeQ`O,59YO!BmQ7[O,59YO:RQ7[O,59YO!BxQWO,5;VO!CQQWO'#HZO!CfQWO'#K[O%[Q^O,5;zO!9cQ`O,5;|O!CnQWO,5=tO!CsQWO,5=tO!CxQWO,5=tO9kQ07hO,5=tO;sQWO,5=dOOQO'#Cu'#CuO!DWQ`O,5=aO!D`Q7[O,5=bO!DkQWO,5=dO!DpQpO,5=gO!DxQWO'#KWO>pQWO'#HQO9aQWO'#HSO!D}QWO'#HSO:RQ7[O'#HUO!ESQWO'#HUOOQU,5=j,5=jO!EXQWO'#HVO!EjQWO'#CnO!EoQWO,59OO!EyQWO,59OO!HOQ^O,59OOOQU,59O,59OO!H`Q07hO,59OO%[Q^O,59OO!JkQ^O'#H^OOQU'#H_'#H_OOQU'#H`'#H`O`Q^O,5=vO!KRQWO,5=vO`Q^O,5=|O`Q^O,5>OO!KWQWO,5>QO`Q^O,5>SO!K]QWO,5>VO!KbQ^O,5>]OOQU,5>c,5>cO%[Q^O,5>cO9kQ07hO,5>eOOQU,5>g,5>gO# lQWO,5>gOOQU,5>i,5>iO# lQWO,5>iOOQU,5>k,5>kO#!YQ`O'#D[O%[Q^O'#JmO#!dQ`O'#JmO##RQ`O'#DjO##dQ`O'#DjO#%uQ^O'#DjO#%|QWO'#JlO#&UQWO,5:TO#&ZQWO'#EpO#&iQWO'#J{O#&qQWO,5;ZO#&vQ`O'#DjO#'TQ`O'#EUOOQ07b,5:n,5:nO%[Q^O,5:nO#'[QWO,5:nO>pQWO,5;UO!BeQ`O,5;UO!BmQ7[O,5;UO:RQ7[O,5;UO#'dQWO,5@XO#'iQ$ISO,5:rOOQO-E<`-E<`O#(oQ07pO,5:}OCnQ`O,5:qO#(yQ`O,5:qOCnQ`O,5:}O!BYQ07hO,5:qOOQ07`'#Ef'#EfOOQO,5:},5:}O%[Q^O,5:}O#)WQ07hO,5:}O#)cQ07hO,5:}O!BeQ`O,5:qOOQO,5;T,5;TO#)qQ07hO,5:}POOO'#IV'#IVP#*VO!0LbO,58{POOO,58{,58{OOOO-E<V-E<VOOQ07b1G.o1G.oOOOO-E<W-E<WO#*bQpO,59zOOOO-E<Y-E<YOOQ07b1G/d1G/dO#*gQrO,5>wO+}Q^O,5>wOOQO,5>},5>}O#*qQ^O'#I]OOQO-E<Z-E<ZO#+OQWO,5@VO#+WQrO,5@VO#+_QWO,5@eOOQ07b1G/j1G/jO%[Q^O,5@fO#+gQWO'#IcOOQO-E<a-E<aO#+_QWO,5@eOOQ07`1G0t1G0tOOQ07f1G/u1G/uOOQ07f1G0X1G0XO%[Q^O,5@cO#+{Q07hO,5@cO#,^Q07hO,5@cO#,eQWO,5@bO9ZQWO,5@bO#,mQWO,5@bO#,{QWO'#IfO#,eQWO,5@bOOQ07`1G0s1G0sO!*OQ`O,5:tO!*ZQ`O,5:tOOQO,5:v,5:vO#-mQWO,5:vO#-uQ7[O1G2sO9aQWO1G2sOOQ07b1G0q1G0qO#.TQ08SO1G0qO#/YQ08QO,5;ROOQ07b'#GR'#GRO#/vQ08SO'#JdO!$aQ^O1G0qO#2OQ7[O'#JnO#2YQWO,5:_O#2_QrO'#JoO%[Q^O'#JoO#2iQWO,5:dOOQ07b'#D['#D[OOQ07b1G0z1G0zO%[Q^O1G0zOOQ07b1G1d1G1dO#2nQWO1G0zO#5VQ08SO1G0{O#5^Q08SO1G0{O#7wQ08SO1G0{O#8OQ08SO1G0{O#:YQ08SO1G0{O#:pQ08SO1G0{O#=jQ08SO1G0{O#=qQ08SO1G0{O#@UQ08SO1G0{O#@cQ08SO1G0{O#BaQ08SO1G0{O#EaQ(CYO'#ChO#G_Q(CYO1G1^O#GfQ(CYO'#JjO!,lQWO1G1dO#GvQ08SO,5?TOOQ07`-E<g-E<gO#HjQ08SO1G0{OOQ07b1G0{1G0{O#JuQ08SO1G1aO#KiQ&jO,5<TO#KqQ&jO,5<UO#KyQ&jO'#FlO#LbQWO'#FkOOQO'#KP'#KPOOQO'#Ig'#IgO#LgQ&jO1G1kOOQ07b1G1k1G1kOOOS1G1v1G1vO#LxQ(CYO'#JiO#MSQWO,5<_O!*fQ^O,5<_OOOS-E<f-E<fOOQ07b1G1i1G1iO#MXQ`O'#KOOOQ07b,5<a,5<aO#MaQ`O,5<aOOQ07b,59e,59eO!&dQ7[O'#DPOOOO'#IZ'#IZO#MfO?MpO,59iOOQ07b,59i,59iO%[Q^O1G1|O!7rQWO'#IkO#MqQ7[O,5<uOOQ07b,5<r,5<rO!(SQ7[O'#InO#NaQ7[O,5=RO!(SQ7[O'#IpO$ SQ7[O,5=TO!&dQ7[O,5=VOOQO1G2O1G2OO$ ^QpO'#CqO$ qQ!LQO'#EnO$!pQ`O'#G]O$#^QpO,5<nO$#eQWO'#KSO9ZQWO'#KSO$#sQWO,5<pO!(SQ7[O,5<oO$#xQWO'#GUO$$ZQWO,5<oO$$`QpO'#GRO$$mQpO'#KTO$$wQWO'#KTO!&dQ7[O'#KTO$$|QWO,5<sO$%RQ`O'#G^O!5{Q`O'#G^O$%dQWO'#G`O$%iQWO'#GbO!3fQWO'#GeO$%nQ07hO'#ImO$%yQ`O,5<wOOQ07f,5<w,5<wO$&QQ`O'#G^O$&`Q`O'#G_O$&hQ`O'#G_O$&mQ7[O,5=RO$&}Q7[O,5=TOOQ07b,5=W,5=WO!(SQ7[O,5?}O!(SQ7[O,5?}O$'_QWO'#IrO$'jQWO,5?|O$'rQWO,59`O$(cQ7[O,59qOOQ07b,59q,59qO$)UQ7[O,5<fO$)wQ7[O,5<hO@bQWO,5<jOOQ07b,5<k,5<kO$*RQWO,5<qO$*WQ7[O,5<vO$*hQWO'#JvO!$aQ^O1G1}O$*mQWO1G1}O9ZQWO'#JyO9ZQWO'#EpO%[Q^O'#EpO9ZQWO'#ItO$*rQ07hO,5@sOOQU1G2w1G2wOOQU1G4X1G4XOOQ07b1G/w1G/wO!,iQWO1G/wO$,wQ08SO1G0TOOQU1G2s1G2sO!&dQ7[O1G2sO%[Q^O1G2sO#-xQWO1G2sO$.{Q7[O'#EgOOQ07`,5?{,5?{O$/VQ07hO,5?{OOQU1G.t1G.tO!BYQ07hO1G.tO!BeQ`O1G.tO!BmQ7[O1G.tO$/hQWO1G0qO$/mQWO'#ChO$/xQWO'#K]O$0QQWO,5=uO$0VQWO'#K]O$0[QWO'#K]O$0jQWO'#IzO$0xQWO,5@vO$1QQrO1G1fOOQ07b1G1h1G1hO9aQWO1G3`O@bQWO1G3`O$1XQWO1G3`O$1^QWO1G3`OOQU1G3`1G3`O!DkQWO1G3OO!&dQ7[O1G2{O$1cQWO1G2{OOQU1G2|1G2|O!&dQ7[O1G2|O$1hQWO1G2|O$1pQ`O'#GzOOQU1G3O1G3OO!5{Q`O'#IvO!DpQpO1G3ROOQU1G3R1G3ROOQU,5=l,5=lO$1xQ7[O,5=nO9aQWO,5=nO$%iQWO,5=pO9UQWO,5=pO!BeQ`O,5=pO!BmQ7[O,5=pO:RQ7[O,5=pO$2WQWO'#KZO$2cQWO,5=qOOQU1G.j1G.jO$2hQ07hO1G.jO@bQWO1G.jO$2sQWO1G.jO9kQ07hO1G.jO$4xQrO,5@xO$5YQWO,5@xO9ZQWO,5@xO$5eQ^O,5=xO$5lQWO,5=xOOQU1G3b1G3bO`Q^O1G3bOOQU1G3h1G3hOOQU1G3j1G3jO>kQWO1G3lO$5qQ^O1G3nO$9uQ^O'#HmOOQU1G3q1G3qO$:SQWO'#HsO>pQWO'#HuOOQU1G3w1G3wO$:[Q^O1G3wO9kQ07hO1G3}OOQU1G4P1G4POOQ07`'#GY'#GYO9kQ07hO1G4RO9kQ07hO1G4TO$>cQWO,5@XO!*fQ^O,5;[O9ZQWO,5;[O>pQWO,5:UO!*fQ^O,5:UO!BeQ`O,5:UO$>hQ(CYO,5:UOOQO,5;[,5;[O$>rQ`O'#I^O$?YQWO,5@WOOQ07b1G/o1G/oO$?bQ`O'#IdO$?lQWO,5@gOOQ07`1G0u1G0uO##dQ`O,5:UOOQO'#Ia'#IaO$?tQ`O,5:pOOQ07f,5:p,5:pO#'_QWO1G0YOOQ07b1G0Y1G0YO%[Q^O1G0YOOQ07b1G0p1G0pO>pQWO1G0pO!BeQ`O1G0pO!BmQ7[O1G0pOOQ07`1G5s1G5sO!BYQ07hO1G0]OOQO1G0i1G0iO%[Q^O1G0iO$?{Q07hO1G0iO$@WQ07hO1G0iO!BeQ`O1G0]OCnQ`O1G0]O$@fQ07hO1G0iOOQO1G0]1G0]O$@zQ08SO1G0iPOOO-E<T-E<TPOOO1G.g1G.gOOOO1G/f1G/fO$AUQpO,5<eO$A^QrO1G4cOOQO1G4i1G4iO%[Q^O,5>wO$AhQWO1G5qO$ApQWO1G6PO$AxQrO1G6QO9ZQWO,5>}O$BSQ08SO1G5}O%[Q^O1G5}O$BdQ07hO1G5}O$BuQWO1G5|O$BuQWO1G5|O9ZQWO1G5|O$B}QWO,5?QO9ZQWO,5?QOOQO,5?Q,5?QO$CcQWO,5?QO$*hQWO,5?QOOQO-E<d-E<dOOQO1G0`1G0`OOQO1G0b1G0bO!,lQWO1G0bOOQU7+(_7+(_O!&dQ7[O7+(_O%[Q^O7+(_O$CqQWO7+(_O$C|Q7[O7+(_O$D[Q08SO,5=RO$FgQ08SO,5=TO$HrQ08SO,5=RO$KTQ08SO,5=TO$MfQ08SO,59qO% nQ08SO,5<fO%#yQ08SO,5<hO%&UQ08SO,5<vOOQ07b7+&]7+&]O%(gQ08SO7+&]O%)ZQ7[O'#I_O%)eQWO,5@YOOQ07b1G/y1G/yO%)mQ^O'#I`O%)zQWO,5@ZO%*SQrO,5@ZOOQ07b1G0O1G0OO%*^QWO7+&fOOQ07b7+&f7+&fO%*cQ(CYO,5:eO%[Q^O7+&xO%*mQ(CYO,5:]O%*zQ(CYO,5:iO%+UQ(CYO,5:kOOQ07b7+'O7+'OOOQO1G1o1G1oOOQO1G1p1G1pO%+`QtO,5<WO!*fQ^O,5<VOOQO-E<e-E<eOOQ07b7+'V7+'VOOOS7+'b7+'bOOOS1G1y1G1yO%+kQWO1G1yOOQ07b1G1{1G1{O%+pQpO,59kOOOO-E<X-E<XOOQ07b1G/T1G/TO%+wQ08SO7+'hOOQ07b,5?V,5?VO%,kQpO,5?VOOQ07b1G2a1G2aP!&dQ7[O'#IkPOQ07b-E<i-E<iO%-ZQ7[O,5?YOOQ07b-E<l-E<lO%-|Q7[O,5?[OOQ07b-E<n-E<nO%.WQpO1G2qO%._QpO'#CqO%.uQ7[O'#JyO%.|Q^O'#EpOOQ07b1G2Y1G2YO%/WQWO'#IjO%/lQWO,5@nO%/lQWO,5@nO%/tQWO,5@nO%0PQWO,5@nOOQO1G2[1G2[O%0_Q7[O1G2ZO!(SQ7[O1G2ZO%0oQ!LQO'#IlO%0|QWO,5@oO!&dQ7[O,5@oO%1UQpO,5@oOOQ07b1G2_1G2_OOQ07`,5<x,5<xOOQ07`,5<y,5<yO$*hQWO,5<yOC_QWO,5<yO!BeQ`O,5<xOOQO'#Ga'#GaO%1`QWO,5<zOOQ07`,5<|,5<|O$*hQWO,5=POOQO,5?X,5?XOOQO-E<k-E<kOOQ07f1G2c1G2cO!5{Q`O,5<xO%1hQWO,5<yO$%dQWO,5<zO!5{Q`O,5<yO!(SQ7[O'#InO%2[Q7[O1G2mO!(SQ7[O'#IpO%2}Q7[O1G2oO%3XQ7[O1G5iO%3cQ7[O1G5iOOQO,5?^,5?^OOQO-E<p-E<pOOQO1G.z1G.zO!9cQ`O,59sO%[Q^O,59sO%3pQWO1G2UO!(SQ7[O1G2]O%3uQ08SO7+'iOOQ07b7+'i7+'iO!$aQ^O7+'iO%4iQWO,5;[OOQ07`,5?`,5?`OOQ07`-E<r-E<rOOQ07b7+%c7+%cO%4nQpO'#KUO#'_QWO7+(_O%4xQrO7+(_O$CtQWO7+(_O%5PQ08QO'#ChO%5dQ08QO,5<}O%6UQWO,5<}OOQ07`1G5g1G5gOOQU7+$`7+$`O!BYQ07hO7+$`O!BeQ`O7+$`O!$aQ^O7+&]O%6ZQWO'#IyO%6rQWO,5@wOOQO1G3a1G3aO9aQWO,5@wO%6rQWO,5@wO%6zQWO,5@wOOQO,5?f,5?fOOQO-E<x-E<xOOQ07b7+'Q7+'QO%7PQWO7+(zO9kQ07hO7+(zO9aQWO7+(zO@bQWO7+(zOOQU7+(j7+(jO%7UQ08QO7+(gO!&dQ7[O7+(gO%7`QpO7+(hOOQU7+(h7+(hO!&dQ7[O7+(hO%7gQWO'#KYO%7rQWO,5=fOOQO,5?b,5?bOOQO-E<t-E<tOOQU7+(m7+(mO%9RQ`O'#HTOOQU1G3Y1G3YO!&dQ7[O1G3YO%[Q^O1G3YO%9YQWO1G3YO%9eQ7[O1G3YO9kQ07hO1G3[O$%iQWO1G3[O9UQWO1G3[O!BeQ`O1G3[O!BmQ7[O1G3[O%9sQWO'#IxO%:XQWO,5@uO%:aQ`O,5@uOOQ07`1G3]1G3]OOQU7+$U7+$UO@bQWO7+$UO9kQ07hO7+$UO%:lQWO7+$UO%[Q^O1G6dO%[Q^O1G6eO%:qQ07hO1G6dO%:{Q^O1G3dO%;SQWO1G3dO%;XQ^O1G3dOOQU7+(|7+(|O9kQ07hO7+)WO`Q^O7+)YOOQU'#K`'#K`OOQU'#I{'#I{O%;`Q^O,5>XOOQU,5>X,5>XO%[Q^O'#HnO%;mQWO'#HpOOQU,5>_,5>_O9ZQWO,5>_OOQU,5>a,5>aOOQU7+)c7+)cOOQU7+)i7+)iOOQU7+)m7+)mOOQU7+)o7+)oO%;rQ`O1G5sO%<WQ(CYO1G0vO%<bQWO1G0vOOQO1G/p1G/pO%<mQ(CYO1G/pO>pQWO1G/pO!*fQ^O'#DjOOQO,5>x,5>xOOQO-E<[-E<[OOQO,5?O,5?OOOQO-E<b-E<bO!BeQ`O1G/pOOQO-E<_-E<_OOQ07f1G0[1G0[OOQ07b7+%t7+%tO#'_QWO7+%tOOQ07b7+&[7+&[O>pQWO7+&[O!BeQ`O7+&[OOQO7+%w7+%wO$@zQ08SO7+&TOOQO7+&T7+&TO%[Q^O7+&TO%<wQ07hO7+&TO!BYQ07hO7+%wO!BeQ`O7+%wO%=SQ07hO7+&TO%=bQ08SO7++iO%[Q^O7++iO%=rQWO7++hO%=rQWO7++hOOQO1G4l1G4lO9ZQWO1G4lO%=zQWO1G4lOOQO7+%|7+%|O#'_QWO<<KyO%4xQrO<<KyO%>YQWO<<KyOOQU<<Ky<<KyO!&dQ7[O<<KyO%[Q^O<<KyO%>bQWO<<KyO%>mQ08SO,5?YO%@xQ08SO,5?[O%CTQ08SO1G2ZO%EfQ08SO1G2mO%GqQ08SO1G2oO%I|Q7[O,5>yOOQO-E<]-E<]O%JWQrO,5>zO%[Q^O,5>zOOQO-E<^-E<^O%JbQWO1G5uOOQ07b<<JQ<<JQO%JjQ(CYO1G0qO%LtQ(CYO1G0{O%L{Q(CYO1G0{O& PQ(CYO1G0{O& WQ(CYO1G0{O&!{Q(CYO1G0{O&#cQ(CYO1G0{O&%vQ(CYO1G0{O&%}Q(CYO1G0{O&'{Q(CYO1G0{O&(YQ(CYO1G0{O&*WQ(CYO1G0{O&*kQ08SO<<JdO&+pQ(CYO1G0{O&-fQ(CYO'#JdO&/iQ(CYO1G1aO&/vQ(CYO1G0TO!*fQ^O'#FnOOQO'#KQ'#KQOOQO1G1r1G1rO&0QQWO1G1qO&0VQ(CYO,5?TOOOS7+'e7+'eOOOO1G/V1G/VOOQ07b1G4q1G4qO!(SQ7[O7+(]O&2gQrO'#ChO&2qQWO,5?UO9ZQWO,5?UOOQO-E<h-E<hO&3PQWO1G6YO&3PQWO1G6YO&3XQWO1G6YO&3dQ7[O7+'uO&3tQpO,5?WO&4OQWO,5?WO!&dQ7[O,5?WOOQO-E<j-E<jO&4TQpO1G6ZO&4_QWO1G6ZOOQ07`1G2e1G2eO$*hQWO1G2eOOQ07`1G2d1G2dO&4gQWO1G2fO!&dQ7[O1G2fOOQ07`1G2k1G2kO!BeQ`O1G2dOC_QWO1G2eO&4lQWO1G2fO&4tQWO1G2eO&5hQ7[O,5?YOOQ07b-E<m-E<mO&6ZQ7[O,5?[OOQ07b-E<o-E<oO!(SQ7[O7++TOOQ07b1G/_1G/_O&6eQWO1G/_OOQ07b7+'p7+'pO&6jQ7[O7+'wO&6zQ08SO<<KTOOQ07b<<KT<<KTO&7nQWO1G0vO!&dQ7[O'#IsO&7sQWO,5@pO!&dQ7[O1G2iOOQU<<Gz<<GzO!BYQ07hO<<GzO&7{Q08SO<<IwOOQ07b<<Iw<<IwOOQO,5?e,5?eO&8oQWO,5?eO&8tQWO,5?eOOQO-E<w-E<wO&9SQWO1G6cO&9SQWO1G6cO9aQWO1G6cO@bQWO<<LfOOQU<<Lf<<LfO&9[QWO<<LfO9kQ07hO<<LfOOQU<<LR<<LRO%7UQ08QO<<LROOQU<<LS<<LSO%7`QpO<<LSO&9aQ`O'#IuO&9lQWO,5@tO!*fQ^O,5@tOOQU1G3Q1G3QO%.|Q^O'#JmOOQO'#Iw'#IwO9kQ07hO'#IwO&9tQ`O,5=oOOQU,5=o,5=oO&9{Q`O'#EcO&:aQWO7+(tO&:fQWO7+(tOOQU7+(t7+(tO!&dQ7[O7+(tO%[Q^O7+(tO&:nQWO7+(tOOQU7+(v7+(vO9kQ07hO7+(vO$%iQWO7+(vO9UQWO7+(vO!BeQ`O7+(vO&:yQWO,5?dOOQO-E<v-E<vOOQO'#HW'#HWO&;UQWO1G6aO9kQ07hO<<GpOOQU<<Gp<<GpO@bQWO<<GpO&;^QWO7+,OO&;cQWO7+,PO%[Q^O7+,OO%[Q^O7+,POOQU7+)O7+)OO&;hQWO7+)OO&;mQ^O7+)OO&;tQWO7+)OOOQU<<Lr<<LrOOQU<<Lt<<LtOOQU-E<y-E<yOOQU1G3s1G3sO&;yQWO,5>YOOQU,5>[,5>[O&<OQWO1G3yO9ZQWO7+&bO!*fQ^O7+&bOOQO7+%[7+%[O&<TQ(CYO1G6QO>pQWO7+%[OOQ07b<<I`<<I`OOQ07b<<Iv<<IvO>pQWO<<IvOOQO<<Io<<IoO$@zQ08SO<<IoO%[Q^O<<IoOOQO<<Ic<<IcO!BYQ07hO<<IcO&<_Q07hO<<IoO&<jQ08SO<= TO&<zQWO<= SOOQO7+*W7+*WO9ZQWO7+*WOOQUANAeANAeO&=SQWOANAeO!&dQ7[OANAeO#'_QWOANAeO%4xQrOANAeO%[Q^OANAeO&=[Q08SO7+'uO&?mQ08SO,5?YO&AxQ08SO,5?[O&DTQ08SO7+'wO&FfQrO1G4fO&FpQ(CYO7+&]O&HtQ(CYO,5=RO&J{Q(CYO,5=TO&K]Q(CYO,5=RO&KmQ(CYO,5=TO&K}Q(CYO,59qO&NQQ(CYO,5<fO'!TQ(CYO,5<hO'$WQ(CYO,5<vO'%|Q(CYO7+'hO'&ZQ(CYO7+'iO'&hQWO,5<YOOQO7+']7+']O'&mQ7[O<<KwOOQO1G4p1G4pO'&tQWO1G4pO''PQWO1G4pO''_QWO7++tO''_QWO7++tO!&dQ7[O1G4rO''gQpO1G4rO''qQWO7++uOOQ07`7+(P7+(PO$*hQWO7+(QO''yQpO7+(QOOQ07`7+(O7+(OO$*hQWO7+(PO'(QQWO7+(QO!&dQ7[O7+(QOC_QWO7+(PO'(VQ7[O<<NoOOQ07b7+$y7+$yO'(aQpO,5?_OOQO-E<q-E<qO'(kQ08QO7+(TOOQUAN=fAN=fO9aQWO1G5POOQO1G5P1G5PO'({QWO1G5PO')QQWO7++}O')QQWO7++}O9kQ07hOANBQO@bQWOANBQOOQUANBQANBQOOQUANAmANAmOOQUANAnANAnO')YQWO,5?aOOQO-E<s-E<sO')eQ(CYO1G6`OOQO,5?c,5?cOOQO-E<u-E<uOOQU1G3Z1G3ZO%.|Q^O,5<zOOQU<<L`<<L`O!&dQ7[O<<L`O&:aQWO<<L`O')oQWO<<L`O%[Q^O<<L`OOQU<<Lb<<LbO9kQ07hO<<LbO$%iQWO<<LbO9UQWO<<LbO')wQ`O1G5OO'*SQWO7++{OOQUAN=[AN=[O9kQ07hOAN=[OOQU<= j<= jOOQU<= k<= kO'*[QWO<= jO'*aQWO<= kOOQU<<Lj<<LjO'*fQWO<<LjO'*kQ^O<<LjOOQU1G3t1G3tO>pQWO7+)eO'*rQWO<<I|O'*}Q(CYO<<I|OOQO<<Hv<<HvOOQ07bAN?bAN?bOOQOAN?ZAN?ZO$@zQ08SOAN?ZOOQOAN>}AN>}O%[Q^OAN?ZOOQO<<Mr<<MrOOQUG27PG27PO!&dQ7[OG27PO#'_QWOG27PO'+XQWOG27PO%4xQrOG27PO'+aQ(CYO<<JdO'+nQ(CYO1G2ZO'-dQ(CYO,5?YO'/gQ(CYO,5?[O'1jQ(CYO1G2mO'3mQ(CYO1G2oO'5pQ(CYO<<KTO'5}Q(CYO<<IwOOQO1G1t1G1tO!(SQ7[OANAcOOQO7+*[7+*[O'6[QWO7+*[O'6gQWO<= `O'6oQpO7+*^OOQ07`<<Kl<<KlO$*hQWO<<KlOOQ07`<<Kk<<KkO'6yQpO<<KlO$*hQWO<<KkOOQO7+*k7+*kO9aQWO7+*kO'7QQWO<= iOOQUG27lG27lO9kQ07hOG27lO!*fQ^O1G4{O'7YQWO7++zO&:aQWOANAzOOQUANAzANAzO!&dQ7[OANAzO'7bQWOANAzOOQUANA|ANA|O9kQ07hOANA|O$%iQWOANA|OOQO'#HX'#HXOOQO7+*j7+*jOOQUG22vG22vOOQUANEUANEUOOQUANEVANEVOOQUANBUANBUO'7jQWOANBUOOQU<<MP<<MPO!*fQ^OAN?hOOQOG24uG24uO$@zQ08SOG24uO#'_QWOLD,kOOQULD,kLD,kO!&dQ7[OLD,kO'7oQWOLD,kO'7wQ(CYO7+'uO'9mQ(CYO,5?YO';pQ(CYO,5?[O'=sQ(CYO7+'wO'?iQ7[OG26}OOQO<<Mv<<MvOOQ07`ANAWANAWO$*hQWOANAWOOQ07`ANAVANAVOOQO<<NV<<NVOOQULD-WLD-WO'?yQ(CYO7+*gOOQUG27fG27fO&:aQWOG27fO!&dQ7[OG27fOOQUG27hG27hO9kQ07hOG27hOOQUG27pG27pO'@TQ(CYOG25SOOQOLD*aLD*aOOQU!$(!V!$(!VO#'_QWO!$(!VO!&dQ7[O!$(!VO'@_Q08SOG26}OOQ07`G26rG26rOOQULD-QLD-QO&:aQWOLD-QOOQULD-SLD-SOOQU!)9Eq!)9EqO#'_QWO!)9EqOOQU!$(!l!$(!lOOQU!.K;]!.K;]O'BpQ(CYOG26}O!*fQ^O'#DyO1PQWO'#EWO'DfQrO'#JiO!*fQ^O'#DqO'DmQ^O'#D}O'DtQrO'#ChO'G[QrO'#ChO!*fQ^O'#EPO'GlQ^O,5;VO!*fQ^O,5;aO!*fQ^O,5;aO!*fQ^O,5;aO!*fQ^O,5;aO!*fQ^O,5;aO!*fQ^O,5;aO!*fQ^O,5;aO!*fQ^O,5;aO!*fQ^O,5;aO!*fQ^O,5;aO!*fQ^O,5;aO!*fQ^O'#IiO'IoQWO,5<eO'IwQ7[O,5;aO'KbQ7[O,5;aO!*fQ^O,5;uO!&dQ7[O'#GgO'IwQ7[O'#GgO!&dQ7[O'#GiO'IwQ7[O'#GiO1SQWO'#DVO1SQWO'#DVO!&dQ7[O'#FzO'IwQ7[O'#FzO!&dQ7[O'#F|O'IwQ7[O'#F|O!&dQ7[O'#G[O'IwQ7[O'#G[O!*fQ^O,5:iO'KiQ`O'#D[O!*fQ^O,5@fO'GlQ^O1G0qO'KsQ(CYO'#ChO!*fQ^O1G1|O!&dQ7[O'#InO'IwQ7[O'#InO!&dQ7[O'#IpO'IwQ7[O'#IpO'K}QpO'#CqO!&dQ7[O,5<oO'IwQ7[O,5<oO'GlQ^O1G1}O!*fQ^O7+&xO!&dQ7[O1G2ZO'IwQ7[O1G2ZO!&dQ7[O'#InO'IwQ7[O'#InO!&dQ7[O'#IpO'IwQ7[O'#IpO!&dQ7[O1G2]O'IwQ7[O1G2]O'GlQ^O7+'iO'GlQ^O7+&]O!&dQ7[OANAcO'IwQ7[OANAcO'LbQWO'#EkO'LgQWO'#EkO'LoQWO'#FZO'LtQWO'#EuO'LyQWO'#JzO'MUQWO'#JxO'MaQWO,5;VO'MfQ7[O,5<bO'MmQWO'#GTO'MrQWO'#GTO'MwQWO,5<cO'NPQWO,5;VO'NXQ(CYO1G1^O'N`QWO,5<oO'NeQWO,5<oO'NjQWO,5<qO'NoQWO,5<qO'NtQWO1G1}O'NyQWO1G0qO( OQ7[O<<KwO( VQ7[O<<KwO7hQ7[O'#FxO9UQWO'#FwOA]QWO'#EjO!*fQ^O,5;rO!3fQWO'#GTO!3fQWO'#GTO!3fQWO'#GVO!3fQWO'#GVO!(SQ7[O7+(]O!(SQ7[O7+(]O%.WQpO1G2qO%.WQpO1G2qO!&dQ7[O,5=VO!&dQ7[O,5=V",stateData:"(!Z~O'tOS'uOSSOS'vRQ~OPYOQYORfOX!VO`qOczOdyOlkOnYOokOpkOvkOxYOzYO!PWO!TkO!UkO![XO!fuO!kZO!nYO!oYO!pYO!rvO!twO!wxO!{]O#s!PO$T|O%b}O%d!QO%f!OO%g!OO%h!OO%k!RO%m!SO%p!TO%q!TO%s!UO&P!WO&V!XO&X!YO&Z!ZO&]![O&`!]O&f!^O&l!_O&n!`O&p!aO&r!bO&t!cO'{SO'}TO(QUO(XVO(g[O(uiO~OVtO~P`OPYOQYORfOc!jOd!iOlkOnYOokOpkOvkOxYOzYO!PWO!TkO!UkO![!eO!fuO!kZO!nYO!oYO!pYO!rvO!t!gO!w!hO$T!kO'{!dO'}TO(QUO(XVO(g[O(uiO~O`!wOo!nO!P!oO!_!yO!`!vO!a!vO!{:jO#P!pO#Q!pO#R!xO#S!pO#T!pO#W!zO#X!zO'|!lO'}TO(QUO([!mO(g!sO~O'v!{O~OP[XZ[X`[Xn[X|[X}[X!P[X!Y[X!h[X!i[X!k[X!o[X#[[X#geX#j[X#k[X#l[X#m[X#n[X#o[X#p[X#q[X#r[X#t[X#v[X#x[X#y[X$O[X'r[X(X[X(i[X(p[X(q[X~O!d$|X~P(qO^!}O'}#PO(O!}O(P#PO~O^#QO(P#PO(Q#PO(R#QO~Ot#SO!R#TO(Y#TO(Z#VO~OPYOQYORfOc!jOd!iOlkOnYOokOpkOvkOxYOzYO!PWO!TkO!UkO![!eO!fuO!kZO!nYO!oYO!pYO!rvO!t!gO!w!hO$T!kO'{:nO'}TO(QUO(XVO(g[O(uiO~O!X#ZO!Y#WO!V(_P!V(mP~P+}O!Z#cO~P`OPYOQYORfOc!jOd!iOnYOokOpkOvkOxYOzYO!PWO!TkO!UkO![!eO!fuO!kZO!nYO!oYO!pYO!rvO!t!gO!w!hO$T!kO'}TO(QUO(XVO(g[O(uiO~Ol#mO!X#iO!{]O#e#lO#f#iO'{:oO!j(jP~P.iO!k#oO'{#nO~O!w#sO!{]O%b#tO~O#g#uO~O!d#vO#g#uO~OP$^OZ$eOn$RO|#zO}#{O!P#|O!Y$bO!h$TO!i#xO!k#yO!o$^O#j$PO#k$QO#l$QO#m$QO#n$SO#o$TO#p$TO#q$dO#r$TO#t$UO#v$WO#x$YO#y$ZO(XVO(i$[O(p#}O(q$OO~O`(]X'r(]X'p(]X!j(]X!V(]X![(]X%c(]X!d(]X~P1qO#[$fO$O$fOP(^XZ(^Xn(^X|(^X}(^X!P(^X!Y(^X!h(^X!k(^X!o(^X#j(^X#k(^X#l(^X#m(^X#n(^X#o(^X#p(^X#q(^X#r(^X#t(^X#v(^X#x(^X#y(^X(X(^X(i(^X(p(^X(q(^X![(^X%c(^X~O`(^X!i(^X'r(^X'p(^X!V(^X!j(^Xr(^X!d(^X~P4XO#[$fO~O$Y$hO$[$gO$c$mO~ORfO![$nO$f$oO$h$qO~Og%WOl%XOn$uOo$tOp$tOv%YOx%ZOz%[O!P$|O![$}O!f%aO!k$yO#f%bO$T%_O$o%]O$q%^O$t%`O'{$sO'}TO(QUO(X$vO(p%OO(q%QOf(UP~O!k%cO~O!P%fO![%gO'{%eO~O!d%kO~O`%lO'r%lO~O'|!lO~P%[O%h%sO~P%[Og%WO!k%cO'{%eO'|!lO~Od%zO!k%cO'{%eO~O#r$TO~O|&PO![%|O!k&OO%d&SO'{%eO'|!lO'}TO(QUO_)OP~O!w#sO~O%m&UO!P(zX![(zX'{(zX~O'{&VO~O!t&[O#s!PO%d!QO%f!OO%g!OO%h!OO%k!RO%m!SO%p!TO%q!TO~Oc&aOd&`O!w&^O%b&_O%u&]O~P;xOc&dOdyO![&cO!t&[O!wxO!{]O#s!PO%b}O%f!OO%g!OO%h!OO%k!RO%m!SO%p!TO%q!TO%s!UO~Oa&gO#[&jO%d&eO'|!lO~P<}O!k&kO!t&oO~O!k#oO~O![XO~O`%lO'q&wO'r%lO~O`%lO'q&zO'r%lO~O`%lO'q&|O'r%lO~O'p[X!V[Xr[X!j[X&T[X![[X%c[X!d[X~P(qO!_'ZO!`'SO!a'SO'|!lO'}TO(QUO~Oo'QO!P'PO!X'TO(['OO!Z(`P!Z(oP~P@UOj'^O!['[O'{%eO~Od'cO!k%cO'{%eO~O|&PO!k&OO~Oo!nO!P!oO!{:jO#P!pO#Q!pO#S!pO#T!pO'|!lO'}TO(QUO([!mO(g!sO~O!_'iO!`'hO!a'hO#R!pO#W'jO#X'jO~PApO`%lOg%WO!d#vO!k%cO'r%lO(i'lO~O!o'pO#['nO~PCOOo!nO!P!oO'}TO(QUO([!mO(g!sO~O![XOo(eX!P(eX!_(eX!`(eX!a(eX!{(eX#P(eX#Q(eX#R(eX#S(eX#T(eX#W(eX#X(eX'|(eX'}(eX(Q(eX([(eX(g(eX~O!`'hO!a'hO'|!lO~PCnO'w'tO'x'tO'y'vO~O^!}O'}'xO(O!}O(P'xO~O^#QO(P'xO(Q'xO(R#QO~Ot#SO!R#TO(Y#TO(Z'|O~O!X(OO!V'PX!V'VX!Y'PX!Y'VX~P+}O!Y(QO!V(_X~OP$^OZ$eOn$RO|#zO}#{O!P#|O!Y(QO!h$TO!i#xO!k#yO!o$^O#j$PO#k$QO#l$QO#m$QO#n$SO#o$TO#p$TO#q$dO#r$TO#t$UO#v$WO#x$YO#y$ZO(XVO(i$[O(p#}O(q$OO~O!V(_X~PGbO!V(VO~O!V(lX!Y(lX!d(lX!j(lX(i(lX~O#[(lX#g#`X!Z(lX~PIhO#[(WO!V(nX!Y(nX~O!Y(XO!V(mX~O!V([O~O#[$fO~PIhO!Z(]O~P`O|#zO}#{O!P#|O!i#xO!k#yO(XVOP!maZ!man!ma!Y!ma!h!ma!o!ma#j!ma#k!ma#l!ma#m!ma#n!ma#o!ma#p!ma#q!ma#r!ma#t!ma#v!ma#x!ma#y!ma(i!ma(p!ma(q!ma~O`!ma'r!ma'p!ma!V!ma!j!mar!ma![!ma%c!ma!d!ma~PKOO!j(^O~O!d#vO#[(_O(i'lO!Y(kX`(kX'r(kX~O!j(kX~PMnO!P%fO![%gO!{]O#e(dO#f(cO'{%eO~O!Y(eO!j(jX~O!j(gO~O!P%fO![%gO#f(cO'{%eO~OP(^XZ(^Xn(^X|(^X}(^X!P(^X!Y(^X!h(^X!i(^X!k(^X!o(^X#j(^X#k(^X#l(^X#m(^X#n(^X#o(^X#p(^X#q(^X#r(^X#t(^X#v(^X#x(^X#y(^X(X(^X(i(^X(p(^X(q(^X~O!d#vO!j(^X~P! [O|(hO}(iO!i#xO!k#yO!{!za!P!za~O!w!za%b!za![!za#e!za#f!za'{!za~P!#`O!w(mO~OPYOQYORfOc!jOd!iOlkOnYOokOpkOvkOxYOzYO!PWO!TkO!UkO![XO!fuO!kZO!nYO!oYO!pYO!rvO!t!gO!w!hO$T!kO'{!dO'}TO(QUO(XVO(g[O(uiO~Og%WOl%XOn$uOo$tOp$tOv%YOx%ZOz;WO!P$|O![$}O!f<hO!k$yO#f;^O$T%_O$o;YO$q;[O$t%`O'{(qO'}TO(QUO(X$vO(p%OO(q%QO~O#g(sO~Og%WOl%XOn$uOo$tOp$tOv%YOx%ZOz%[O!P$|O![$}O!f%aO!k$yO#f%bO$T%_O$o%]O$q%^O$t%`O'{(qO'}TO(QUO(X$vO(p%OO(q%QO~Of(bP~P!(SO!X(wO!j(cP~P%[O([(yO(g[O~O!P({O!k#yO([(yO(g[O~OP:iOQ:iORfOc<dOd!iOlkOn:iOokOpkOvkOx:iOz:iO!PWO!TkO!UkO![!eO!f:lO!kZO!n:iO!o:iO!p:iO!r:mO!t:pO!w!hO$T!kO'{)ZO'}TO(QUO(XVO(g[O(u<bO~O})^O!k#yO~O!Y$bO`$ma'r$ma'p$ma!j$ma!V$ma![$ma%c$ma!d$ma~O#s)bO~P!&dO|)eO!d)dO![$ZX$W$ZX$Y$ZX$[$ZX$c$ZX~O!d)dO![(rX$W(rX$Y(rX$[(rX$c(rX~O|)eO~P!.OO|)eO![(rX$W(rX$Y(rX$[(rX$c(rX~O![)gO$W)kO$Y)fO$[)fO$c)lO~O!X)oO~P!*fO$Y$hO$[$gO$c)sO~Oj$uX|$uX!P$uX!i$uX(p$uX(q$uX~OfiXf$uXjiX!YiX#[iX~P!/tOo)uO~Ot)vO(Y)wO(Z)yO~Oj*SO|){O!P)|O(p%OO(q%QO~Of)zO~P!0}Of*TO~Og%WOl%XOn$uOo$tOp$tOv%YOx%ZOz;WO!P*VO![*WO!f<hO!k$yO#f;^O$T%_O$o;YO$q;[O$t%`O'}TO(QUO(X$vO(p%OO(q%QO~O!X*ZO'{*UO!j(vP~P!1lO#g*]O~O!k*^O~Og%WOl%XOn$uOo$tOp$tOv%YOx%ZOz;WO!P$|O![$}O!f<hO!k$yO#f;^O$T%_O$o;YO$q;[O$t%`O'{*`O'}TO(QUO(X$vO(p%OO(q%QO~O!X*cO!V(wP~P!3kOn*oO!P*gO!_*mO!`*fO!a*fO!k*^O#W*nO%Y*iO'|!lO([!mO~O!Z*lO~P!5`O!i#xOj(WX|(WX!P(WX(p(WX(q(WX!Y(WX#[(WX~Of(WX#|(WX~P!6XOj*tO#[*sOf(VX!Y(VX~O!Y*uOf(UX~O'{&VOf(UP~O!k*|O~O'{(qO~Ol+QO!P%fO!X#iO![%gO!{]O#e#lO#f#iO'{%eO!j(jP~O!d#vO#g+RO~O!P%fO!X+TO!Y(XO![%gO'{%eO!V(mP~Oo'WO!P+VO!X+UO'}TO(QUO([(yO~O!Z(oP~P!9SO!Y+WO`({X'r({X~OP$^OZ$eOn$RO|#zO}#{O!P#|O!h$TO!i#xO!k#yO!o$^O#j$PO#k$QO#l$QO#m$QO#n$SO#o$TO#p$TO#q$dO#r$TO#t$UO#v$WO#x$YO#y$ZO(XVO(i$[O(p#}O(q$OO~O`!ea!Y!ea'r!ea'p!ea!V!ea!j!ear!ea![!ea%c!ea!d!ea~P!9zO|#zO}#{O!P#|O!i#xO!k#yO(XVOP!qaZ!qan!qa!Y!qa!h!qa!o!qa#j!qa#k!qa#l!qa#m!qa#n!qa#o!qa#p!qa#q!qa#r!qa#t!qa#v!qa#x!qa#y!qa(i!qa(p!qa(q!qa~O`!qa'r!qa'p!qa!V!qa!j!qar!qa![!qa%c!qa!d!qa~P!<eO|#zO}#{O!P#|O!i#xO!k#yO(XVOP!saZ!san!sa!Y!sa!h!sa!o!sa#j!sa#k!sa#l!sa#m!sa#n!sa#o!sa#p!sa#q!sa#r!sa#t!sa#v!sa#x!sa#y!sa(i!sa(p!sa(q!sa~O`!sa'r!sa'p!sa!V!sa!j!sar!sa![!sa%c!sa!d!sa~P!?OOg%WOj+aO!['[O%c+`O~O!d+cO`(TX![(TX'r(TX!Y(TX~O`%lO![XO'r%lO~Og%WO!k%cO~Og%WO!k%cO'{%eO~O!d#vO#g(sO~Oa+nO%d+oO'{+kO'}TO(QUO!Z)PP~O!Y+pO_)OX~OZ+tO~O_+uO~O![%|O'{%eO'|!lO_)OP~Og%WO#[+zO~Og%WOj+}O![$}O~O![,PO~O|,RO![XO~O%h%sO~O!w,WO~Od,]O~Oa,^O'{#nO'}TO(QUO!Z(}P~Od%zO~O%d!QO'{&VO~P<}OZ,cO_,bO~OPYOQYORfOczOdyOlkOnYOokOpkOvkOxYOzYO!PWO!TkO!UkO!fuO!kZO!nYO!oYO!pYO!rvO!wxO!{]O%b}O'}TO(QUO(XVO(g[O(uiO~O![!eO!t!gO$T!kO'{!dO~P!FRO_,bO`%lO'r%lO~OPYOQYORfOc!jOd!iOlkOnYOokOpkOvkOxYOzYO!PWO!TkO!UkO![!eO!fuO!kZO!nYO!oYO!pYO!rvO!w!hO$T!kO'{!dO'}TO(QUO(XVO(g[O(uiO~O`,hO!twO#s!OO%f!OO%g!OO%h!OO~P!HkO!k&kO~O&V,nO~O![,pO~O&h,rO&j,sOP&eaQ&eaR&eaX&ea`&eac&ead&eal&ean&eao&eap&eav&eax&eaz&ea!P&ea!T&ea!U&ea![&ea!f&ea!k&ea!n&ea!o&ea!p&ea!r&ea!t&ea!w&ea!{&ea#s&ea$T&ea%b&ea%d&ea%f&ea%g&ea%h&ea%k&ea%m&ea%p&ea%q&ea%s&ea&P&ea&V&ea&X&ea&Z&ea&]&ea&`&ea&f&ea&l&ea&n&ea&p&ea&r&ea&t&ea'p&ea'{&ea'}&ea(Q&ea(X&ea(g&ea(u&ea!Z&ea&^&eaa&ea&c&ea~O'{,xO~Og!bX!Y!OX!Z!OX!d!OX!d!bX!k!bX#[!OX~O!Y!bX!Z!bX~P# qO!d,}O#[,|Og(aX!Y#dX!Y(aX!Z#dX!Z(aX!d(aX!k(aX~Og%WO!d-PO!k%cO!Y!^X!Z!^X~Oo!nO!P!oO'}TO(QUO([!mO~OP:iOQ:iORfOc<dOd!iOlkOn:iOokOpkOvkOx:iOz:iO!PWO!TkO!UkO![!eO!f:lO!kZO!n:iO!o:iO!p:iO!r:mO!t:pO!w!hO$T!kO'}TO(QUO(XVO(g[O(u<bO~O'{;dO~P##uO!Y-TO!Z(`X~O!Z-VO~O!d,}O#[,|O!Y#dX!Z#dX~O!Y-WO!Z(oX~O!Z-YO~O!`-ZO!a-ZO'|!lO~P##dO!Z-^O~P'_Oj-aO!['[O~O!V-fO~Oo!za!_!za!`!za!a!za#P!za#Q!za#R!za#S!za#T!za#W!za#X!za'|!za'}!za(Q!za([!za(g!za~P!#`O!o-kO#[-iO~PCOO!`-mO!a-mO'|!lO~PCnO`%lO#[-iO'r%lO~O`%lO!d#vO#[-iO'r%lO~O`%lO!d#vO!o-kO#[-iO'r%lO(i'lO~O'w'tO'x'tO'y-rO~Or-sO~O!V'Pa!Y'Pa~P!9zO!X-wO!V'PX!Y'PX~P%[O!Y(QO!V(_a~O!V(_a~PGbO!Y(XO!V(ma~O!P%fO!X-{O![%gO'{%eO!V'VX!Y'VX~O#[-}O!Y(ka!j(ka`(ka'r(ka~O!d#vO~P#+{O!Y(eO!j(ja~O!P%fO![%gO#f.RO'{%eO~Ol.WO!P%fO!X.TO![%gO!{]O#e.VO#f.TO'{%eO!Y'YX!j'YX~O}.[O!k#yO~Og%WOj._O!['[O%c.^O~O`#_i!Y#_i'r#_i'p#_i!V#_i!j#_ir#_i![#_i%c#_i!d#_i~P!9zOj<nO|){O!P)|O(p%OO(q%QO~O#g#Za`#Za#[#Za'r#Za!Y#Za!j#Za![#Za!V#Za~P#.wO#g(WXP(WXZ(WX`(WXn(WX}(WX!h(WX!k(WX!o(WX#j(WX#k(WX#l(WX#m(WX#n(WX#o(WX#p(WX#q(WX#r(WX#t(WX#v(WX#x(WX#y(WX'r(WX(X(WX(i(WX!j(WX!V(WX'p(WXr(WX![(WX%c(WX!d(WX~P!6XO!Y.lOf(bX~P!0}Of.nO~O!Y.oO!j(cX~P!9zO!j.rO~O!V.tO~OP$^O|#zO}#{O!P#|O!i#xO!k#yO!o$^O(XVOZ#ii`#iin#ii!Y#ii!h#ii#k#ii#l#ii#m#ii#n#ii#o#ii#p#ii#q#ii#r#ii#t#ii#v#ii#x#ii#y#ii'r#ii(i#ii(p#ii(q#ii'p#ii!V#ii!j#iir#ii![#ii%c#ii!d#ii~O#j#ii~P#2sO#j$PO~P#2sOP$^O|#zO}#{O!P#|O!i#xO!k#yO!o$^O#j$PO#k$QO#l$QO#m$QO(XVOZ#ii`#ii!Y#ii!h#ii#n#ii#o#ii#p#ii#q#ii#r#ii#t#ii#v#ii#x#ii#y#ii'r#ii(i#ii(p#ii(q#ii'p#ii!V#ii!j#iir#ii![#ii%c#ii!d#ii~On#ii~P#5eOn$RO~P#5eOP$^On$RO|#zO}#{O!P#|O!i#xO!k#yO!o$^O#j$PO#k$QO#l$QO#m$QO#n$SO(XVO`#ii!Y#ii#t#ii#v#ii#x#ii#y#ii'r#ii(i#ii(p#ii(q#ii'p#ii!V#ii!j#iir#ii![#ii%c#ii!d#ii~OZ#ii!h#ii#o#ii#p#ii#q#ii#r#ii~P#8VOZ$eO!h$TO#o$TO#p$TO#q$dO#r$TO~P#8VOP$^OZ$eOn$RO|#zO}#{O!P#|O!h$TO!i#xO!k#yO!o$^O#j$PO#k$QO#l$QO#m$QO#n$SO#o$TO#p$TO#q$dO#r$TO#t$UO(XVO(q$OO`#ii!Y#ii#x#ii#y#ii'r#ii(i#ii(p#ii'p#ii!V#ii!j#iir#ii![#ii%c#ii!d#ii~O#v$WO~P#;WO#v#ii~P#;WOP$^OZ$eOn$RO|#zO}#{O!P#|O!h$TO!i#xO!k#yO!o$^O#j$PO#k$QO#l$QO#m$QO#n$SO#o$TO#p$TO#q$dO#r$TO#t$UO(XVO`#ii!Y#ii#x#ii#y#ii'r#ii(i#ii'p#ii!V#ii!j#iir#ii![#ii%c#ii!d#ii~O#v#ii(p#ii(q#ii~P#=xO#v$WO(p#}O(q$OO~P#=xOP$^OZ$eOn$RO|#zO}#{O!P#|O!h$TO!i#xO!k#yO!o$^O#j$PO#k$QO#l$QO#m$QO#n$SO#o$TO#p$TO#q$dO#r$TO#t$UO#v$WO#x$YO(XVO(p#}O(q$OO~O`#ii!Y#ii#y#ii'r#ii(i#ii'p#ii!V#ii!j#iir#ii![#ii%c#ii!d#ii~P#@pOP[XZ[Xn[X|[X}[X!P[X!h[X!i[X!k[X!o[X#[[X#geX#j[X#k[X#l[X#m[X#n[X#o[X#p[X#q[X#r[X#t[X#v[X#x[X#y[X$O[X(X[X(i[X(p[X(q[X!Y[X!Z[X~O#|[X~P#CZOP$^OZ;QOn:tO|#zO}#{O!P#|O!h:vO!i#xO!k#yO!o$^O#j:rO#k:sO#l:sO#m:sO#n:uO#o:vO#p:vO#q;PO#r:vO#t:wO#v:yO#x:{O#y:|O(XVO(i$[O(p#}O(q$OO~O#|.vO~P#EhO#[;RO$O;RO#|(^X!Z(^X~P! [O`']a!Y']a'r']a'p']a!j']a!V']ar']a![']a%c']a!d']a~P!9zOP#iiZ#ii`#iin#ii}#ii!Y#ii!h#ii!i#ii!k#ii!o#ii#j#ii#k#ii#l#ii#m#ii#n#ii#o#ii#p#ii#q#ii#r#ii#t#ii#v#ii#x#ii#y#ii'r#ii(X#ii(i#ii'p#ii!V#ii!j#iir#ii![#ii%c#ii!d#ii~P#.wO`#}i!Y#}i'r#}i'p#}i!V#}i!j#}ir#}i![#}i%c#}i!d#}i~P!9zO$Y.{O$[.{O~O$Y.|O$[.|O~O!d)dO#[.}O![$`X$W$`X$Y$`X$[$`X$c$`X~O!X/OO~O![)gO$W/QO$Y)fO$[)fO$c/RO~O!Y:}O!Z(]X~P#EhO!Z/SO~O!d)dO$c(rX~O$c/UO~Ot)vO(Y)wO(Z/XO~O!V/]O~P!&dO(p%OOj%Za|%Za!P%Za(q%Za!Y%Za#[%Za~Of%Za#|%Za~P#MxO(q%QOj%]a|%]a!P%]a(p%]a!Y%]a#[%]a~Of%]a#|%]a~P#NkO!YeX!deX!jeX!j$uX(ieX~P!/tO!X/fO!Y(XO'{/eO!V(mP!V(wP~P!1lOn*oO!_*mO!`*fO!a*fO!k*^O#W*nO%Y*iO'|!lO~Oo'WO!P/gO!X+UO!Z*lO'}TO(QUO([;aO!Z(oP~P$!UO!j/hO~P#.wO!Y/iO!d#vO(i'lO!j(vX~O!j/nO~O!P%fO!X*ZO![%gO'{%eO!j(vP~O#g/pO~O!V$uX!Y$uX!d$|X~P!/tO!Y/qO!V(wX~P#.wO!d/sO~O!V/uO~Og%WOn/yO!d#vO!k%cO(i'lO~O'{/{O~O!d+cO~O`%lO!Y0PO'r%lO~O!Z0RO~P!5`O!`0SO!a0SO'|!lO([!mO~O!P0UO([!mO~O#W0VO~Of%Za!Y%Za#[%Za#|%Za~P!0}Of%]a!Y%]a#[%]a#|%]a~P!0}O'{&VOf'fX!Y'fX~O!Y*uOf(Ua~Of0`O~O|0aO}0aO!P0bOjya(pya(qya!Yya#[ya~Ofya#|ya~P$'wO|){O!P)|Oj$na(p$na(q$na!Y$na#[$na~Of$na#|$na~P$(mO|){O!P)|Oj$pa(p$pa(q$pa!Y$pa#[$pa~Of$pa#|$pa~P$)`O#g0dO~Of%Oa!Y%Oa#[%Oa#|%Oa~P!0}O!d#vO~O#g0gO~O!Y+WO`({a'r({a~O|#zO}#{O!P#|O!i#xO!k#yO(XVOP!qiZ!qin!qi!Y!qi!h!qi!o!qi#j!qi#k!qi#l!qi#m!qi#n!qi#o!qi#p!qi#q!qi#r!qi#t!qi#v!qi#x!qi#y!qi(i!qi(p!qi(q!qi~O`!qi'r!qi'p!qi!V!qi!j!qir!qi![!qi%c!qi!d!qi~P$*}Og%WOn$uOo$tOp$tOv%YOx%ZOz;WO!P$|O![$}O!f<hO!k$yO#f;^O$T%_O$o;YO$q;[O$t%`O'}TO(QUO(X$vO(p%OO(q%QO~Ol0qO'{0pO~P$-hO!d+cO`(Ta![(Ta'r(Ta!Y(Ta~O#g0wO~OZ[X!YeX!ZeX~O!Y0xO!Z)PX~O!Z0zO~OZ0{O~Oa0}O'{+kO'}TO(QUO~O![%|O'{%eO_'nX!Y'nX~O!Y+pO_)Oa~O!j1QO~P!9zOZ1TO~O_1UO~O#[1XO~Oj1[O![$}O~O([(yO!Z(|P~Og%WOj1eO![1bO%c1dO~OZ1oO!Y1mO!Z(}X~O!Z1pO~O_1rO`%lO'r%lO~O'{#nO'}TO(QUO~O#[$fO$O$fOP(^XZ(^Xn(^X|(^X}(^X!P(^X!Y(^X!h(^X!k(^X!o(^X#j(^X#k(^X#l(^X#m(^X#n(^X#o(^X#p(^X#q(^X#t(^X#v(^X#x(^X#y(^X(X(^X(i(^X(p(^X(q(^X~O#r1uO&T1vO`(^X!i(^X~P$3OO#[$fO#r1uO&T1vO~O`1xO~P%[O`1zO~O&^1}OP&[iQ&[iR&[iX&[i`&[ic&[id&[il&[in&[io&[ip&[iv&[ix&[iz&[i!P&[i!T&[i!U&[i![&[i!f&[i!k&[i!n&[i!o&[i!p&[i!r&[i!t&[i!w&[i!{&[i#s&[i$T&[i%b&[i%d&[i%f&[i%g&[i%h&[i%k&[i%m&[i%p&[i%q&[i%s&[i&P&[i&V&[i&X&[i&Z&[i&]&[i&`&[i&f&[i&l&[i&n&[i&p&[i&r&[i&t&[i'p&[i'{&[i'}&[i(Q&[i(X&[i(g&[i(u&[i!Z&[ia&[i&c&[i~Oa2TO!Z2RO&c2SO~P`O![XO!k2VO~O&j,sOP&eiQ&eiR&eiX&ei`&eic&eid&eil&ein&eio&eip&eiv&eix&eiz&ei!P&ei!T&ei!U&ei![&ei!f&ei!k&ei!n&ei!o&ei!p&ei!r&ei!t&ei!w&ei!{&ei#s&ei$T&ei%b&ei%d&ei%f&ei%g&ei%h&ei%k&ei%m&ei%p&ei%q&ei%s&ei&P&ei&V&ei&X&ei&Z&ei&]&ei&`&ei&f&ei&l&ei&n&ei&p&ei&r&ei&t&ei'p&ei'{&ei'}&ei(Q&ei(X&ei(g&ei(u&ei!Z&ei&^&eia&ei&c&ei~O!V2]O~O!Y!^a!Z!^a~P#EhOo!nO!P!oO!X2cO([!mO!Y'QX!Z'QX~P@UO!Y-TO!Z(`a~O!Y'WX!Z'WX~P!9SO!Y-WO!Z(oa~O!Z2jO~P'_O`%lO#[2sO'r%lO~O`%lO!d#vO#[2sO'r%lO~O`%lO!d#vO!o2wO#[2sO'r%lO(i'lO~O`%lO'r%lO~P!9zO!Y$bOr$ma~O!V'Pi!Y'Pi~P!9zO!Y(QO!V(_i~O!Y(XO!V(mi~O!V(ni!Y(ni~P!9zO!Y(ki!j(ki`(ki'r(ki~P!9zO#[2yO!Y(ki!j(ki`(ki'r(ki~O!Y(eO!j(ji~O!P%fO![%gO!{]O#e3OO#f2}O'{%eO~O!P%fO![%gO#f2}O'{%eO~Oj3VO!['[O%c3UO~Og%WOj3VO!['[O%c3UO~O#g%ZaP%ZaZ%Za`%Zan%Za}%Za!h%Za!i%Za!k%Za!o%Za#j%Za#k%Za#l%Za#m%Za#n%Za#o%Za#p%Za#q%Za#r%Za#t%Za#v%Za#x%Za#y%Za'r%Za(X%Za(i%Za!j%Za!V%Za'p%Zar%Za![%Za%c%Za!d%Za~P#MxO#g%]aP%]aZ%]a`%]an%]a}%]a!h%]a!i%]a!k%]a!o%]a#j%]a#k%]a#l%]a#m%]a#n%]a#o%]a#p%]a#q%]a#r%]a#t%]a#v%]a#x%]a#y%]a'r%]a(X%]a(i%]a!j%]a!V%]a'p%]ar%]a![%]a%c%]a!d%]a~P#NkO#g%ZaP%ZaZ%Za`%Zan%Za}%Za!Y%Za!h%Za!i%Za!k%Za!o%Za#j%Za#k%Za#l%Za#m%Za#n%Za#o%Za#p%Za#q%Za#r%Za#t%Za#v%Za#x%Za#y%Za'r%Za(X%Za(i%Za!j%Za!V%Za'p%Za#[%Zar%Za![%Za%c%Za!d%Za~P#.wO#g%]aP%]aZ%]a`%]an%]a}%]a!Y%]a!h%]a!i%]a!k%]a!o%]a#j%]a#k%]a#l%]a#m%]a#n%]a#o%]a#p%]a#q%]a#r%]a#t%]a#v%]a#x%]a#y%]a'r%]a(X%]a(i%]a!j%]a!V%]a'p%]a#[%]ar%]a![%]a%c%]a!d%]a~P#.wO#gyaPyaZya`yanya!hya!iya!kya!oya#jya#kya#lya#mya#nya#oya#pya#qya#rya#tya#vya#xya#yya'rya(Xya(iya!jya!Vya'pyarya![ya%cya!dya~P$'wO#g$naP$naZ$na`$nan$na}$na!h$na!i$na!k$na!o$na#j$na#k$na#l$na#m$na#n$na#o$na#p$na#q$na#r$na#t$na#v$na#x$na#y$na'r$na(X$na(i$na!j$na!V$na'p$nar$na![$na%c$na!d$na~P$(mO#g$paP$paZ$pa`$pan$pa}$pa!h$pa!i$pa!k$pa!o$pa#j$pa#k$pa#l$pa#m$pa#n$pa#o$pa#p$pa#q$pa#r$pa#t$pa#v$pa#x$pa#y$pa'r$pa(X$pa(i$pa!j$pa!V$pa'p$par$pa![$pa%c$pa!d$pa~P$)`O#g%OaP%OaZ%Oa`%Oan%Oa}%Oa!Y%Oa!h%Oa!i%Oa!k%Oa!o%Oa#j%Oa#k%Oa#l%Oa#m%Oa#n%Oa#o%Oa#p%Oa#q%Oa#r%Oa#t%Oa#v%Oa#x%Oa#y%Oa'r%Oa(X%Oa(i%Oa!j%Oa!V%Oa'p%Oa#[%Oar%Oa![%Oa%c%Oa!d%Oa~P#.wO`#_q!Y#_q'r#_q'p#_q!V#_q!j#_qr#_q![#_q%c#_q!d#_q~P!9zOf'RX!Y'RX~P!(SO!Y.lOf(ba~O!X3aO!Y'SX!j'SX~P%[O!Y.oO!j(ca~O!Y.oO!j(ca~P!9zO!V3dO~O#|!ma!Z!ma~PKOO#|!ea!Y!ea!Z!ea~P#EhO#|!qa!Z!qa~P!<eO#|!sa!Z!sa~P!?OORfO![3vO$a3wO~O!Z3{O~Or3|O~P#.wO`$jq!Y$jq'r$jq'p$jq!V$jq!j$jqr$jq![$jq%c$jq!d$jq~P!9zO!V3}O~P#.wO|){O!P)|O(q%QOj'ba(p'ba!Y'ba#['ba~Of'ba#|'ba~P%,rO|){O!P)|Oj'da(p'da(q'da!Y'da#['da~Of'da#|'da~P%-eO(i$[O~P#.wO!VeX!V$uX!YeX!Y$uX!d$|X#[eX~P!/tO'{;jO~P!1lOlkO'{4PO~P.iO!P%fO!X4RO![%gO'{%eO!Y'^X!j'^X~O!Y/iO!j(va~O!Y/iO!d#vO!j(va~O!Y/iO!d#vO(i'lO!j(va~Of$wi!Y$wi#[$wi#|$wi~P!0}O!X4ZO!V'`X!Y'`X~P!3kO!Y/qO!V(wa~O!Y/qO!V(wa~P#.wO!d#vO#r4cO~On4fO!d#vO(i'lO~O(p%OOj%Zi|%Zi!P%Zi(q%Zi!Y%Zi#[%Zi~Of%Zi#|%Zi~P%1sO(q%QOj%]i|%]i!P%]i(p%]i!Y%]i#[%]i~Of%]i#|%]i~P%2fOf(Vi!Y(Vi~P!0}O#[4mOf(Vi!Y(Vi~P!0}O!j4pO~O`$kq!Y$kq'r$kq'p$kq!V$kq!j$kqr$kq![$kq%c$kq!d$kq~P!9zO!V4tO~O!Y4uO![(xX~P#.wO!i#xO~P4XO`$uX![$uX%W[X'r$uX!Y$uX~P!/tO%W4wO`kXjkX|kX!PkX![kX'rkX(pkX(qkX!YkX~O%W4wO~Oa4}O%d5OO'{+kO'}TO(QUO!Y'mX!Z'mX~O!Y0xO!Z)Pa~OZ5SO~O_5TO~O`%lO'r%lO~P#.wO![$}O~P#.wO!Y5]O#[5_O!Z(|X~O!Z5`O~Oo!nO!P5aO!_!yO!`!vO!a!vO!{:jO#P!pO#Q!pO#R!pO#S!pO#T!pO#W5fO#X!zO'|!lO'}TO(QUO([!mO(g!sO~O!Z5eO~P%7wOj5kO![1bO%c5jO~Og%WOj5kO![1bO%c5jO~Oa5rO'{#nO'}TO(QUO!Y'lX!Z'lX~O!Y1mO!Z(}a~O'}TO(QUO([5tO~O_5xO~O#r5{O&T5|O~PMnO!j5}O~P%[O`6PO~O`6PO~P%[Oa2TO!Z6UO&c2SO~P`O!d6WO~O!d6YOg(ai!Y(ai!Z(ai!d(ai!k(ai~O!Y#di!Z#di~P#EhO#[6ZO!Y#di!Z#di~O!Y!^i!Z!^i~P#EhO`%lO#[6dO'r%lO~O`%lO!d#vO#[6dO'r%lO~O!Y(kq!j(kq`(kq'r(kq~P!9zO!Y(eO!j(jq~O!P%fO![%gO#f6kO'{%eO~O!['[O%c6nO~Oj6qO!['[O%c6nO~O#g'baP'baZ'ba`'ban'ba}'ba!h'ba!i'ba!k'ba!o'ba#j'ba#k'ba#l'ba#m'ba#n'ba#o'ba#p'ba#q'ba#r'ba#t'ba#v'ba#x'ba#y'ba'r'ba(X'ba(i'ba!j'ba!V'ba'p'bar'ba!['ba%c'ba!d'ba~P%,rO#g'daP'daZ'da`'dan'da}'da!h'da!i'da!k'da!o'da#j'da#k'da#l'da#m'da#n'da#o'da#p'da#q'da#r'da#t'da#v'da#x'da#y'da'r'da(X'da(i'da!j'da!V'da'p'dar'da!['da%c'da!d'da~P%-eO#g$wiP$wiZ$wi`$win$wi}$wi!Y$wi!h$wi!i$wi!k$wi!o$wi#j$wi#k$wi#l$wi#m$wi#n$wi#o$wi#p$wi#q$wi#r$wi#t$wi#v$wi#x$wi#y$wi'r$wi(X$wi(i$wi!j$wi!V$wi'p$wi#[$wir$wi![$wi%c$wi!d$wi~P#.wO#g%ZiP%ZiZ%Zi`%Zin%Zi}%Zi!h%Zi!i%Zi!k%Zi!o%Zi#j%Zi#k%Zi#l%Zi#m%Zi#n%Zi#o%Zi#p%Zi#q%Zi#r%Zi#t%Zi#v%Zi#x%Zi#y%Zi'r%Zi(X%Zi(i%Zi!j%Zi!V%Zi'p%Zir%Zi![%Zi%c%Zi!d%Zi~P%1sO#g%]iP%]iZ%]i`%]in%]i}%]i!h%]i!i%]i!k%]i!o%]i#j%]i#k%]i#l%]i#m%]i#n%]i#o%]i#p%]i#q%]i#r%]i#t%]i#v%]i#x%]i#y%]i'r%]i(X%]i(i%]i!j%]i!V%]i'p%]ir%]i![%]i%c%]i!d%]i~P%2fOf'Ra!Y'Ra~P!0}O!Y'Sa!j'Sa~P!9zO!Y.oO!j(ci~O#|#_i!Y#_i!Z#_i~P#EhOP$^O|#zO}#{O!P#|O!i#xO!k#yO!o$^O(XVOZ#iin#ii!h#ii#k#ii#l#ii#m#ii#n#ii#o#ii#p#ii#q#ii#r#ii#t#ii#v#ii#x#ii#y#ii#|#ii(i#ii(p#ii(q#ii!Y#ii!Z#ii~O#j#ii~P%JwO#j:rO~P%JwOP$^O|#zO}#{O!P#|O!i#xO!k#yO!o$^O#j:rO#k:sO#l:sO#m:sO(XVOZ#ii!h#ii#n#ii#o#ii#p#ii#q#ii#r#ii#t#ii#v#ii#x#ii#y#ii#|#ii(i#ii(p#ii(q#ii!Y#ii!Z#ii~On#ii~P%MSOn:tO~P%MSOP$^On:tO|#zO}#{O!P#|O!i#xO!k#yO!o$^O#j:rO#k:sO#l:sO#m:sO#n:uO(XVO#t#ii#v#ii#x#ii#y#ii#|#ii(i#ii(p#ii(q#ii!Y#ii!Z#ii~OZ#ii!h#ii#o#ii#p#ii#q#ii#r#ii~P& _OZ;QO!h:vO#o:vO#p:vO#q;PO#r:vO~P& _OP$^OZ;QOn:tO|#zO}#{O!P#|O!h:vO!i#xO!k#yO!o$^O#j:rO#k:sO#l:sO#m:sO#n:uO#o:vO#p:vO#q;PO#r:vO#t:wO(XVO(q$OO#x#ii#y#ii#|#ii(i#ii(p#ii!Y#ii!Z#ii~O#v:yO~P&#yO#v#ii~P&#yOP$^OZ;QOn:tO|#zO}#{O!P#|O!h:vO!i#xO!k#yO!o$^O#j:rO#k:sO#l:sO#m:sO#n:uO#o:vO#p:vO#q;PO#r:vO#t:wO(XVO#x#ii#y#ii#|#ii(i#ii!Y#ii!Z#ii~O#v#ii(p#ii(q#ii~P&&UO#v:yO(p#}O(q$OO~P&&UOP$^OZ;QOn:tO|#zO}#{O!P#|O!h:vO!i#xO!k#yO!o$^O#j:rO#k:sO#l:sO#m:sO#n:uO#o:vO#p:vO#q;PO#r:vO#t:wO#v:yO#x:{O(XVO(p#}O(q$OO~O#y#ii#|#ii(i#ii!Y#ii!Z#ii~P&(gO`#zy!Y#zy'r#zy'p#zy!V#zy!j#zyr#zy![#zy%c#zy!d#zy~P!9zOj<oO|){O!P)|O(p%OO(q%QO~OP#iiZ#iin#ii}#ii!h#ii!i#ii!k#ii!o#ii#j#ii#k#ii#l#ii#m#ii#n#ii#o#ii#p#ii#q#ii#r#ii#t#ii#v#ii#x#ii#y#ii#|#ii(X#ii(i#ii!Y#ii!Z#ii~P&+_O!i#xOP(WXZ(WXj(WXn(WX|(WX}(WX!P(WX!h(WX!k(WX!o(WX#j(WX#k(WX#l(WX#m(WX#n(WX#o(WX#p(WX#q(WX#r(WX#t(WX#v(WX#x(WX#y(WX#|(WX(X(WX(i(WX(p(WX(q(WX!Y(WX!Z(WX~O#|#}i!Y#}i!Z#}i~P#EhO#|!qi!Z!qi~P$*}O!Z7TO~O!Y']a!Z']a~P#EhOP[XZ[Xn[X|[X}[X!P[X!V[X!Y[X!h[X!i[X!k[X!o[X#[[X#geX#j[X#k[X#l[X#m[X#n[X#o[X#p[X#q[X#r[X#t[X#v[X#x[X#y[X$O[X(X[X(i[X(p[X(q[X~O!d%TX#r%TX~P&0aO!d#vO(i'lO!Y'^a!j'^a~O!Y/iO!j(vi~O!Y/iO!d#vO!j(vi~Of$wq!Y$wq#[$wq#|$wq~P!0}O!V'`a!Y'`a~P#.wO!d7[O~O!Y/qO!V(wi~P#.wO!Y/qO!V(wi~O!V7`O~O!d#vO#r7eO~On7fO!d#vO(i'lO~O|){O!P)|O(q%QOj'ca(p'ca!Y'ca#['ca~Of'ca#|'ca~P&5PO|){O!P)|Oj'ea(p'ea(q'ea!Y'ea#['ea~Of'ea#|'ea~P&5rO!V7hO~Of$yq!Y$yq#[$yq#|$yq~P!0}O`$ky!Y$ky'r$ky'p$ky!V$ky!j$kyr$ky![$ky%c$ky!d$ky~P!9zO!d6YO~O!Y4uO![(xa~O`#_y!Y#_y'r#_y'p#_y!V#_y!j#_yr#_y![#_y%c#_y!d#_y~P!9zOZ7mO~Oa7oO'{+kO'}TO(QUO~O!Y0xO!Z)Pi~O_7sO~O([(yO!Y'iX!Z'iX~O!Y5]O!Z(|a~O!Z7|O~P%7wOo!nO!P7}O'}TO(QUO([!mO(g!sO~O![1bO~O![1bO%c8PO~Oj8SO![1bO%c8PO~OZ8XO!Y'la!Z'la~O!Y1mO!Z(}i~O!j8]O~O!j8^O~O!j8aO~O!j8aO~P%[O`8cO~O!d8dO~O!j8eO~O!Y(ni!Z(ni~P#EhO`%lO#[8mO'r%lO~O!Y(ky!j(ky`(ky'r(ky~P!9zO!Y(eO!j(jy~O!['[O%c8pO~O#g$wqP$wqZ$wq`$wqn$wq}$wq!Y$wq!h$wq!i$wq!k$wq!o$wq#j$wq#k$wq#l$wq#m$wq#n$wq#o$wq#p$wq#q$wq#r$wq#t$wq#v$wq#x$wq#y$wq'r$wq(X$wq(i$wq!j$wq!V$wq'p$wq#[$wqr$wq![$wq%c$wq!d$wq~P#.wO#g'caP'caZ'ca`'can'ca}'ca!h'ca!i'ca!k'ca!o'ca#j'ca#k'ca#l'ca#m'ca#n'ca#o'ca#p'ca#q'ca#r'ca#t'ca#v'ca#x'ca#y'ca'r'ca(X'ca(i'ca!j'ca!V'ca'p'car'ca!['ca%c'ca!d'ca~P&5PO#g'eaP'eaZ'ea`'ean'ea}'ea!h'ea!i'ea!k'ea!o'ea#j'ea#k'ea#l'ea#m'ea#n'ea#o'ea#p'ea#q'ea#r'ea#t'ea#v'ea#x'ea#y'ea'r'ea(X'ea(i'ea!j'ea!V'ea'p'ear'ea!['ea%c'ea!d'ea~P&5rO#g$yqP$yqZ$yq`$yqn$yq}$yq!Y$yq!h$yq!i$yq!k$yq!o$yq#j$yq#k$yq#l$yq#m$yq#n$yq#o$yq#p$yq#q$yq#r$yq#t$yq#v$yq#x$yq#y$yq'r$yq(X$yq(i$yq!j$yq!V$yq'p$yq#[$yqr$yq![$yq%c$yq!d$yq~P#.wO!Y'Si!j'Si~P!9zO#|#_q!Y#_q!Z#_q~P#EhO(p%OOP%ZaZ%Zan%Za}%Za!h%Za!i%Za!k%Za!o%Za#j%Za#k%Za#l%Za#m%Za#n%Za#o%Za#p%Za#q%Za#r%Za#t%Za#v%Za#x%Za#y%Za#|%Za(X%Za(i%Za!Y%Za!Z%Za~Oj%Za|%Za!P%Za(q%Za~P&F}O(q%QOP%]aZ%]an%]a}%]a!h%]a!i%]a!k%]a!o%]a#j%]a#k%]a#l%]a#m%]a#n%]a#o%]a#p%]a#q%]a#r%]a#t%]a#v%]a#x%]a#y%]a#|%]a(X%]a(i%]a!Y%]a!Z%]a~Oj%]a|%]a!P%]a(p%]a~P&IUOj<oO|){O!P)|O(q%QO~P&F}Oj<oO|){O!P)|O(p%OO~P&IUO|0aO}0aO!P0bOPyaZyajyanya!hya!iya!kya!oya#jya#kya#lya#mya#nya#oya#pya#qya#rya#tya#vya#xya#yya#|ya(Xya(iya(pya(qya!Yya!Zya~O|){O!P)|OP$naZ$naj$nan$na}$na!h$na!i$na!k$na!o$na#j$na#k$na#l$na#m$na#n$na#o$na#p$na#q$na#r$na#t$na#v$na#x$na#y$na#|$na(X$na(i$na(p$na(q$na!Y$na!Z$na~O|){O!P)|OP$paZ$paj$pan$pa}$pa!h$pa!i$pa!k$pa!o$pa#j$pa#k$pa#l$pa#m$pa#n$pa#o$pa#p$pa#q$pa#r$pa#t$pa#v$pa#x$pa#y$pa#|$pa(X$pa(i$pa(p$pa(q$pa!Y$pa!Z$pa~OP%OaZ%Oan%Oa}%Oa!h%Oa!i%Oa!k%Oa!o%Oa#j%Oa#k%Oa#l%Oa#m%Oa#n%Oa#o%Oa#p%Oa#q%Oa#r%Oa#t%Oa#v%Oa#x%Oa#y%Oa#|%Oa(X%Oa(i%Oa!Y%Oa!Z%Oa~P&+_O#|$jq!Y$jq!Z$jq~P#EhO#|$kq!Y$kq!Z$kq~P#EhO!Z8|O~O#|8}O~P!0}O!d#vO!Y'^i!j'^i~O!d#vO(i'lO!Y'^i!j'^i~O!Y/iO!j(vq~O!V'`i!Y'`i~P#.wO!Y/qO!V(wq~O!V9TO~P#.wO!V9TO~Of(Vy!Y(Vy~P!0}O!Y'ga!['ga~P#.wO`%Vq![%Vq'r%Vq!Y%Vq~P#.wOZ9YO~O!Y0xO!Z)Pq~O#[9^O!Y'ia!Z'ia~O!Y5]O!Z(|i~P#EhO![1bO%c9bO~O'}TO(QUO([9gO~O!Y1mO!Z(}q~O!j9jO~O!j9kO~O!j9lO~O!j9lO~P%[O#[9oO!Y#dy!Z#dy~O!Y#dy!Z#dy~P#EhO!['[O%c9tO~O#|#zy!Y#zy!Z#zy~P#EhOP$wiZ$win$wi}$wi!h$wi!i$wi!k$wi!o$wi#j$wi#k$wi#l$wi#m$wi#n$wi#o$wi#p$wi#q$wi#r$wi#t$wi#v$wi#x$wi#y$wi#|$wi(X$wi(i$wi!Y$wi!Z$wi~P&+_O|){O!P)|O(q%QOP'baZ'baj'ban'ba}'ba!h'ba!i'ba!k'ba!o'ba#j'ba#k'ba#l'ba#m'ba#n'ba#o'ba#p'ba#q'ba#r'ba#t'ba#v'ba#x'ba#y'ba#|'ba(X'ba(i'ba(p'ba!Y'ba!Z'ba~O|){O!P)|OP'daZ'daj'dan'da}'da!h'da!i'da!k'da!o'da#j'da#k'da#l'da#m'da#n'da#o'da#p'da#q'da#r'da#t'da#v'da#x'da#y'da#|'da(X'da(i'da(p'da(q'da!Y'da!Z'da~O(p%OOP%ZiZ%Zij%Zin%Zi|%Zi}%Zi!P%Zi!h%Zi!i%Zi!k%Zi!o%Zi#j%Zi#k%Zi#l%Zi#m%Zi#n%Zi#o%Zi#p%Zi#q%Zi#r%Zi#t%Zi#v%Zi#x%Zi#y%Zi#|%Zi(X%Zi(i%Zi(q%Zi!Y%Zi!Z%Zi~O(q%QOP%]iZ%]ij%]in%]i|%]i}%]i!P%]i!h%]i!i%]i!k%]i!o%]i#j%]i#k%]i#l%]i#m%]i#n%]i#o%]i#p%]i#q%]i#r%]i#t%]i#v%]i#x%]i#y%]i#|%]i(X%]i(i%]i(p%]i!Y%]i!Z%]i~O#|$ky!Y$ky!Z$ky~P#EhO#|#_y!Y#_y!Z#_y~P#EhO!d#vO!Y'^q!j'^q~O!Y/iO!j(vy~O!V'`q!Y'`q~P#.wO!V9}O~P#.wO!Y0xO!Z)Py~O!Y5]O!Z(|q~O![1bO%c:UO~O!j:XO~O!['[O%c:^O~OP$wqZ$wqn$wq}$wq!h$wq!i$wq!k$wq!o$wq#j$wq#k$wq#l$wq#m$wq#n$wq#o$wq#p$wq#q$wq#r$wq#t$wq#v$wq#x$wq#y$wq#|$wq(X$wq(i$wq!Y$wq!Z$wq~P&+_O|){O!P)|O(q%QOP'caZ'caj'can'ca}'ca!h'ca!i'ca!k'ca!o'ca#j'ca#k'ca#l'ca#m'ca#n'ca#o'ca#p'ca#q'ca#r'ca#t'ca#v'ca#x'ca#y'ca#|'ca(X'ca(i'ca(p'ca!Y'ca!Z'ca~O|){O!P)|OP'eaZ'eaj'ean'ea}'ea!h'ea!i'ea!k'ea!o'ea#j'ea#k'ea#l'ea#m'ea#n'ea#o'ea#p'ea#q'ea#r'ea#t'ea#v'ea#x'ea#y'ea#|'ea(X'ea(i'ea(p'ea(q'ea!Y'ea!Z'ea~OP$yqZ$yqn$yq}$yq!h$yq!i$yq!k$yq!o$yq#j$yq#k$yq#l$yq#m$yq#n$yq#o$yq#p$yq#q$yq#r$yq#t$yq#v$yq#x$yq#y$yq#|$yq(X$yq(i$yq!Y$yq!Z$yq~P&+_Of%_!Z!Y%_!Z#[%_!Z#|%_!Z~P!0}O!Y'iq!Z'iq~P#EhO!Y#d!Z!Z#d!Z~P#EhO#g%_!ZP%_!ZZ%_!Z`%_!Zn%_!Z}%_!Z!Y%_!Z!h%_!Z!i%_!Z!k%_!Z!o%_!Z#j%_!Z#k%_!Z#l%_!Z#m%_!Z#n%_!Z#o%_!Z#p%_!Z#q%_!Z#r%_!Z#t%_!Z#v%_!Z#x%_!Z#y%_!Z'r%_!Z(X%_!Z(i%_!Z!j%_!Z!V%_!Z'p%_!Z#[%_!Zr%_!Z![%_!Z%c%_!Z!d%_!Z~P#.wOP%_!ZZ%_!Zn%_!Z}%_!Z!h%_!Z!i%_!Z!k%_!Z!o%_!Z#j%_!Z#k%_!Z#l%_!Z#m%_!Z#n%_!Z#o%_!Z#p%_!Z#q%_!Z#r%_!Z#t%_!Z#v%_!Z#x%_!Z#y%_!Z#|%_!Z(X%_!Z(i%_!Z!Y%_!Z!Z%_!Z~P&+_Or(]X~P1qO'|!lO~P!*fO!VeX!YeX#[eX~P&0aOP[XZ[Xn[X|[X}[X!P[X!Y[X!YeX!h[X!i[X!k[X!o[X#[[X#[eX#geX#j[X#k[X#l[X#m[X#n[X#o[X#p[X#q[X#r[X#t[X#v[X#x[X#y[X$O[X(X[X(i[X(p[X(q[X~O!deX!j[X!jeX(ieX~P'EROP:iOQ:iORfOc<dOd!iOlkOn:iOokOpkOvkOx:iOz:iO!PWO!TkO!UkO![XO!f:lO!kZO!n:iO!o:iO!p:iO!r:mO!t:pO!w!hO$T!kO'{)ZO'}TO(QUO(XVO(g[O(u<bO~O!Y:}O!Z$ma~Og%WOl%XOn$uOo$tOp$tOv%YOx%ZOz;XO!P$|O![$}O!f<iO!k$yO#f;_O$T%_O$o;ZO$q;]O$t%`O'{(qO'}TO(QUO(X$vO(p%OO(q%QO~O#s)bO~P'IwOn!bX(i!bX~P# qO!Z[X!ZeX~P'ERO!VeX!V$uX!YeX!Y$uX#[eX~P!/tO#g:qO~O!d#vO#g:qO~O#[;RO~O#r:vO~O#[;bO!Y(nX!Z(nX~O#[;RO!Y(lX!Z(lX~O#g;cO~Of;eO~P!0}O#g;kO~O#g;lO~O!d#vO#g;mO~O!d#vO#g;cO~O#|;nO~P#EhO#g;oO~O#g;pO~O#g;uO~O#g;vO~O#g;wO~O#g;xO~O#|;yO~P!0}O#|;zO~P!0}O!i#P#Q#S#T#W#e#f#q(u$o$q$t%W%b%c%d%k%m%p%q%s%u~'vS#k!U't'|#lo#j#mn|'u$Y'u'{$[([~",goto:"$4`)TPPPPP)UPP)XP)jP*z/PPPPP5wPP6_PP<U?kP@OP@OPPP@OPBOP@OP@OP@OPBSPPBXPBsPGlPPPGpPPPPGpJrPPPJxKtPGpPNSPPPP!!bGpPPPGpPGpP!$pGpP!(V!)X!)bP!*U!*Y!*UPPPPP!-f!)XPP!-v!.pP!1dGpGp!1i!4t!9[!9[!=YPPP!=bGpPPPPPPPPPPP!@pP!A}PPGp!C`PGpPGpGpGpGpPGp!DrP!G{P!KQP!KU!K`!Kd!KdP!GxP!Kh!KhP!NmP!NqGpGp!Nw##{@OP@OP@O@OP#%X@O@O#'c@O#*R@O#,V@O@O#,u#/R#/R#/W#/a#/R#/jP#/RP@O#0S@O#3s@O@O5wPPP#7jPPP#8T#8TP#8TP#8k#8TPP#8qP#8hP#8h#9U#8h#9p#9v5t)X#9y)XP#:Q#:Q#:QP)XP)XP)XP)XPP)XP#:W#:ZP#:Z)XP#:_P#:bP)XP)XP)XP)XP)XP)X)XPP#:h#:n#:y#;P#;V#;]#;c#;q#;w#;}#<X#<_#<i#<y#=P#=q#>T#>Z#>a#>o#?U#@s#AR#AY#Bn#B|#Dh#Dv#D|#ES#EY#Ed#Ej#Ep#Ez#F^#FdPPPPPPPPPP#FjPPPPPPP#G_#Jf#Ku#K|#LUPPPP$#[$&S$,l$,o$,r$-_$-b$-e$-l$-tP$-zP$.h$.l$/d$0r$0w$1_PP$1d$1j$1nP$1q$1u$1y$2o$3W$3o$3s$3v$3y$4P$4S$4W$4[R!|RoqOXst!Z#d%k&n&p&q&s,k,p1}2QY!vQ'[-]1b5dQ%qvQ%yyQ&Q|Q&f!VS'S!e-TQ'b!iS'h!r!yU*f$}*W*kQ+i%zQ+v&SQ,[&`Q-Z'ZQ-e'cQ-m'iQ0S*mQ1l,]R;`:m%QdOPWXYZstuvw!Z!`!g!o#S#W#Z#d#o#u#y#|$P$Q$R$S$T$U$V$W$X$Y$Z$b$f%k%q&O&g&j&n&p&q&s&w'P'^'n(O(Q(W(_(s(w({)z+R+V,h,k,p-a-i-w-}.o.v/g0b0g0w1e1u1v1x1z1}2Q2S2s2y3a5a5k5{5|6P6d7}8S8c8mS#q]:j!r)]$]$n'T)o,|-P/O2c3v5_6Z9^9o:i:l:m:p:q:r:s:t:u:v:w:x:y:z:{:|:};R;`;b;c;e;m;n;w;x<eQ*x%[Q+n%|Q,^&cQ,e&kQ.f;WQ0n+aQ0r+cQ0}+oQ1t,cQ3R._Q4}0xQ5r1mQ6p3VQ6|;XQ7o5OR8s6q'OkOPWXYZstuvw!Z!`!g!o#S#W#Z#d#o#u#y#|$P$Q$R$S$T$U$V$W$X$Y$Z$]$b$f$n%k%q&O&g&j&k&n&p&q&s&w'P'T'^'n(O(Q(W(_(s(w({)o)z+R+V+a,h,k,p,|-P-a-i-w-}._.o.v/O/g0b0g0w1e1u1v1x1z1}2Q2S2c2s2y3V3a3v5_5a5k5{5|6P6Z6d6q7}8S8c8m9^9o:i:l:m:p:q:r:s:t:u:v:w:x:y:z:{:|:};R;`;b;c;e;m;n;w;x<et!nQ!r!v!y!z'S'Z'['h'i'j-T-Z-]-m1b5d5f$z$ti#v#x$d$e$y$|%P%R%]%^%b)v)|*O*Q*S*V*]*c*s*t+`+c+z+}.^.l/^/f/p/q/s0W0Y0d1X1[1d3U4O4Z4c4m4u4w5j6n7[7e8P8p8}9b9t:U:^;P;Q;S;T;U;V;Y;Z;[;];^;_;f;g;h;i;k;l;o;p;q;r;s;t;u;v;y;z<b<j<k<n<oQ&T|Q'Q!eU'W%g*W-WQ+n%|Q,^&cQ0c*|Q0}+oQ1S+uQ1s,bQ1t,cQ4}0xQ5W1UQ5r1mQ5u1oQ5v1rQ7o5OQ7r5TQ8[5xQ9]7sR9h8XrnOXst!V!Z#d%k&e&n&p&q&s,k,p1}2QR,`&g&x^OPXYstuvwz!Z!`!g!j!o#S#d#o#u#y#|$P$Q$R$S$T$U$V$W$X$Y$Z$]$b$f$n%k%q&O&g&j&k&n&p&q&s&w'P'^'n(Q(W(_(s(w({)o)z+R+V+a,h,k,p,|-P-a-i-w-}._.o.v/O/g0b0g0w1e1u1v1x1z1}2Q2S2c2s2y3V3a3v5_5a5k5{5|6P6Z6d6q7}8S8c8m9^9o:i:l:m:p:q:r:s:t:u:v:w:x:y:z:{:|:};R;`;b;c;e;m;n;w;x<d<e[#]WZ#W#Z'T(O!b%hm#h#i#l$y%c%f(X(c(d(e*V*Z*^+T+U+W,g,}-{.R.S.T.V/f/i2V2}3O4R6Y6kQ%txQ%xyS%}|&SQ&Z!TQ'_!hQ'a!iQ(l#sS+h%y%zQ+l%|Q,V&^Q,Z&`S-d'b'cQ.a(mQ0v+iQ0|+oQ1O+pQ1R+tQ1g,WS1k,[,]Q2o-eQ4|0xQ5Q0{Q5V1TQ5q1lQ7n5OQ7q5SQ9X7mR:P9Y!O${i#x%P%R%]%^%b*O*Q*]*s*t.l/p0W0Y0d4O4m8}<b<j<k!S%vy!i!u%x%y%z'R'a'b'c'g'q*e+h+i-Q-d-e-l/z0v2h2o2v4eQ+b%tQ+{&WQ,O&XQ,Y&`Q.`(lQ1f,VU1j,Z,[,]Q3W.aQ5l1gS5p1k1lQ8W5q#[<f#v$d$e$y$|)v)|*S*V*c+`+c+z+}.^/^/f/q/s1X1[1d3U4Z4c4u4w5j6n7[7e8P8p9b9t:U:^;S;U;Y;[;^;f;h;k;o;q;s;u;y<n<oo<g;P;Q;T;V;Z;];_;g;i;l;p;r;t;v;zW%Ui%W*u<bS&W!Q&eQ&X!RQ&Y!SR+y&U${%Ti#v#x$d$e$y$|%P%R%]%^%b)v)|*O*Q*S*V*]*c*s*t+`+c+z+}.^.l/^/f/p/q/s0W0Y0d1X1[1d3U4O4Z4c4m4u4w5j6n7[7e8P8p8}9b9t:U:^;P;Q;S;T;U;V;Y;Z;[;];^;_;f;g;h;i;k;l;o;p;q;r;s;t;u;v;y;z<b<j<k<n<oT)w$v)xV*y%[;W;XW'W!e%g*W-WS(z#z#{Q+s&PS.Y(h(iQ1],PQ4n0aR7w5]'OkOPWXYZstuvw!Z!`!g!o#S#W#Z#d#o#u#y#|$P$Q$R$S$T$U$V$W$X$Y$Z$]$b$f$n%k%q&O&g&j&k&n&p&q&s&w'P'T'^'n(O(Q(W(_(s(w({)o)z+R+V+a,h,k,p,|-P-a-i-w-}._.o.v/O/g0b0g0w1e1u1v1x1z1}2Q2S2c2s2y3V3a3v5_5a5k5{5|6P6Z6d6q7}8S8c8m9^9o:i:l:m:p:q:r:s:t:u:v:w:x:y:z:{:|:};R;`;b;c;e;m;n;w;x<e$i$ac#Y#e%o%p%r'}(T(o(v)O)P)Q)R)S)T)U)V)W)X)Y)[)_)c)m+^+r-R-p-u-z-|.k.q.u.w.x.y/Y0e2^2a2q2x3`3e3f3g3h3i3j3k3l3m3n3o3p3q3t3u3z4r4z6]6c6h6v6w7Q7R7y8g8k8t8z8{9q:R:Y:k<XT#TV#U'PkOPWXYZstuvw!Z!`!g!o#S#W#Z#d#o#u#y#|$P$Q$R$S$T$U$V$W$X$Y$Z$]$b$f$n%k%q&O&g&j&k&n&p&q&s&w'P'T'^'n(O(Q(W(_(s(w({)o)z+R+V+a,h,k,p,|-P-a-i-w-}._.o.v/O/g0b0g0w1e1u1v1x1z1}2Q2S2c2s2y3V3a3v5_5a5k5{5|6P6Z6d6q7}8S8c8m9^9o:i:l:m:p:q:r:s:t:u:v:w:x:y:z:{:|:};R;`;b;c;e;m;n;w;x<eQ'U!eR2d-Tv!nQ!e!r!v!y!z'S'Z'['h'i'j-T-Z-]-m1b5d5fU*e$}*W*kS/z*f*mQ0T*nQ1_,RQ4e0SR4h0VnqOXst!Z#d%k&n&p&q&s,k,p1}2QQ&u!^Q'r!xS(n#u:qQ+f%wQ,T&ZQ,U&]Q-b'`Q-o'kS.j(s;cS0f+R;mQ0t+gQ1a,SQ2U,rQ2W,sQ2`-OQ2m-cQ2p-gS4s0g;wQ4x0uS4{0w;xQ6[2bQ6`2nQ6e2uQ7l4yQ8h6^Q8i6aQ8l6fR9n8e$d$`c#Y#e%p%r'}(T(o(v)O)P)Q)R)S)T)U)V)W)X)Y)[)_)c)m+^+r-R-p-u-z-|.k.q.u.x.y/Y0e2^2a2q2x3`3e3f3g3h3i3j3k3l3m3n3o3p3q3t3u3z4r4z6]6c6h6v6w7Q7R7y8g8k8t8z8{9q:R:Y:k<XS(k#p'eU*r%S(r3sS+]%o.wQ3S0nQ6m3RQ8r6pR9u8s$d$_c#Y#e%p%r'}(T(o(v)O)P)Q)R)S)T)U)V)W)X)Y)[)_)c)m+^+r-R-p-u-z-|.k.q.u.x.y/Y0e2^2a2q2x3`3e3f3g3h3i3j3k3l3m3n3o3p3q3t3u3z4r4z6]6c6h6v6w7Q7R7y8g8k8t8z8{9q:R:Y:k<XS(j#p'eS(|#{$`S+[%o.wS.Z(i(kQ.z)^Q0k+]R3P.['OkOPWXYZstuvw!Z!`!g!o#S#W#Z#d#o#u#y#|$P$Q$R$S$T$U$V$W$X$Y$Z$]$b$f$n%k%q&O&g&j&k&n&p&q&s&w'P'T'^'n(O(Q(W(_(s(w({)o)z+R+V+a,h,k,p,|-P-a-i-w-}._.o.v/O/g0b0g0w1e1u1v1x1z1}2Q2S2c2s2y3V3a3v5_5a5k5{5|6P6Z6d6q7}8S8c8m9^9o:i:l:m:p:q:r:s:t:u:v:w:x:y:z:{:|:};R;`;b;c;e;m;n;w;x<eS#q]:jQ&p!XQ&q!YQ&s![Q&t!]R1|,nQ']!hQ+_%tQ-`'_S.](l+bQ2k-_W3T.`.a0m0oQ6_2lU6l3Q3S3WS8o6m6oS9s8q8rS:[9r9uQ:d:]R:g:eU!wQ'[-]T5b1b5d!Q_OXZ`st!V!Z#d#h%c%k&e&g&n&p&q&s(e,k,p.S1}2Q]!pQ!r'[-]1b5dT#q]:j%[{OPWXYZstuvw!Z!`!g!o#S#W#Z#d#o#u#y#|$P$Q$R$S$T$U$V$W$X$Y$Z$b$f%k%q&O&g&j&k&n&p&q&s&w'P'^'n(O(Q(W(_(s(w({)z+R+V+a,h,k,p-a-i-w-}._.o.v/g0b0g0w1e1u1v1x1z1}2Q2S2s2y3V3a5a5k5{5|6P6d6q7}8S8c8mS(z#z#{S.Y(h(i!s<O$]$n'T)o,|-P/O2c3v5_6Z9^9o:i:l:m:p:q:r:s:t:u:v:w:x:y:z:{:|:};R;`;b;c;e;m;n;w;x<em!tQ!r!v!y!z'['h'i'j-]-m1b5d5fQ'p!uS(a#g1wS-k'g'sQ/l*YQ/x*eQ2w-nQ4V/mS4`/y0TQ7W4QS7c4f4hQ9P7XR9W7fQ#wbQ'o!uS(`#g1wS(b#m+QQ+S%dQ+d%uQ+j%{U-j'g'p'sQ.O(aQ/k*YQ/w*eQ/}*hQ0s+eQ1h,XS2t-k-nQ2|.WS4U/l/mS4_/x0TQ4b/|Q4d0OQ5n1iQ6g2wQ7V4QQ7Z4VS7_4`4hQ7d4gQ8U5oS9O7W7XQ9S7`Q9U7cQ9e8VQ9{9PQ9|9TQ:O9WQ:W9fQ:`9}Q<R;|Q<^<VR<_<WV!wQ'[-]%[aOPWXYZstuvw!Z!`!g!o#S#W#Z#d#o#u#y#|$P$Q$R$S$T$U$V$W$X$Y$Z$b$f%k%q&O&g&j&k&n&p&q&s&w'P'^'n(O(Q(W(_(s(w({)z+R+V+a,h,k,p-a-i-w-}._.o.v/g0b0g0w1e1u1v1x1z1}2Q2S2s2y3V3a5a5k5{5|6P6d6q7}8S8c8mS#wz!j!r;{$]$n'T)o,|-P/O2c3v5_6Z9^9o:i:l:m:p:q:r:s:t:u:v:w:x:y:z:{:|:};R;`;b;c;e;m;n;w;x<eR<R<d%[bOPWXYZstuvw!Z!`!g!o#S#W#Z#d#o#u#y#|$P$Q$R$S$T$U$V$W$X$Y$Z$b$f%k%q&O&g&j&k&n&p&q&s&w'P'^'n(O(Q(W(_(s(w({)z+R+V+a,h,k,p-a-i-w-}._.o.v/g0b0g0w1e1u1v1x1z1}2Q2S2s2y3V3a5a5k5{5|6P6d6q7}8S8c8mQ%dj!S%uy!i!u%x%y%z'R'a'b'c'g'q*e+h+i-Q-d-e-l/z0v2h2o2v4eS%{z!jQ+e%vQ,X&`W1i,Y,Z,[,]U5o1j1k1lS8V5p5qQ9f8W!r;|$]$n'T)o,|-P/O2c3v5_6Z9^9o:i:l:m:p:q:r:s:t:u:v:w:x:y:z:{:|:};R;`;b;c;e;m;n;w;x<eQ<V<cR<W<d%OeOPXYstuvw!Z!`!g!o#S#d#o#u#y#|$P$Q$R$S$T$U$V$W$X$Y$Z$b$f%k%q&O&g&j&n&p&q&s&w'P'^'n(Q(W(_(s(w({)z+R+V+a,h,k,p-a-i-w-}._.o.v/g0b0g0w1e1u1v1x1z1}2Q2S2s2y3V3a5a5k5{5|6P6d6q7}8S8c8mY#bWZ#W#Z(O!b%hm#h#i#l$y%c%f(X(c(d(e*V*Z*^+T+U+W,g,}-{.R.S.T.V/f/i2V2}3O4R6Y6kQ,f&k!p;}$]$n)o,|-P/O2c3v5_6Z9^9o:i:l:m:p:q:r:s:t:u:v:w:x:y:z:{:|:};R;`;b;c;e;m;n;w;x<eR<Q'TU'X!e%g*WR2f-W%QdOPWXYZstuvw!Z!`!g!o#S#W#Z#d#o#u#y#|$P$Q$R$S$T$U$V$W$X$Y$Z$b$f%k%q&O&g&j&n&p&q&s&w'P'^'n(O(Q(W(_(s(w({)z+R+V,h,k,p-a-i-w-}.o.v/g0b0g0w1e1u1v1x1z1}2Q2S2s2y3a5a5k5{5|6P6d7}8S8c8m!r)]$]$n'T)o,|-P/O2c3v5_6Z9^9o:i:l:m:p:q:r:s:t:u:v:w:x:y:z:{:|:};R;`;b;c;e;m;n;w;x<eQ,e&kQ0n+aQ3R._Q6p3VR8s6q!b$Vc#Y%o'}(T(o(v)X)Y)_)c+r-p-u-z-|.k.q/Y0e2q2x3`3q4r4z6c6h6v8k9q:k!P:x)[)m-R.w2^2a3e3o3p3t3z6]6w7Q7R7y8g8t8z8{:R:Y<X!f$Xc#Y%o'}(T(o(v)U)V)X)Y)_)c+r-p-u-z-|.k.q/Y0e2q2x3`3q4r4z6c6h6v8k9q:k!T:z)[)m-R.w2^2a3e3l3m3o3p3t3z6]6w7Q7R7y8g8t8z8{:R:Y<X!^$]c#Y%o'}(T(o(v)_)c+r-p-u-z-|.k.q/Y0e2q2x3`3q4r4z6c6h6v8k9q:kQ4O/dz<e)[)m-R.w2^2a3e3t3z6]6w7Q7R7y8g8t8z8{:R:Y<XQ<j<lR<k<m'OkOPWXYZstuvw!Z!`!g!o#S#W#Z#d#o#u#y#|$P$Q$R$S$T$U$V$W$X$Y$Z$]$b$f$n%k%q&O&g&j&k&n&p&q&s&w'P'T'^'n(O(Q(W(_(s(w({)o)z+R+V+a,h,k,p,|-P-a-i-w-}._.o.v/O/g0b0g0w1e1u1v1x1z1}2Q2S2c2s2y3V3a3v5_5a5k5{5|6P6Z6d6q7}8S8c8m9^9o:i:l:m:p:q:r:s:t:u:v:w:x:y:z:{:|:};R;`;b;c;e;m;n;w;x<eS$oh$pR3w.}'VgOPWXYZhstuvw!Z!`!g!o#S#W#Z#d#o#u#y#|$P$Q$R$S$T$U$V$W$X$Y$Z$]$b$f$n$p%k%q&O&g&j&k&n&p&q&s&w'P'T'^'n(O(Q(W(_(s(w({)o)z+R+V+a,h,k,p,|-P-a-i-w-}._.o.v.}/O/g0b0g0w1e1u1v1x1z1}2Q2S2c2s2y3V3a3v5_5a5k5{5|6P6Z6d6q7}8S8c8m9^9o:i:l:m:p:q:r:s:t:u:v:w:x:y:z:{:|:};R;`;b;c;e;m;n;w;x<eT$kf$qQ$ifS)f$l)jR)r$qT$jf$qT)h$l)j'VhOPWXYZhstuvw!Z!`!g!o#S#W#Z#d#o#u#y#|$P$Q$R$S$T$U$V$W$X$Y$Z$]$b$f$n$p%k%q&O&g&j&k&n&p&q&s&w'P'T'^'n(O(Q(W(_(s(w({)o)z+R+V+a,h,k,p,|-P-a-i-w-}._.o.v.}/O/g0b0g0w1e1u1v1x1z1}2Q2S2c2s2y3V3a3v5_5a5k5{5|6P6Z6d6q7}8S8c8m9^9o:i:l:m:p:q:r:s:t:u:v:w:x:y:z:{:|:};R;`;b;c;e;m;n;w;x<eT$oh$pQ$rhR)q$p%[jOPWXYZstuvw!Z!`!g!o#S#W#Z#d#o#u#y#|$P$Q$R$S$T$U$V$W$X$Y$Z$b$f%k%q&O&g&j&k&n&p&q&s&w'P'^'n(O(Q(W(_(s(w({)z+R+V+a,h,k,p-a-i-w-}._.o.v/g0b0g0w1e1u1v1x1z1}2Q2S2s2y3V3a5a5k5{5|6P6d6q7}8S8c8m!s<c$]$n'T)o,|-P/O2c3v5_6Z9^9o:i:l:m:p:q:r:s:t:u:v:w:x:y:z:{:|:};R;`;b;c;e;m;n;w;x<e#elOPXZst!Z!`!o#S#d#o#|$n%k&g&j&k&n&p&q&s&w'P'^({)o+V+a,h,k,p-a._/O/g0b1e1u1v1x1z1}2Q2S3V3v5a5k5{5|6P6q7}8S8c!O%Si#x%P%R%]%^%b*O*Q*]*s*t.l/p0W0Y0d4O4m8}<b<j<k#[(r#v$d$e$y$|)v)|*S*V*c+`+c+z+}.^/^/f/q/s1X1[1d3U4Z4c4u4w5j6n7[7e8P8p9b9t:U:^;S;U;Y;[;^;f;h;k;o;q;s;u;y<n<oQ*}%`Q/Z){o3s;P;Q;T;V;Z;];_;g;i;l;p;r;t;v;z!O$zi#x%P%R%]%^%b*O*Q*]*s*t.l/p0W0Y0d4O4m8}<b<j<kQ*_${U*h$}*W*kQ+O%aQ0O*i#[<T#v$d$e$y$|)v)|*S*V*c+`+c+z+}.^/^/f/q/s1X1[1d3U4Z4c4u4w5j6n7[7e8P8p9b9t:U:^;S;U;Y;[;^;f;h;k;o;q;s;u;y<n<on<U;P;Q;T;V;Z;];_;g;i;l;p;r;t;v;zQ<Y<fQ<Z<gQ<[<hR<]<i!O%Si#x%P%R%]%^%b*O*Q*]*s*t.l/p0W0Y0d4O4m8}<b<j<k#[(r#v$d$e$y$|)v)|*S*V*c+`+c+z+}.^/^/f/q/s1X1[1d3U4Z4c4u4w5j6n7[7e8P8p9b9t:U:^;S;U;Y;[;^;f;h;k;o;q;s;u;y<n<oo3s;P;Q;T;V;Z;];_;g;i;l;p;r;t;v;znoOXst!Z#d%k&n&p&q&s,k,p1}2QS*b$|*VQ,y&zQ,z&|R4Y/q$z%Ti#v#x$d$e$y$|%P%R%]%^%b)v)|*O*Q*S*V*]*c*s*t+`+c+z+}.^.l/^/f/p/q/s0W0Y0d1X1[1d3U4O4Z4c4m4u4w5j6n7[7e8P8p8}9b9t:U:^;P;Q;S;T;U;V;Y;Z;[;];^;_;f;g;h;i;k;l;o;p;q;r;s;t;u;v;y;z<b<j<k<n<oQ+|&XQ1Z,OQ5Z1YR7v5[V*j$}*W*kU*j$}*W*kT5c1b5dU/|*g/g5aT4g0U7}Q+d%uQ/}*hQ0s+eQ1h,XQ5n1iQ8U5oQ9e8VR:W9f!O%Pi#x%P%R%]%^%b*O*Q*]*s*t.l/p0W0Y0d4O4m8}<b<j<kr*O$w(t*P*q+P/o0[0]3^4W4q7U7g9z<S<`<aS0W*p0X#[;S#v$d$e$y$|)v)|*S*V*c+`+c+z+}.^/^/f/q/s1X1[1d3U4Z4c4u4w5j6n7[7e8P8p9b9t:U:^;S;U;Y;[;^;f;h;k;o;q;s;u;y<n<on;T;P;Q;T;V;Z;];_;g;i;l;p;r;t;v;z!^;f(p)a*X*a.b.e.i/V/[/d/t0l1W1Y3Z4X4]5Y5[6r6u7]7a7i7k9R9V:_<l<m`;g3r6x6{7P8u9v9y:hS;q.d3[T;r6z8x!O%Ri#x%P%R%]%^%b*O*Q*]*s*t.l/p0W0Y0d4O4m8}<b<j<kv*Q$w(t*R*p+P/`/o0[0]3^4W4i4q7U7g9z<S<`<aS0Y*q0Z#[;U#v$d$e$y$|)v)|*S*V*c+`+c+z+}.^/^/f/q/s1X1[1d3U4Z4c4u4w5j6n7[7e8P8p9b9t:U:^;S;U;Y;[;^;f;h;k;o;q;s;u;y<n<on;V;P;Q;T;V;Z;];_;g;i;l;p;r;t;v;z!b;h(p)a*X*a.c.d.i/V/[/d/t0l1W1Y3X3Z4X4]5Y5[6r6s6u7]7a7i7k9R9V:_<l<md;i3r6y6z7P8u8v9v9w9y:hS;s.e3]T;t6{8yrnOXst!V!Z#d%k&e&n&p&q&s,k,p1}2QQ&b!UR,h&krnOXst!V!Z#d%k&e&n&p&q&s,k,p1}2QR&b!UQ,Q&YR1V+ysnOXst!V!Z#d%k&e&n&p&q&s,k,p1}2QQ1c,VS5i1f1gU8O5g5h5lS9a8Q8RS:S9`9cQ:a:TR:f:bQ&i!VR,a&eR5u1oS%}|&SR1O+pQ&n!WR,k&oR,q&tT2O,p2QR,u&uQ,t&uR2X,uQ'u!{R-q'uSsOtQ#dXT%ns#dQ#OTR'w#OQ#RUR'y#RQ)x$vR/W)xQ#UVR'{#UQ#XWU(R#X(S-xQ(S#YR-x(TQ-U'UR2e-UQ.m(tR3_.mQ.p(vS3b.p3cR3c.qQ-]'[R2i-]Y!rQ'[-]1b5dR'f!rU#_W%f*VU(Y#_(Z-yQ(Z#`R-y(UQ-X'XR2g-Xt`OXst!V!Z#d%k&e&g&n&p&q&s,k,p1}2QS#hZ%cU#r`#h.SR.S(eQ(f#jQ.P(bW.X(f.P2z6iQ2z.QR6i2{Q)j$lR/P)jQ$phR)p$pQ$ccU)`$c-t;OQ-t:kR;O)mQ/j*YW4S/j4T7Y9QU4T/k/l/mS7Y4U4VR9Q7Z$X)}$w(p(t)a*X*a*p*q*z*{+P.d.e.g.h.i/V/[/`/b/d/o/t0[0]0l1W1Y3X3Y3Z3^3r4W4X4]4i4k4q5Y5[6r6s6t6u6z6{6}7O7P7U7]7a7g7i7k8u8v8w9R9V9v9w9x9y9z:_:h<S<`<a<l<mQ/r*aU4[/r4^7^Q4^/tR7^4]S*k$}*WR0Q*kr*P$w(t*p*q+P/o0[0]3^4W4q7U7g9z<S<`<a!^.b(p)a*X*a.d.e.i/V/[/d/t0l1W1Y3Z4X4]5Y5[6r6u7]7a7i7k9R9V:_<l<mU/a*P.b6xa6x3r6z6{7P8u9v9y:hQ0X*pQ3[.dU4j0X3[8xR8x6zv*R$w(t*p*q+P/`/o0[0]3^4W4i4q7U7g9z<S<`<a!b.c(p)a*X*a.d.e.i/V/[/d/t0l1W1Y3X3Z4X4]5Y5[6r6s6u7]7a7i7k9R9V:_<l<mU/c*R.c6ye6y3r6z6{7P8u8v9v9w9y:hQ0Z*qQ3].eU4l0Z3]8yR8y6{Q*v%VR0_*vQ4v0lR7j4vQ+X%iR0j+XQ5^1]S7x5^9_R9_7yQ,S&ZR1`,SQ5d1bR7{5dQ1n,^S5s1n8YR8Y5uQ0y+lW5P0y5R7p9ZQ5R0|Q7p5QR9Z7qQ+q%}R1P+qQ2Q,pR6T2QYrOXst#dQ&r!ZQ+Z%kQ,j&nQ,l&pQ,m&qQ,o&sQ1{,kS2O,p2QR6S1}Q%mpQ&v!_Q&y!aQ&{!bQ&}!cQ'm!uQ+Y%jQ+f%wQ+x&TQ,`&iQ,w&xW-h'g'o'p'sQ-o'kQ0P*jQ0t+gS1q,a,dQ2Y,vQ2Z,yQ2[,zQ2p-gW2r-j-k-n-pQ4x0uQ5U1SQ5X1WQ5m1hQ5w1sQ6R1|U6b2q2t2wQ6e2uQ7l4yQ7t5WQ7u5YQ7z5cQ8T5nQ8Z5vS8j6c6gQ8l6fQ9[7rQ9d8UQ9i8[Q9p8kQ:Q9]Q:V9eQ:Z9qR:c:WQ%wyQ'`!iQ'k!uU+g%x%y%zQ-O'RU-c'a'b'cS-g'g'qQ/v*eS0u+h+iQ2b-QS2n-d-eQ2u-lQ4a/zQ4y0vQ6^2hQ6a2oQ6f2vR7b4eS$xi<bR*w%WU%Vi%W<bR0^*uQ$wiS(p#v+cQ(t#xS)a$d$eQ*X$yS*a$|*VQ*p%PQ*q%RQ*z%]Q*{%^Q+P%bQ.d;SQ.e;UQ.g;YQ.h;[Q.i;^Q/V)vS/[)|/^Q/`*OQ/b*QQ/d*SQ/o*]S/t*c/fQ0[*sQ0]*th0l+`.^1d3U5j6n8P8p9b9t:U:^Q1W+zQ1Y+}Q3X;fQ3Y;hQ3Z;kQ3^.lS3r;P;QQ4W/pQ4X/qQ4]/sQ4i0WQ4k0YQ4q0dQ5Y1XQ5[1[Q6r;oQ6s;qQ6t;sQ6u;uQ6z;TQ6{;VQ6};ZQ7O;]Q7P;_Q7U4OQ7]4ZQ7a4cQ7g4mQ7i4uQ7k4wQ8u;lQ8v;gQ8w;iQ9R7[Q9V7eQ9v;pQ9w;rQ9x;tQ9y;vQ9z8}Q:_;yQ:h;zQ<S<bQ<`<jQ<a<kQ<l<nR<m<onpOXst!Z#d%k&n&p&q&s,k,p1}2QQ!fPS#fZ#oQ&x!`U'd!o5a7}Q'z#SQ(}#|Q)n$nS,d&g&jQ,i&kQ,v&wQ,{'PQ-_'^Q.s({Q/T)oS0h+V/gQ0o+aQ1y,hQ2l-aQ3S._Q3y/OQ4o0bQ5h1eQ5y1uQ5z1vQ6O1xQ6Q1zQ6V2SQ6m3VQ7S3vQ8R5kQ8_5{Q8`5|Q8b6PQ8r6qQ9c8SR9m8c#YcOPXZst!Z!`!o#d#o#|%k&g&j&k&n&p&q&s&w'P'^({+V+a,h,k,p-a._/g0b1e1u1v1x1z1}2Q2S3V5a5k5{5|6P6q7}8S8cQ#YWQ#eYQ%ouQ%pvS%rw!gS'}#W(QQ(T#ZQ(o#uQ(v#yQ)O$PQ)P$QQ)Q$RQ)R$SQ)S$TQ)T$UQ)U$VQ)V$WQ)W$XQ)X$YQ)Y$ZQ)[$]Q)_$bQ)c$fW)m$n)o/O3vQ+^%qQ+r&OS-R'T2cQ-p'nS-u(O-wQ-z(WQ-|(_Q.k(sQ.q(wQ.u:iQ.w:lQ.x:mQ.y:pQ/Y)zQ0e+RQ2^,|Q2a-PQ2q-iQ2x-}Q3`.oQ3e:qQ3f:rQ3g:sQ3h:tQ3i:uQ3j:vQ3k:wQ3l:xQ3m:yQ3n:zQ3o:{Q3p:|Q3q.vQ3t;RQ3u;`Q3z:}Q4r0gQ4z0wQ6];bQ6c2sQ6h2yQ6v3aQ6w;cQ7Q;eQ7R;mQ7y5_Q8g6ZQ8k6dQ8t;nQ8z;wQ8{;xQ9q8mQ:R9^Q:Y9oQ:k#SR<X<eR#[WR'V!el!tQ!r!v!y!z'['h'i'j-]-m1b5d5fS'R!e-TS-Q'S'ZR2h-ZR(u#xR(x#yQ!fQT-['[-]]!qQ!r'[-]1b5dQ#p]R'e:jY!uQ'[-]1b5dQ'g!rS'q!v!yS's!z5fS-l'h'iQ-n'jR2v-mT#kZ%cS#jZ%cS%im,gU(b#h#i#lS.Q(c(dQ.U(eQ0i+WQ2{.RU2|.S.T.VS6j2}3OR8n6kd#^W#W#Z%f(O(X*V+T-{/fr#gZm#h#i#l%c(c(d(e+W.R.S.T.V2}3O6kS*Y$y*^Q/m*ZQ1w,gQ2_,}Q4Q/iQ6X2VQ7X4RQ8f6YT<P'T+UV#aW%f*VU#`W%f*VS(P#W(XU(U#Z+T/fS-S'T+UT-v(O-{V'Y!e%g*WQ$lfR)t$qT)i$l)jR3x.}T*[$y*^T*d$|*VQ0m+`Q3Q.^Q5g1dQ6o3UQ8Q5jQ8q6nQ9`8PQ9r8pQ:T9bQ:]9tQ:b:UR:e:^nqOXst!Z#d%k&n&p&q&s,k,p1}2QQ&h!VR,`&etmOXst!U!V!Z#d%k&e&n&p&q&s,k,p1}2QR,g&kT%jm,gR1^,PR,_&cQ&R|R+w&SR+m%|T&l!W&oT&m!W&oT2P,p2Q",nodeNames:"\u26A0 ArithOp ArithOp JSXStartTag LineComment BlockComment Script Hashbang ExportDeclaration export Star as VariableName String Escape from ; default FunctionDeclaration async function VariableDefinition > < TypeParamList TypeDefinition extends ThisType this LiteralType ArithOp Number BooleanLiteral TemplateType InterpolationEnd Interpolation InterpolationStart NullType null VoidType void TypeofType typeof MemberExpression . ?. PropertyName [ TemplateString Escape Interpolation super RegExp ] ArrayExpression Spread , } { ObjectExpression Property async get set PropertyDefinition Block : NewExpression new TypeArgList CompareOp < ) ( ArgList UnaryExpression delete LogicOp BitOp YieldExpression yield AwaitExpression await ParenthesizedExpression ClassExpression class ClassBody MethodDeclaration Decorator @ MemberExpression PrivatePropertyName CallExpression declare Privacy static abstract override PrivatePropertyDefinition PropertyDeclaration readonly accessor Optional TypeAnnotation Equals StaticBlock FunctionExpression ArrowFunction ParamList ParamList ArrayPattern ObjectPattern PatternProperty Privacy readonly Arrow MemberExpression BinaryExpression ArithOp ArithOp ArithOp ArithOp BitOp CompareOp instanceof satisfies in const CompareOp BitOp BitOp BitOp LogicOp LogicOp ConditionalExpression LogicOp LogicOp AssignmentExpression UpdateOp PostfixExpression CallExpression TaggedTemplateExpression DynamicImport import ImportMeta JSXElement JSXSelfCloseEndTag JSXSelfClosingTag JSXIdentifier JSXBuiltin JSXIdentifier JSXNamespacedName JSXMemberExpression JSXSpreadAttribute JSXAttribute JSXAttributeValue JSXEscape JSXEndTag JSXOpenTag JSXFragmentTag JSXText JSXEscape JSXStartCloseTag JSXCloseTag PrefixCast ArrowFunction TypeParamList SequenceExpression KeyofType keyof UniqueType unique ImportType InferredType infer TypeName ParenthesizedType FunctionSignature ParamList NewSignature IndexedType TupleType Label ArrayType ReadonlyType ObjectType MethodType PropertyType IndexSignature PropertyDefinition CallSignature TypePredicate is NewSignature new UnionType LogicOp IntersectionType LogicOp ConditionalType ParameterizedType ClassDeclaration abstract implements type VariableDeclaration let var using TypeAliasDeclaration InterfaceDeclaration interface EnumDeclaration enum EnumBody NamespaceDeclaration namespace module AmbientDeclaration declare GlobalDeclaration global ClassDeclaration ClassBody AmbientFunctionDeclaration ExportGroup VariableName VariableName ImportDeclaration ImportGroup ForStatement for ForSpec ForInSpec ForOfSpec of WhileStatement while WithStatement with DoStatement do IfStatement if else SwitchStatement switch SwitchBody CaseLabel case DefaultLabel TryStatement try CatchClause catch FinallyClause finally ReturnStatement return ThrowStatement throw BreakStatement break ContinueStatement continue DebuggerStatement debugger LabeledStatement ExpressionStatement SingleExpression SingleClassItem",maxTerm:372,context:LP,nodeProps:[["isolate",-8,4,5,13,33,35,48,50,52,""],["group",-26,8,16,18,65,201,205,209,210,212,215,218,228,230,236,238,240,242,245,251,257,259,261,263,265,267,268,"Statement",-32,12,13,28,31,32,38,48,51,52,54,59,67,75,79,81,83,84,106,107,116,117,134,137,139,140,141,142,144,145,164,165,167,"Expression",-23,27,29,33,37,39,41,168,170,172,173,175,176,177,179,180,181,183,184,185,195,197,199,200,"Type",-3,87,99,105,"ClassItem"],["openedBy",22,"<",34,"InterpolationStart",53,"[",57,"{",72,"(",157,"JSXStartCloseTag"],["closedBy",23,">",36,"InterpolationEnd",47,"]",58,"}",73,")",162,"JSXEndTag"]],propSources:[_P],skippedNodes:[0,4,5,271],repeatNodeCount:37,tokenData:"$HR(CSR!bOX%ZXY+gYZ-yZ[+g[]%Z]^.c^p%Zpq+gqr/mrs3cst:_tuEruvJSvwLkwx! Yxy!'iyz!(sz{!)}{|!,q|}!.O}!O!,q!O!P!/Y!P!Q!9j!Q!R#:O!R![#<_![!]#I_!]!^#Jk!^!_#Ku!_!`$![!`!a$$v!a!b$*T!b!c$.S!c!}Er!}#O$/^#O#P$0h#P#Q$6P#Q#R$7Z#R#SEr#S#T$8h#T#o$9r#o#p$>S#p#q$>x#q#r$@Y#r#s$Af#s$f%Z$f$g+g$g#BYEr#BY#BZ$Bp#BZ$ISEr$IS$I_$Bp$I_$I|Er$I|$I}$E{$I}$JO$E{$JO$JTEr$JT$JU$Bp$JU$KVEr$KV$KW$Bp$KW&FUEr&FU&FV$Bp&FV;'SEr;'S;=`I|<%l?HTEr?HT?HU$Bp?HUOEr(n%d_$f&j(Op(R!bOY%ZYZ&cZr%Zrs&}sw%Zwx(rx!^%Z!^!_*g!_#O%Z#O#P&c#P#o%Z#o#p*g#p;'S%Z;'S;=`+a<%lO%Z&j&hT$f&jO!^&c!_#o&c#p;'S&c;'S;=`&w<%lO&c&j&zP;=`<%l&c'|'U]$f&j(R!bOY&}YZ&cZw&}wx&cx!^&}!^!_'}!_#O&}#O#P&c#P#o&}#o#p'}#p;'S&};'S;=`(l<%lO&}!b(SU(R!bOY'}Zw'}x#O'}#P;'S'};'S;=`(f<%lO'}!b(iP;=`<%l'}'|(oP;=`<%l&}'[(y]$f&j(OpOY(rYZ&cZr(rrs&cs!^(r!^!_)r!_#O(r#O#P&c#P#o(r#o#p)r#p;'S(r;'S;=`*a<%lO(rp)wU(OpOY)rZr)rs#O)r#P;'S)r;'S;=`*Z<%lO)rp*^P;=`<%l)r'[*dP;=`<%l(r#S*nX(Op(R!bOY*gZr*grs'}sw*gwx)rx#O*g#P;'S*g;'S;=`+Z<%lO*g#S+^P;=`<%l*g(n+dP;=`<%l%Z(CS+rq$f&j(Op(R!b't(;dOX%ZXY+gYZ&cZ[+g[p%Zpq+gqr%Zrs&}sw%Zwx(rx!^%Z!^!_*g!_#O%Z#O#P&c#P#o%Z#o#p*g#p$f%Z$f$g+g$g#BY%Z#BY#BZ+g#BZ$IS%Z$IS$I_+g$I_$JT%Z$JT$JU+g$JU$KV%Z$KV$KW+g$KW&FU%Z&FU&FV+g&FV;'S%Z;'S;=`+a<%l?HT%Z?HT?HU+g?HUO%Z(CS.ST(P#S$f&j'u(;dO!^&c!_#o&c#p;'S&c;'S;=`&w<%lO&c(CS.n_$f&j(Op(R!b'u(;dOY%ZYZ&cZr%Zrs&}sw%Zwx(rx!^%Z!^!_*g!_#O%Z#O#P&c#P#o%Z#o#p*g#p;'S%Z;'S;=`+a<%lO%Z%#`/x`$f&j!o$Ip(Op(R!bOY%ZYZ&cZr%Zrs&}sw%Zwx(rx!^%Z!^!_*g!_!`0z!`#O%Z#O#P&c#P#o%Z#o#p*g#p;'S%Z;'S;=`+a<%lO%Z%#S1V`#t$Id$f&j(Op(R!bOY%ZYZ&cZr%Zrs&}sw%Zwx(rx!^%Z!^!_*g!_!`2X!`#O%Z#O#P&c#P#o%Z#o#p*g#p;'S%Z;'S;=`+a<%lO%Z%#S2d_#t$Id$f&j(Op(R!bOY%ZYZ&cZr%Zrs&}sw%Zwx(rx!^%Z!^!_*g!_#O%Z#O#P&c#P#o%Z#o#p*g#p;'S%Z;'S;=`+a<%lO%Z$/|3l_'}$(n$f&j(R!bOY4kYZ5qZr4krs7nsw4kwx5qx!^4k!^!_8p!_#O4k#O#P5q#P#o4k#o#p8p#p;'S4k;'S;=`:X<%lO4k(^4r_$f&j(R!bOY4kYZ5qZr4krs7nsw4kwx5qx!^4k!^!_8p!_#O4k#O#P5q#P#o4k#o#p8p#p;'S4k;'S;=`:X<%lO4k&z5vX$f&jOr5qrs6cs!^5q!^!_6y!_#o5q#o#p6y#p;'S5q;'S;=`7h<%lO5q&z6jT$a`$f&jO!^&c!_#o&c#p;'S&c;'S;=`&w<%lO&c`6|TOr6yrs7]s;'S6y;'S;=`7b<%lO6y`7bO$a``7eP;=`<%l6y&z7kP;=`<%l5q(^7w]$a`$f&j(R!bOY&}YZ&cZw&}wx&cx!^&}!^!_'}!_#O&}#O#P&c#P#o&}#o#p'}#p;'S&};'S;=`(l<%lO&}!r8uZ(R!bOY8pYZ6yZr8prs9hsw8pwx6yx#O8p#O#P6y#P;'S8p;'S;=`:R<%lO8p!r9oU$a`(R!bOY'}Zw'}x#O'}#P;'S'};'S;=`(f<%lO'}!r:UP;=`<%l8p(^:[P;=`<%l4k#%|:hh$f&j(Op(R!bOY%ZYZ&cZq%Zqr<Srs&}st%ZtuCruw%Zwx(rx!^%Z!^!_*g!_!c%Z!c!}Cr!}#O%Z#O#P&c#P#R%Z#R#SCr#S#T%Z#T#oCr#o#p*g#p$g%Z$g;'SCr;'S;=`El<%lOCr(r<__VS$f&j(Op(R!bOY<SYZ&cZr<Srs=^sw<Swx@nx!^<S!^!_Bm!_#O<S#O#P>`#P#o<S#o#pBm#p;'S<S;'S;=`Cl<%lO<S(Q=g]VS$f&j(R!bOY=^YZ&cZw=^wx>`x!^=^!^!_?q!_#O=^#O#P>`#P#o=^#o#p?q#p;'S=^;'S;=`@h<%lO=^&n>gXVS$f&jOY>`YZ&cZ!^>`!^!_?S!_#o>`#o#p?S#p;'S>`;'S;=`?k<%lO>`S?XSVSOY?SZ;'S?S;'S;=`?e<%lO?SS?hP;=`<%l?S&n?nP;=`<%l>`!f?xWVS(R!bOY?qZw?qwx?Sx#O?q#O#P?S#P;'S?q;'S;=`@b<%lO?q!f@eP;=`<%l?q(Q@kP;=`<%l=^'`@w]VS$f&j(OpOY@nYZ&cZr@nrs>`s!^@n!^!_Ap!_#O@n#O#P>`#P#o@n#o#pAp#p;'S@n;'S;=`Bg<%lO@ntAwWVS(OpOYApZrAprs?Ss#OAp#O#P?S#P;'SAp;'S;=`Ba<%lOAptBdP;=`<%lAp'`BjP;=`<%l@n#WBvYVS(Op(R!bOYBmZrBmrs?qswBmwxApx#OBm#O#P?S#P;'SBm;'S;=`Cf<%lOBm#WCiP;=`<%lBm(rCoP;=`<%l<S#%|C}i$f&j(g!L^(Op(R!bOY%ZYZ&cZr%Zrs&}st%ZtuCruw%Zwx(rx!Q%Z!Q![Cr![!^%Z!^!_*g!_!c%Z!c!}Cr!}#O%Z#O#P&c#P#R%Z#R#SCr#S#T%Z#T#oCr#o#p*g#p$g%Z$g;'SCr;'S;=`El<%lOCr#%|EoP;=`<%lCr(CSFRk$f&j(Op(R!b$Y#t'{&;d([!LYOY%ZYZ&cZr%Zrs&}st%ZtuEruw%Zwx(rx}%Z}!OGv!O!Q%Z!Q![Er![!^%Z!^!_*g!_!c%Z!c!}Er!}#O%Z#O#P&c#P#R%Z#R#SEr#S#T%Z#T#oEr#o#p*g#p$g%Z$g;'SEr;'S;=`I|<%lOEr+dHRk$f&j(Op(R!b$Y#tOY%ZYZ&cZr%Zrs&}st%ZtuGvuw%Zwx(rx}%Z}!OGv!O!Q%Z!Q![Gv![!^%Z!^!_*g!_!c%Z!c!}Gv!}#O%Z#O#P&c#P#R%Z#R#SGv#S#T%Z#T#oGv#o#p*g#p$g%Z$g;'SGv;'S;=`Iv<%lOGv+dIyP;=`<%lGv(CSJPP;=`<%lEr%#SJ_`$f&j(Op(R!b#l$IdOY%ZYZ&cZr%Zrs&}sw%Zwx(rx!^%Z!^!_*g!_!`Ka!`#O%Z#O#P&c#P#o%Z#o#p*g#p;'S%Z;'S;=`+a<%lO%Z%#SKl_$f&j$O$Id(Op(R!bOY%ZYZ&cZr%Zrs&}sw%Zwx(rx!^%Z!^!_*g!_#O%Z#O#P&c#P#o%Z#o#p*g#p;'S%Z;'S;=`+a<%lO%Z&COLva(q&;`$f&j(Op(R!bOY%ZYZ&cZr%Zrs&}sv%ZvwM{wx(rx!^%Z!^!_*g!_!`Ka!`#O%Z#O#P&c#P#o%Z#o#p*g#p;'S%Z;'S;=`+a<%lO%Z%#SNW`$f&j#x$Id(Op(R!bOY%ZYZ&cZr%Zrs&}sw%Zwx(rx!^%Z!^!_*g!_!`Ka!`#O%Z#O#P&c#P#o%Z#o#p*g#p;'S%Z;'S;=`+a<%lO%Z$/|! c_(Q$)`$f&j(OpOY!!bYZ!#hZr!!brs!#hsw!!bwx!$xx!^!!b!^!_!%z!_#O!!b#O#P!#h#P#o!!b#o#p!%z#p;'S!!b;'S;=`!'c<%lO!!b'l!!i_$f&j(OpOY!!bYZ!#hZr!!brs!#hsw!!bwx!$xx!^!!b!^!_!%z!_#O!!b#O#P!#h#P#o!!b#o#p!%z#p;'S!!b;'S;=`!'c<%lO!!b&z!#mX$f&jOw!#hwx6cx!^!#h!^!_!$Y!_#o!#h#o#p!$Y#p;'S!#h;'S;=`!$r<%lO!#h`!$]TOw!$Ywx7]x;'S!$Y;'S;=`!$l<%lO!$Y`!$oP;=`<%l!$Y&z!$uP;=`<%l!#h'l!%R]$a`$f&j(OpOY(rYZ&cZr(rrs&cs!^(r!^!_)r!_#O(r#O#P&c#P#o(r#o#p)r#p;'S(r;'S;=`*a<%lO(r!Q!&PZ(OpOY!%zYZ!$YZr!%zrs!$Ysw!%zwx!&rx#O!%z#O#P!$Y#P;'S!%z;'S;=`!']<%lO!%z!Q!&yU$a`(OpOY)rZr)rs#O)r#P;'S)r;'S;=`*Z<%lO)r!Q!'`P;=`<%l!%z'l!'fP;=`<%l!!b(*Q!'t_!k(!b$f&j(Op(R!bOY%ZYZ&cZr%Zrs&}sw%Zwx(rx!^%Z!^!_*g!_#O%Z#O#P&c#P#o%Z#o#p*g#p;'S%Z;'S;=`+a<%lO%Z!'l!)O_!jM|$f&j(Op(R!bOY%ZYZ&cZr%Zrs&}sw%Zwx(rx!^%Z!^!_*g!_#O%Z#O#P&c#P#o%Z#o#p*g#p;'S%Z;'S;=`+a<%lO%Z'+h!*[b$f&j(Op(R!b'|#)d#m$IdOY%ZYZ&cZr%Zrs&}sw%Zwx(rxz%Zz{!+d{!^%Z!^!_*g!_!`Ka!`#O%Z#O#P&c#P#o%Z#o#p*g#p;'S%Z;'S;=`+a<%lO%Z%#S!+o`$f&j(Op(R!b#j$IdOY%ZYZ&cZr%Zrs&}sw%Zwx(rx!^%Z!^!_*g!_!`Ka!`#O%Z#O#P&c#P#o%Z#o#p*g#p;'S%Z;'S;=`+a<%lO%Z&-O!,|`$f&j(Op(R!bn&%`OY%ZYZ&cZr%Zrs&}sw%Zwx(rx!^%Z!^!_*g!_!`Ka!`#O%Z#O#P&c#P#o%Z#o#p*g#p;'S%Z;'S;=`+a<%lO%Z&C[!.Z_!Y&;l$f&j(Op(R!bOY%ZYZ&cZr%Zrs&}sw%Zwx(rx!^%Z!^!_*g!_#O%Z#O#P&c#P#o%Z#o#p*g#p;'S%Z;'S;=`+a<%lO%Z(CS!/ec$f&j(Op(R!b|'<nOY%ZYZ&cZr%Zrs&}sw%Zwx(rx!O%Z!O!P!0p!P!Q%Z!Q![!3Y![!^%Z!^!_*g!_#O%Z#O#P&c#P#o%Z#o#p*g#p;'S%Z;'S;=`+a<%lO%Z!'d!0ya$f&j(Op(R!bOY%ZYZ&cZr%Zrs&}sw%Zwx(rx!O%Z!O!P!2O!P!^%Z!^!_*g!_#O%Z#O#P&c#P#o%Z#o#p*g#p;'S%Z;'S;=`+a<%lO%Z!'d!2Z_!XMt$f&j(Op(R!bOY%ZYZ&cZr%Zrs&}sw%Zwx(rx!^%Z!^!_*g!_#O%Z#O#P&c#P#o%Z#o#p*g#p;'S%Z;'S;=`+a<%lO%Z$/l!3eg$f&j(Op(R!bo$'|OY%ZYZ&cZr%Zrs&}sw%Zwx(rx!Q%Z!Q![!3Y![!^%Z!^!_*g!_!g%Z!g!h!4|!h#O%Z#O#P&c#P#R%Z#R#S!3Y#S#X%Z#X#Y!4|#Y#o%Z#o#p*g#p;'S%Z;'S;=`+a<%lO%Z$/l!5Vg$f&j(Op(R!bOY%ZYZ&cZr%Zrs&}sw%Zwx(rx{%Z{|!6n|}%Z}!O!6n!O!Q%Z!Q![!8S![!^%Z!^!_*g!_#O%Z#O#P&c#P#R%Z#R#S!8S#S#o%Z#o#p*g#p;'S%Z;'S;=`+a<%lO%Z$/l!6wc$f&j(Op(R!bOY%ZYZ&cZr%Zrs&}sw%Zwx(rx!Q%Z!Q![!8S![!^%Z!^!_*g!_#O%Z#O#P&c#P#R%Z#R#S!8S#S#o%Z#o#p*g#p;'S%Z;'S;=`+a<%lO%Z$/l!8_c$f&j(Op(R!bo$'|OY%ZYZ&cZr%Zrs&}sw%Zwx(rx!Q%Z!Q![!8S![!^%Z!^!_*g!_#O%Z#O#P&c#P#R%Z#R#S!8S#S#o%Z#o#p*g#p;'S%Z;'S;=`+a<%lO%Z(CS!9uf$f&j(Op(R!b#k$IdOY!;ZYZ&cZr!;Zrs!<nsw!;Zwx!Lcxz!;Zz{#-}{!P!;Z!P!Q#/d!Q!^!;Z!^!_#(i!_!`#7S!`!a#8i!a!}!;Z!}#O#,f#O#P!Dy#P#o!;Z#o#p#(i#p;'S!;Z;'S;=`#-w<%lO!;Z(r!;fb$f&j(Op(R!b!USOY!;ZYZ&cZr!;Zrs!<nsw!;Zwx!Lcx!P!;Z!P!Q#&`!Q!^!;Z!^!_#(i!_!}!;Z!}#O#,f#O#P!Dy#P#o!;Z#o#p#(i#p;'S!;Z;'S;=`#-w<%lO!;Z(Q!<w`$f&j(R!b!USOY!<nYZ&cZw!<nwx!=yx!P!<n!P!Q!Eq!Q!^!<n!^!_!Gr!_!}!<n!}#O!KS#O#P!Dy#P#o!<n#o#p!Gr#p;'S!<n;'S;=`!L]<%lO!<n&n!>Q^$f&j!USOY!=yYZ&cZ!P!=y!P!Q!>|!Q!^!=y!^!_!@c!_!}!=y!}#O!CW#O#P!Dy#P#o!=y#o#p!@c#p;'S!=y;'S;=`!Ek<%lO!=y&n!?Td$f&j!USO!^&c!_#W&c#W#X!>|#X#Z&c#Z#[!>|#[#]&c#]#^!>|#^#a&c#a#b!>|#b#g&c#g#h!>|#h#i&c#i#j!>|#j#k!>|#k#m&c#m#n!>|#n#o&c#p;'S&c;'S;=`&w<%lO&cS!@hX!USOY!@cZ!P!@c!P!Q!AT!Q!}!@c!}#O!Ar#O#P!Bq#P;'S!@c;'S;=`!CQ<%lO!@cS!AYW!US#W#X!AT#Z#[!AT#]#^!AT#a#b!AT#g#h!AT#i#j!AT#j#k!AT#m#n!ATS!AuVOY!ArZ#O!Ar#O#P!B[#P#Q!@c#Q;'S!Ar;'S;=`!Bk<%lO!ArS!B_SOY!ArZ;'S!Ar;'S;=`!Bk<%lO!ArS!BnP;=`<%l!ArS!BtSOY!@cZ;'S!@c;'S;=`!CQ<%lO!@cS!CTP;=`<%l!@c&n!C][$f&jOY!CWYZ&cZ!^!CW!^!_!Ar!_#O!CW#O#P!DR#P#Q!=y#Q#o!CW#o#p!Ar#p;'S!CW;'S;=`!Ds<%lO!CW&n!DWX$f&jOY!CWYZ&cZ!^!CW!^!_!Ar!_#o!CW#o#p!Ar#p;'S!CW;'S;=`!Ds<%lO!CW&n!DvP;=`<%l!CW&n!EOX$f&jOY!=yYZ&cZ!^!=y!^!_!@c!_#o!=y#o#p!@c#p;'S!=y;'S;=`!Ek<%lO!=y&n!EnP;=`<%l!=y(Q!Ezl$f&j(R!b!USOY&}YZ&cZw&}wx&cx!^&}!^!_'}!_#O&}#O#P&c#P#W&}#W#X!Eq#X#Z&}#Z#[!Eq#[#]&}#]#^!Eq#^#a&}#a#b!Eq#b#g&}#g#h!Eq#h#i&}#i#j!Eq#j#k!Eq#k#m&}#m#n!Eq#n#o&}#o#p'}#p;'S&};'S;=`(l<%lO&}!f!GyZ(R!b!USOY!GrZw!Grwx!@cx!P!Gr!P!Q!Hl!Q!}!Gr!}#O!JU#O#P!Bq#P;'S!Gr;'S;=`!J|<%lO!Gr!f!Hse(R!b!USOY'}Zw'}x#O'}#P#W'}#W#X!Hl#X#Z'}#Z#[!Hl#[#]'}#]#^!Hl#^#a'}#a#b!Hl#b#g'}#g#h!Hl#h#i'}#i#j!Hl#j#k!Hl#k#m'}#m#n!Hl#n;'S'};'S;=`(f<%lO'}!f!JZX(R!bOY!JUZw!JUwx!Arx#O!JU#O#P!B[#P#Q!Gr#Q;'S!JU;'S;=`!Jv<%lO!JU!f!JyP;=`<%l!JU!f!KPP;=`<%l!Gr(Q!KZ^$f&j(R!bOY!KSYZ&cZw!KSwx!CWx!^!KS!^!_!JU!_#O!KS#O#P!DR#P#Q!<n#Q#o!KS#o#p!JU#p;'S!KS;'S;=`!LV<%lO!KS(Q!LYP;=`<%l!KS(Q!L`P;=`<%l!<n'`!Ll`$f&j(Op!USOY!LcYZ&cZr!Lcrs!=ys!P!Lc!P!Q!Mn!Q!^!Lc!^!_# o!_!}!Lc!}#O#%P#O#P!Dy#P#o!Lc#o#p# o#p;'S!Lc;'S;=`#&Y<%lO!Lc'`!Mwl$f&j(Op!USOY(rYZ&cZr(rrs&cs!^(r!^!_)r!_#O(r#O#P&c#P#W(r#W#X!Mn#X#Z(r#Z#[!Mn#[#](r#]#^!Mn#^#a(r#a#b!Mn#b#g(r#g#h!Mn#h#i(r#i#j!Mn#j#k!Mn#k#m(r#m#n!Mn#n#o(r#o#p)r#p;'S(r;'S;=`*a<%lO(rt# vZ(Op!USOY# oZr# ors!@cs!P# o!P!Q#!i!Q!}# o!}#O#$R#O#P!Bq#P;'S# o;'S;=`#$y<%lO# ot#!pe(Op!USOY)rZr)rs#O)r#P#W)r#W#X#!i#X#Z)r#Z#[#!i#[#])r#]#^#!i#^#a)r#a#b#!i#b#g)r#g#h#!i#h#i)r#i#j#!i#j#k#!i#k#m)r#m#n#!i#n;'S)r;'S;=`*Z<%lO)rt#$WX(OpOY#$RZr#$Rrs!Ars#O#$R#O#P!B[#P#Q# o#Q;'S#$R;'S;=`#$s<%lO#$Rt#$vP;=`<%l#$Rt#$|P;=`<%l# o'`#%W^$f&j(OpOY#%PYZ&cZr#%Prs!CWs!^#%P!^!_#$R!_#O#%P#O#P!DR#P#Q!Lc#Q#o#%P#o#p#$R#p;'S#%P;'S;=`#&S<%lO#%P'`#&VP;=`<%l#%P'`#&]P;=`<%l!Lc(r#&kn$f&j(Op(R!b!USOY%ZYZ&cZr%Zrs&}sw%Zwx(rx!^%Z!^!_*g!_#O%Z#O#P&c#P#W%Z#W#X#&`#X#Z%Z#Z#[#&`#[#]%Z#]#^#&`#^#a%Z#a#b#&`#b#g%Z#g#h#&`#h#i%Z#i#j#&`#j#k#&`#k#m%Z#m#n#&`#n#o%Z#o#p*g#p;'S%Z;'S;=`+a<%lO%Z#W#(r](Op(R!b!USOY#(iZr#(irs!Grsw#(iwx# ox!P#(i!P!Q#)k!Q!}#(i!}#O#+`#O#P!Bq#P;'S#(i;'S;=`#,`<%lO#(i#W#)th(Op(R!b!USOY*gZr*grs'}sw*gwx)rx#O*g#P#W*g#W#X#)k#X#Z*g#Z#[#)k#[#]*g#]#^#)k#^#a*g#a#b#)k#b#g*g#g#h#)k#h#i*g#i#j#)k#j#k#)k#k#m*g#m#n#)k#n;'S*g;'S;=`+Z<%lO*g#W#+gZ(Op(R!bOY#+`Zr#+`rs!JUsw#+`wx#$Rx#O#+`#O#P!B[#P#Q#(i#Q;'S#+`;'S;=`#,Y<%lO#+`#W#,]P;=`<%l#+`#W#,cP;=`<%l#(i(r#,o`$f&j(Op(R!bOY#,fYZ&cZr#,frs!KSsw#,fwx#%Px!^#,f!^!_#+`!_#O#,f#O#P!DR#P#Q!;Z#Q#o#,f#o#p#+`#p;'S#,f;'S;=`#-q<%lO#,f(r#-tP;=`<%l#,f(r#-zP;=`<%l!;Z(CS#.[b$f&j(Op(R!b'v(;d!USOY!;ZYZ&cZr!;Zrs!<nsw!;Zwx!Lcx!P!;Z!P!Q#&`!Q!^!;Z!^!_#(i!_!}!;Z!}#O#,f#O#P!Dy#P#o!;Z#o#p#(i#p;'S!;Z;'S;=`#-w<%lO!;Z(CS#/o_$f&j(Op(R!bS(;dOY#/dYZ&cZr#/drs#0nsw#/dwx#4Ox!^#/d!^!_#5}!_#O#/d#O#P#1p#P#o#/d#o#p#5}#p;'S#/d;'S;=`#6|<%lO#/d(Bb#0w]$f&j(R!bS(;dOY#0nYZ&cZw#0nwx#1px!^#0n!^!_#3R!_#O#0n#O#P#1p#P#o#0n#o#p#3R#p;'S#0n;'S;=`#3x<%lO#0n(AO#1wX$f&jS(;dOY#1pYZ&cZ!^#1p!^!_#2d!_#o#1p#o#p#2d#p;'S#1p;'S;=`#2{<%lO#1p(;d#2iSS(;dOY#2dZ;'S#2d;'S;=`#2u<%lO#2d(;d#2xP;=`<%l#2d(AO#3OP;=`<%l#1p(<v#3YW(R!bS(;dOY#3RZw#3Rwx#2dx#O#3R#O#P#2d#P;'S#3R;'S;=`#3r<%lO#3R(<v#3uP;=`<%l#3R(Bb#3{P;=`<%l#0n(Ap#4X]$f&j(OpS(;dOY#4OYZ&cZr#4Ors#1ps!^#4O!^!_#5Q!_#O#4O#O#P#1p#P#o#4O#o#p#5Q#p;'S#4O;'S;=`#5w<%lO#4O(<U#5XW(OpS(;dOY#5QZr#5Qrs#2ds#O#5Q#O#P#2d#P;'S#5Q;'S;=`#5q<%lO#5Q(<U#5tP;=`<%l#5Q(Ap#5zP;=`<%l#4O(=h#6WY(Op(R!bS(;dOY#5}Zr#5}rs#3Rsw#5}wx#5Qx#O#5}#O#P#2d#P;'S#5};'S;=`#6v<%lO#5}(=h#6yP;=`<%l#5}(CS#7PP;=`<%l#/d%#W#7ab$f&j$O$Id(Op(R!b!USOY!;ZYZ&cZr!;Zrs!<nsw!;Zwx!Lcx!P!;Z!P!Q#&`!Q!^!;Z!^!_#(i!_!}!;Z!}#O#,f#O#P!Dy#P#o!;Z#o#p#(i#p;'S!;Z;'S;=`#-w<%lO!;Z+h#8vb$W#t$f&j(Op(R!b!USOY!;ZYZ&cZr!;Zrs!<nsw!;Zwx!Lcx!P!;Z!P!Q#&`!Q!^!;Z!^!_#(i!_!}!;Z!}#O#,f#O#P!Dy#P#o!;Z#o#p#(i#p;'S!;Z;'S;=`#-w<%lO!;Z$/l#:Zp$f&j(Op(R!bo$'|OY%ZYZ&cZr%Zrs&}sw%Zwx(rx!O%Z!O!P!3Y!P!Q%Z!Q![#<_![!^%Z!^!_*g!_!g%Z!g!h!4|!h#O%Z#O#P&c#P#R%Z#R#S#<_#S#U%Z#U#V#?i#V#X%Z#X#Y!4|#Y#b%Z#b#c#>_#c#d#Bq#d#l%Z#l#m#Es#m#o%Z#o#p*g#p;'S%Z;'S;=`+a<%lO%Z$/l#<jk$f&j(Op(R!bo$'|OY%ZYZ&cZr%Zrs&}sw%Zwx(rx!O%Z!O!P!3Y!P!Q%Z!Q![#<_![!^%Z!^!_*g!_!g%Z!g!h!4|!h#O%Z#O#P&c#P#R%Z#R#S#<_#S#X%Z#X#Y!4|#Y#b%Z#b#c#>_#c#o%Z#o#p*g#p;'S%Z;'S;=`+a<%lO%Z$/l#>j_$f&j(Op(R!bo$'|OY%ZYZ&cZr%Zrs&}sw%Zwx(rx!^%Z!^!_*g!_#O%Z#O#P&c#P#o%Z#o#p*g#p;'S%Z;'S;=`+a<%lO%Z$/l#?rd$f&j(Op(R!bOY%ZYZ&cZr%Zrs&}sw%Zwx(rx!Q%Z!Q!R#AQ!R!S#AQ!S!^%Z!^!_*g!_#O%Z#O#P&c#P#R%Z#R#S#AQ#S#o%Z#o#p*g#p;'S%Z;'S;=`+a<%lO%Z$/l#A]f$f&j(Op(R!bo$'|OY%ZYZ&cZr%Zrs&}sw%Zwx(rx!Q%Z!Q!R#AQ!R!S#AQ!S!^%Z!^!_*g!_#O%Z#O#P&c#P#R%Z#R#S#AQ#S#b%Z#b#c#>_#c#o%Z#o#p*g#p;'S%Z;'S;=`+a<%lO%Z$/l#Bzc$f&j(Op(R!bOY%ZYZ&cZr%Zrs&}sw%Zwx(rx!Q%Z!Q!Y#DV!Y!^%Z!^!_*g!_#O%Z#O#P&c#P#R%Z#R#S#DV#S#o%Z#o#p*g#p;'S%Z;'S;=`+a<%lO%Z$/l#Dbe$f&j(Op(R!bo$'|OY%ZYZ&cZr%Zrs&}sw%Zwx(rx!Q%Z!Q!Y#DV!Y!^%Z!^!_*g!_#O%Z#O#P&c#P#R%Z#R#S#DV#S#b%Z#b#c#>_#c#o%Z#o#p*g#p;'S%Z;'S;=`+a<%lO%Z$/l#E|g$f&j(Op(R!bOY%ZYZ&cZr%Zrs&}sw%Zwx(rx!Q%Z!Q![#Ge![!^%Z!^!_*g!_!c%Z!c!i#Ge!i#O%Z#O#P&c#P#R%Z#R#S#Ge#S#T%Z#T#Z#Ge#Z#o%Z#o#p*g#p;'S%Z;'S;=`+a<%lO%Z$/l#Gpi$f&j(Op(R!bo$'|OY%ZYZ&cZr%Zrs&}sw%Zwx(rx!Q%Z!Q![#Ge![!^%Z!^!_*g!_!c%Z!c!i#Ge!i#O%Z#O#P&c#P#R%Z#R#S#Ge#S#T%Z#T#Z#Ge#Z#b%Z#b#c#>_#c#o%Z#o#p*g#p;'S%Z;'S;=`+a<%lO%Z%Gh#Il_!d$b$f&j#|%<f(Op(R!bOY%ZYZ&cZr%Zrs&}sw%Zwx(rx!^%Z!^!_*g!_#O%Z#O#P&c#P#o%Z#o#p*g#p;'S%Z;'S;=`+a<%lO%Z)[#Jv_`l$f&j(Op(R!bOY%ZYZ&cZr%Zrs&}sw%Zwx(rx!^%Z!^!_*g!_#O%Z#O#P&c#P#o%Z#o#p*g#p;'S%Z;'S;=`+a<%lO%Z(@^#LS^g!*v!h'.r(Op(R!b(uSOY*gZr*grs'}sw*gwx)rx!P*g!P!Q#MO!Q!^*g!^!_#Mt!_!`$ f!`#O*g#P;'S*g;'S;=`+Z<%lO*g(n#MXX$h&j(Op(R!bOY*gZr*grs'}sw*gwx)rx#O*g#P;'S*g;'S;=`+Z<%lO*g$Kh#M}Z#n$Id(Op(R!bOY*gZr*grs'}sw*gwx)rx!_*g!_!`#Np!`#O*g#P;'S*g;'S;=`+Z<%lO*g$Kh#NyX$O$Id(Op(R!bOY*gZr*grs'}sw*gwx)rx#O*g#P;'S*g;'S;=`+Z<%lO*g$Kh$ oX#o$Id(Op(R!bOY*gZr*grs'}sw*gwx)rx#O*g#P;'S*g;'S;=`+Z<%lO*g%Gh$!ga#[%?x$f&j(Op(R!bOY%ZYZ&cZr%Zrs&}sw%Zwx(rx!^%Z!^!_*g!_!`0z!`!a$#l!a#O%Z#O#P&c#P#o%Z#o#p*g#p;'S%Z;'S;=`+a<%lO%Z%#W$#w_#g$Ih$f&j(Op(R!bOY%ZYZ&cZr%Zrs&}sw%Zwx(rx!^%Z!^!_*g!_#O%Z#O#P&c#P#o%Z#o#p*g#p;'S%Z;'S;=`+a<%lO%Z%Gh$%VafBf#o$Id$c#|$f&j(Op(R!bOY%ZYZ&cZr%Zrs&}sw%Zwx(rx!^%Z!^!_*g!_!`$&[!`!a$'f!a#O%Z#O#P&c#P#o%Z#o#p*g#p;'S%Z;'S;=`+a<%lO%Z%#S$&g_#o$Id$f&j(Op(R!bOY%ZYZ&cZr%Zrs&}sw%Zwx(rx!^%Z!^!_*g!_#O%Z#O#P&c#P#o%Z#o#p*g#p;'S%Z;'S;=`+a<%lO%Z%#S$'qa#n$Id$f&j(Op(R!bOY%ZYZ&cZr%Zrs&}sw%Zwx(rx!^%Z!^!_*g!_!`Ka!`!a$(v!a#O%Z#O#P&c#P#o%Z#o#p*g#p;'S%Z;'S;=`+a<%lO%Z%#S$)R`#n$Id$f&j(Op(R!bOY%ZYZ&cZr%Zrs&}sw%Zwx(rx!^%Z!^!_*g!_!`Ka!`#O%Z#O#P&c#P#o%Z#o#p*g#p;'S%Z;'S;=`+a<%lO%Z'+h$*`c(i$Ip$f&j(Op(R!bOY%ZYZ&cZr%Zrs&}sw%Zwx(rx!O%Z!O!P$+k!P!^%Z!^!_*g!_!a%Z!a!b$,u!b#O%Z#O#P&c#P#o%Z#o#p*g#p;'S%Z;'S;=`+a<%lO%Z'+`$+v_}'#p$f&j(Op(R!bOY%ZYZ&cZr%Zrs&}sw%Zwx(rx!^%Z!^!_*g!_#O%Z#O#P&c#P#o%Z#o#p*g#p;'S%Z;'S;=`+a<%lO%Z%#S$-Q`$f&j#y$Id(Op(R!bOY%ZYZ&cZr%Zrs&}sw%Zwx(rx!^%Z!^!_*g!_!`Ka!`#O%Z#O#P&c#P#o%Z#o#p*g#p;'S%Z;'S;=`+a<%lO%Z#&^$.__!{!Ln$f&j(Op(R!bOY%ZYZ&cZr%Zrs&}sw%Zwx(rx!^%Z!^!_*g!_#O%Z#O#P&c#P#o%Z#o#p*g#p;'S%Z;'S;=`+a<%lO%Z(@^$/i_!P(8n$f&j(Op(R!bOY%ZYZ&cZr%Zrs&}sw%Zwx(rx!^%Z!^!_*g!_#O%Z#O#P&c#P#o%Z#o#p*g#p;'S%Z;'S;=`+a<%lO%Z(n$0mZ$f&jO!^$1`!^!_$1v!_#i$1`#i#j$1{#j#l$1`#l#m$3n#m#o$1`#o#p$1v#p;'S$1`;'S;=`$5y<%lO$1`(n$1gT^#S$f&jO!^&c!_#o&c#p;'S&c;'S;=`&w<%lO&c#S$1{O^#S(n$2Q[$f&jO!Q&c!Q![$2v![!^&c!_!c&c!c!i$2v!i#T&c#T#Z$2v#Z#o&c#o#p$5^#p;'S&c;'S;=`&w<%lO&c(n$2{Z$f&jO!Q&c!Q![$3n![!^&c!_!c&c!c!i$3n!i#T&c#T#Z$3n#Z#o&c#p;'S&c;'S;=`&w<%lO&c(n$3sZ$f&jO!Q&c!Q![$4f![!^&c!_!c&c!c!i$4f!i#T&c#T#Z$4f#Z#o&c#p;'S&c;'S;=`&w<%lO&c(n$4kZ$f&jO!Q&c!Q![$1`![!^&c!_!c&c!c!i$1`!i#T&c#T#Z$1`#Z#o&c#p;'S&c;'S;=`&w<%lO&c#S$5aR!Q![$5j!c!i$5j#T#Z$5j#S$5mS!Q![$5j!c!i$5j#T#Z$5j#q#r$1v(n$5|P;=`<%l$1`!2r$6[_!V!+S$f&j(Op(R!bOY%ZYZ&cZr%Zrs&}sw%Zwx(rx!^%Z!^!_*g!_#O%Z#O#P&c#P#o%Z#o#p*g#p;'S%Z;'S;=`+a<%lO%Z%#S$7f`#v$Id$f&j(Op(R!bOY%ZYZ&cZr%Zrs&}sw%Zwx(rx!^%Z!^!_*g!_!`Ka!`#O%Z#O#P&c#P#o%Z#o#p*g#p;'S%Z;'S;=`+a<%lO%Z&,v$8s_$f&j(Op(R!b(X&%WOY%ZYZ&cZr%Zrs&}sw%Zwx(rx!^%Z!^!_*g!_#O%Z#O#P&c#P#o%Z#o#p*g#p;'S%Z;'S;=`+a<%lO%Z(CS$:Rk$f&j(Op(R!b'{&;d$[#t([!LYOY%ZYZ&cZr%Zrs&}st%Ztu$9ruw%Zwx(rx}%Z}!O$;v!O!Q%Z!Q![$9r![!^%Z!^!_*g!_!c%Z!c!}$9r!}#O%Z#O#P&c#P#R%Z#R#S$9r#S#T%Z#T#o$9r#o#p*g#p$g%Z$g;'S$9r;'S;=`$=|<%lO$9r+d$<Rk$f&j(Op(R!b$[#tOY%ZYZ&cZr%Zrs&}st%Ztu$;vuw%Zwx(rx}%Z}!O$;v!O!Q%Z!Q![$;v![!^%Z!^!_*g!_!c%Z!c!}$;v!}#O%Z#O#P&c#P#R%Z#R#S$;v#S#T%Z#T#o$;v#o#p*g#p$g%Z$g;'S$;v;'S;=`$=v<%lO$;v+d$=yP;=`<%l$;v(CS$>PP;=`<%l$9r!5p$>]X![!3l(Op(R!bOY*gZr*grs'}sw*gwx)rx#O*g#P;'S*g;'S;=`+Z<%lO*g&CO$?Ta(p&;`$f&j(Op(R!bOY%ZYZ&cZr%Zrs&}sw%Zwx(rx!^%Z!^!_*g!_!`Ka!`#O%Z#O#P&c#P#o%Z#o#p*g#p#q$,u#q;'S%Z;'S;=`+a<%lO%Z%#`$@g_!Z$I`r`$f&j(Op(R!bOY%ZYZ&cZr%Zrs&}sw%Zwx(rx!^%Z!^!_*g!_#O%Z#O#P&c#P#o%Z#o#p*g#p;'S%Z;'S;=`+a<%lO%Z(r$Aq_!pS$f&j(Op(R!bOY%ZYZ&cZr%Zrs&}sw%Zwx(rx!^%Z!^!_*g!_#O%Z#O#P&c#P#o%Z#o#p*g#p;'S%Z;'S;=`+a<%lO%Z(CS$CR|$f&j(Op(R!b't(;d$Y#t'{&;d([!LYOX%ZXY+gYZ&cZ[+g[p%Zpq+gqr%Zrs&}st%ZtuEruw%Zwx(rx}%Z}!OGv!O!Q%Z!Q![Er![!^%Z!^!_*g!_!c%Z!c!}Er!}#O%Z#O#P&c#P#R%Z#R#SEr#S#T%Z#T#oEr#o#p*g#p$f%Z$f$g+g$g#BYEr#BY#BZ$Bp#BZ$ISEr$IS$I_$Bp$I_$JTEr$JT$JU$Bp$JU$KVEr$KV$KW$Bp$KW&FUEr&FU&FV$Bp&FV;'SEr;'S;=`I|<%l?HTEr?HT?HU$Bp?HUOEr(CS$F^k$f&j(Op(R!b'u(;d$Y#t'{&;d([!LYOY%ZYZ&cZr%Zrs&}st%ZtuEruw%Zwx(rx}%Z}!OGv!O!Q%Z!Q![Er![!^%Z!^!_*g!_!c%Z!c!}Er!}#O%Z#O#P&c#P#R%Z#R#SEr#S#T%Z#T#oEr#o#p*g#p$g%Z$g;'SEr;'S;=`I|<%lOEr",tokenizers:[NP,jP,DP,2,3,4,5,6,7,8,9,10,11,12,13,VP,new Ki("$S~RRtu[#O#Pg#S#T#|~_P#o#pb~gOt~~jVO#i!P#i#j!U#j#l!P#l#m!q#m;'S!P;'S;=`#v<%lO!P~!UO!R~~!XS!Q![!e!c!i!e#T#Z!e#o#p#Z~!hR!Q![!q!c!i!q#T#Z!q~!tR!Q![!}!c!i!}#T#Z!}~#QR!Q![!P!c!i!P#T#Z!P~#^R!Q![#g!c!i#g#T#Z#g~#jS!Q![#g!c!i#g#T#Z#g#q#r!P~#yP;=`<%l!P~$RO(Z~~",141,332),new Ki("j~RQYZXz{^~^O'x~~aP!P!Qd~iO'y~~",25,315)],topRules:{Script:[0,6],SingleExpression:[1,269],SingleClassItem:[2,270]},dialects:{jsx:0,ts:14826},dynamicPrecedences:{69:1,79:1,81:1,165:1,193:1},specialized:[{term:319,get:e=>UP[e]||-1},{term:334,get:e=>zP[e]||-1},{term:70,get:e=>BP[e]||-1}],tokenPrec:14850});var lm=[Ae("function ${name}(${params}) {\n	${}\n}",{label:"function",detail:"definition",type:"keyword"}),Ae("for (let ${index} = 0; ${index} < ${bound}; ${index}++) {\n	${}\n}",{label:"for",detail:"loop",type:"keyword"}),Ae("for (let ${name} of ${collection}) {\n	${}\n}",{label:"for",detail:"of loop",type:"keyword"}),Ae("do {\n	${}\n} while (${})",{label:"do",detail:"loop",type:"keyword"}),Ae("while (${}) {\n	${}\n}",{label:"while",detail:"loop",type:"keyword"}),Ae(`try {
-	\${}
-} catch (\${error}) {
-	\${}
-}`,{label:"try",detail:"/ catch block",type:"keyword"}),Ae("if (${}) {\n	${}\n}",{label:"if",detail:"block",type:"keyword"}),Ae(`if (\${}) {
-	\${}
-} else {
-	\${}
-}`,{label:"if",detail:"/ else block",type:"keyword"}),Ae(`class \${name} {
-	constructor(\${params}) {
-		\${}
-	}
-}`,{label:"class",detail:"definition",type:"keyword"}),Ae('import {${names}} from "${module}"\n${}',{label:"import",detail:"named",type:"keyword"}),Ae('import ${name} from "${module}"\n${}',{label:"import",detail:"default",type:"keyword"})],GP=lm.concat([Ae("interface ${name} {\n	${}\n}",{label:"interface",detail:"definition",type:"keyword"}),Ae("type ${name} = ${type}",{label:"type",detail:"definition",type:"keyword"}),Ae("enum ${name} {\n	${}\n}",{label:"enum",detail:"definition",type:"keyword"})]),sm=new kn,hm=new Set(["Script","Block","FunctionExpression","FunctionDeclaration","ArrowFunction","MethodDeclaration","ForStatement"]);function Ur(e){return(t,i)=>{let r=t.node.getChild("VariableDefinition");return r&&i(r,e),!0}}var FP=["FunctionDeclaration"],HP={FunctionDeclaration:Ur("function"),ClassDeclaration:Ur("class"),ClassExpression:()=>!0,EnumDeclaration:Ur("constant"),TypeAliasDeclaration:Ur("type"),NamespaceDeclaration:Ur("namespace"),VariableDefinition(e,t){e.matchContext(FP)||t(e,"variable")},TypeDefinition(e,t){t(e,"type")},__proto__:null};function cm(e,t){let i=sm.get(t);if(i)return i;let r=[],n=!0;function s(o,a){let l=e.sliceString(o.from,o.to);r.push({label:l,type:a})}return t.cursor(B.IncludeAnonymous).iterate(o=>{if(n)n=!1;else if(o.name){let a=HP[o.name];if(a&&a(o,s)||hm.has(o.name))return!1}else if(o.to-o.from>8192){for(let a of cm(e,o.node))r.push(a);return!1}}),sm.set(t,r),r}var om=/^[\w$\xa1-\uffff][\w$\d\xa1-\uffff]*$/,um=["TemplateString","String","RegExp","LineComment","BlockComment","VariableDefinition","TypeDefinition","Label","PropertyDefinition","PropertyName","PrivatePropertyDefinition","PrivatePropertyName",".","?."];function KP(e){let t=te(e.state).resolveInner(e.pos,-1);if(um.indexOf(t.name)>-1)return null;let i=t.name=="VariableName"||t.to-t.from<20&&om.test(e.state.sliceDoc(t.from,t.to));if(!i&&!e.explicit)return null;let r=[];for(let n=t;n;n=n.parent)hm.has(n.name)&&(r=r.concat(cm(e.state.doc,n)));return{options:r,from:i?t.from:e.pos,validFor:om}}var Ot=Bi.define({name:"javascript",parser:nm.configure({props:[ei.add({IfStatement:Gi({except:/^\s*({|else\b)/}),TryStatement:Gi({except:/^\s*({|catch\b|finally\b)/}),LabeledStatement:Qp,SwitchBody:e=>{let t=e.textAfter,i=/^\s*\}/.test(t),r=/^\s*(case|default)\b/.test(t);return e.baseIndent+(i?0:r?1:2)*e.unit},Block:kp({closing:"}"}),ArrowFunction:e=>e.baseIndent+e.unit,"TemplateString BlockComment":()=>null,"Statement Property":Gi({except:/^{/}),JSXElement(e){let t=/^\s*<\//.test(e.textAfter);return e.lineIndent(e.node.from)+(t?0:e.unit)},JSXEscape(e){let t=/\s*\}/.test(e.textAfter);return e.lineIndent(e.node.from)+(t?0:e.unit)},"JSXOpenTag JSXSelfClosingTag"(e){return e.column(e.node.from)+e.unit}}),pt.add({"Block ClassBody SwitchBody EnumBody ObjectExpression ArrayExpression ObjectType":ws,BlockComment(e){return{from:e.from+2,to:e.to-2}}})]}),languageData:{closeBrackets:{brackets:["(","[","{","'",'"',"`"]},commentTokens:{line:"//",block:{open:"/*",close:"*/"}},indentOnInput:/^\s*(?:case |default:|\{|\}|<\/)$/,wordChars:"$"}}),dm={test:e=>/^JSX/.test(e.name),facet:zi({commentTokens:{block:{open:"{/*",close:"*/}"}}})},_l=Ot.configure({dialect:"ts"},"typescript"),Ul=Ot.configure({dialect:"jsx",props:[bs.add(e=>e.isTop?[dm]:void 0)]}),zl=Ot.configure({dialect:"jsx ts",props:[bs.add(e=>e.isTop?[dm]:void 0)]},"typescript"),fm=e=>({label:e,type:"keyword"}),pm="break case const continue default delete export extends false finally in instanceof let new return static super switch this throw true typeof var yield".split(" ").map(fm),JP=pm.concat(["declare","implements","private","protected","public"].map(fm));function Om(e={}){let t=e.jsx?e.typescript?zl:Ul:e.typescript?_l:Ot,i=e.typescript?GP.concat(JP):lm.concat(pm);return new It(t,[Ot.data.of({autocomplete:eO(um,wl(i))}),Ot.data.of({autocomplete:KP}),e.jsx?ik:[]])}function ek(e){for(;;){if(e.name=="JSXOpenTag"||e.name=="JSXSelfClosingTag"||e.name=="JSXFragmentTag")return e;if(e.name=="JSXEscape"||!e.parent)return null;e=e.parent}}function am(e,t,i=e.length){for(let r=t?.firstChild;r;r=r.nextSibling)if(r.name=="JSXIdentifier"||r.name=="JSXBuiltin"||r.name=="JSXNamespacedName"||r.name=="JSXMemberExpression")return e.sliceString(r.from,Math.min(r.to,i));return""}var tk=typeof navigator=="object"&&/Android\b/.test(navigator.userAgent),ik=W.inputHandler.of((e,t,i,r,n)=>{if((tk?e.composing:e.compositionStarted)||e.state.readOnly||t!=i||r!=">"&&r!="/"||!Ot.isActiveAt(e.state,t,-1))return!1;let s=n(),{state:o}=s,a=o.changeByRange(l=>{var h;let{head:c}=l,u=te(o).resolveInner(c-1,-1),d;if(u.name=="JSXStartTag"&&(u=u.parent),!(o.doc.sliceString(c-1,c)!=r||u.name=="JSXAttributeValue"&&u.to>c)){if(r==">"&&u.name=="JSXFragmentTag")return{range:l,changes:{from:c,insert:"</>"}};if(r=="/"&&u.name=="JSXStartCloseTag"){let f=u.parent,p=f.parent;if(p&&f.from==c-2&&((d=am(o.doc,p.firstChild,c))||((h=p.firstChild)===null||h===void 0?void 0:h.name)=="JSXFragmentTag")){let O=`${d}>`;return{range:$.cursor(c+O.length,-1),changes:{from:c,insert:O}}}}else if(r==">"){let f=ek(u);if(f&&f.name=="JSXOpenTag"&&!/^\/?>|^<\//.test(o.doc.sliceString(c,c+2))&&(d=am(o.doc,f,c)))return{range:l,changes:{from:c,insert:`</${d}>`}}}}return{range:l}});return a.changes.empty?!1:(e.dispatch([s,o.update(a,{userEvent:"input.complete",scrollIntoView:!0})]),!0)});var zr=["_blank","_self","_top","_parent"],Bl=["ascii","utf-8","utf-16","latin1","latin1"],Gl=["get","post","put","delete"],Fl=["application/x-www-form-urlencoded","multipart/form-data","text/plain"],Fe=["true","false"],R={},rk={a:{attrs:{href:null,ping:null,type:null,media:null,target:zr,hreflang:null}},abbr:R,address:R,area:{attrs:{alt:null,coords:null,href:null,target:null,ping:null,media:null,hreflang:null,type:null,shape:["default","rect","circle","poly"]}},article:R,aside:R,audio:{attrs:{src:null,mediagroup:null,crossorigin:["anonymous","use-credentials"],preload:["none","metadata","auto"],autoplay:["autoplay"],loop:["loop"],controls:["controls"]}},b:R,base:{attrs:{href:null,target:zr}},bdi:R,bdo:R,blockquote:{attrs:{cite:null}},body:R,br:R,button:{attrs:{form:null,formaction:null,name:null,value:null,autofocus:["autofocus"],disabled:["autofocus"],formenctype:Fl,formmethod:Gl,formnovalidate:["novalidate"],formtarget:zr,type:["submit","reset","button"]}},canvas:{attrs:{width:null,height:null}},caption:R,center:R,cite:R,code:R,col:{attrs:{span:null}},colgroup:{attrs:{span:null}},command:{attrs:{type:["command","checkbox","radio"],label:null,icon:null,radiogroup:null,command:null,title:null,disabled:["disabled"],checked:["checked"]}},data:{attrs:{value:null}},datagrid:{attrs:{disabled:["disabled"],multiple:["multiple"]}},datalist:{attrs:{data:null}},dd:R,del:{attrs:{cite:null,datetime:null}},details:{attrs:{open:["open"]}},dfn:R,div:R,dl:R,dt:R,em:R,embed:{attrs:{src:null,type:null,width:null,height:null}},eventsource:{attrs:{src:null}},fieldset:{attrs:{disabled:["disabled"],form:null,name:null}},figcaption:R,figure:R,footer:R,form:{attrs:{action:null,name:null,"accept-charset":Bl,autocomplete:["on","off"],enctype:Fl,method:Gl,novalidate:["novalidate"],target:zr}},h1:R,h2:R,h3:R,h4:R,h5:R,h6:R,head:{children:["title","base","link","style","meta","script","noscript","command"]},header:R,hgroup:R,hr:R,html:{attrs:{manifest:null}},i:R,iframe:{attrs:{src:null,srcdoc:null,name:null,width:null,height:null,sandbox:["allow-top-navigation","allow-same-origin","allow-forms","allow-scripts"],seamless:["seamless"]}},img:{attrs:{alt:null,src:null,ismap:null,usemap:null,width:null,height:null,crossorigin:["anonymous","use-credentials"]}},input:{attrs:{alt:null,dirname:null,form:null,formaction:null,height:null,list:null,max:null,maxlength:null,min:null,name:null,pattern:null,placeholder:null,size:null,src:null,step:null,value:null,width:null,accept:["audio/*","video/*","image/*"],autocomplete:["on","off"],autofocus:["autofocus"],checked:["checked"],disabled:["disabled"],formenctype:Fl,formmethod:Gl,formnovalidate:["novalidate"],formtarget:zr,multiple:["multiple"],readonly:["readonly"],required:["required"],type:["hidden","text","search","tel","url","email","password","datetime","date","month","week","time","datetime-local","number","range","color","checkbox","radio","file","submit","image","reset","button"]}},ins:{attrs:{cite:null,datetime:null}},kbd:R,keygen:{attrs:{challenge:null,form:null,name:null,autofocus:["autofocus"],disabled:["disabled"],keytype:["RSA"]}},label:{attrs:{for:null,form:null}},legend:R,li:{attrs:{value:null}},link:{attrs:{href:null,type:null,hreflang:null,media:null,sizes:["all","16x16","16x16 32x32","16x16 32x32 64x64"]}},map:{attrs:{name:null}},mark:R,menu:{attrs:{label:null,type:["list","context","toolbar"]}},meta:{attrs:{content:null,charset:Bl,name:["viewport","application-name","author","description","generator","keywords"],"http-equiv":["content-language","content-type","default-style","refresh"]}},meter:{attrs:{value:null,min:null,low:null,high:null,max:null,optimum:null}},nav:R,noscript:R,object:{attrs:{data:null,type:null,name:null,usemap:null,form:null,width:null,height:null,typemustmatch:["typemustmatch"]}},ol:{attrs:{reversed:["reversed"],start:null,type:["1","a","A","i","I"]},children:["li","script","template","ul","ol"]},optgroup:{attrs:{disabled:["disabled"],label:null}},option:{attrs:{disabled:["disabled"],label:null,selected:["selected"],value:null}},output:{attrs:{for:null,form:null,name:null}},p:R,param:{attrs:{name:null,value:null}},pre:R,progress:{attrs:{value:null,max:null}},q:{attrs:{cite:null}},rp:R,rt:R,ruby:R,samp:R,script:{attrs:{type:["text/javascript"],src:null,async:["async"],defer:["defer"],charset:Bl}},section:R,select:{attrs:{form:null,name:null,size:null,autofocus:["autofocus"],disabled:["disabled"],multiple:["multiple"]}},slot:{attrs:{name:null}},small:R,source:{attrs:{src:null,type:null,media:null}},span:R,strong:R,style:{attrs:{type:["text/css"],media:null,scoped:null}},sub:R,summary:R,sup:R,table:R,tbody:R,td:{attrs:{colspan:null,rowspan:null,headers:null}},template:R,textarea:{attrs:{dirname:null,form:null,maxlength:null,name:null,placeholder:null,rows:null,cols:null,autofocus:["autofocus"],disabled:["disabled"],readonly:["readonly"],required:["required"],wrap:["soft","hard"]}},tfoot:R,th:{attrs:{colspan:null,rowspan:null,headers:null,scope:["row","col","rowgroup","colgroup"]}},thead:R,time:{attrs:{datetime:null}},title:R,tr:R,track:{attrs:{src:null,label:null,default:null,kind:["subtitles","captions","descriptions","chapters","metadata"],srclang:null}},ul:{children:["li","script","template","ul","ol"]},var:R,video:{attrs:{src:null,poster:null,width:null,height:null,crossorigin:["anonymous","use-credentials"],preload:["auto","metadata","none"],autoplay:["autoplay"],mediagroup:["movie"],muted:["muted"],controls:["controls"]}},wbr:R},bm={accesskey:null,class:null,contenteditable:Fe,contextmenu:null,dir:["ltr","rtl","auto"],draggable:["true","false","auto"],dropzone:["copy","move","link","string:","file:"],hidden:["hidden"],id:null,inert:["inert"],itemid:null,itemprop:null,itemref:null,itemscope:["itemscope"],itemtype:null,lang:["ar","bn","de","en-GB","en-US","es","fr","hi","id","ja","pa","pt","ru","tr","zh"],spellcheck:Fe,autocorrect:Fe,autocapitalize:Fe,style:null,tabindex:null,title:null,translate:["yes","no"],rel:["stylesheet","alternate","author","bookmark","help","license","next","nofollow","noreferrer","prefetch","prev","search","tag"],role:"alert application article banner button cell checkbox complementary contentinfo dialog document feed figure form grid gridcell heading img list listbox listitem main navigation region row rowgroup search switch tab table tabpanel textbox timer".split(" "),"aria-activedescendant":null,"aria-atomic":Fe,"aria-autocomplete":["inline","list","both","none"],"aria-busy":Fe,"aria-checked":["true","false","mixed","undefined"],"aria-controls":null,"aria-describedby":null,"aria-disabled":Fe,"aria-dropeffect":null,"aria-expanded":["true","false","undefined"],"aria-flowto":null,"aria-grabbed":["true","false","undefined"],"aria-haspopup":Fe,"aria-hidden":Fe,"aria-invalid":["true","false","grammar","spelling"],"aria-label":null,"aria-labelledby":null,"aria-level":null,"aria-live":["off","polite","assertive"],"aria-multiline":Fe,"aria-multiselectable":Fe,"aria-owns":null,"aria-posinset":null,"aria-pressed":["true","false","mixed","undefined"],"aria-readonly":Fe,"aria-relevant":null,"aria-required":Fe,"aria-selected":["true","false","undefined"],"aria-setsize":null,"aria-sort":["ascending","descending","none","other"],"aria-valuemax":null,"aria-valuemin":null,"aria-valuenow":null,"aria-valuetext":null},wm="beforeunload copy cut dragstart dragover dragleave dragenter dragend drag paste focus blur change click load mousedown mouseenter mouseleave mouseup keydown keyup resize scroll unload".split(" ").map(e=>"on"+e);for(let e of wm)bm[e]=null;var Br=class{constructor(e,t){this.tags=Object.assign(Object.assign({},rk),e),this.globalAttrs=Object.assign(Object.assign({},bm),t),this.allTags=Object.keys(this.tags),this.globalAttrNames=Object.keys(this.globalAttrs)}};Br.default=new Br;function Ji(e,t,i=e.length){if(!t)return"";let r=t.firstChild,n=r&&r.getChild("TagName");return n?e.sliceString(n.from,Math.min(n.to,i)):""}function er(e,t=!1){for(;e;e=e.parent)if(e.name=="Element")if(t)t=!1;else return e;return null}function vm(e,t,i){return i.tags[Ji(e,er(t))]?.children||i.allTags}function Hl(e,t){let i=[];for(let r=er(t);r&&!r.type.isTop;r=er(r.parent)){let n=Ji(e,r);if(n&&r.lastChild.name=="CloseTag")break;n&&i.indexOf(n)<0&&(t.name=="EndTag"||t.from>=r.firstChild.to)&&i.push(n)}return i}var Sm=/^[:\-\.\w\u00b7-\uffff]*$/;function mm(e,t,i,r,n){let s=/\s*>/.test(e.sliceDoc(n,n+5))?"":">",o=er(i,!0);return{from:r,to:n,options:vm(e.doc,o,t).map(a=>({label:a,type:"type"})).concat(Hl(e.doc,i).map((a,l)=>({label:"/"+a,apply:"/"+a+s,type:"type",boost:99-l}))),validFor:/^\/?[:\-\.\w\u00b7-\uffff]*$/}}function gm(e,t,i,r){let n=/\s*>/.test(e.sliceDoc(r,r+5))?"":">";return{from:i,to:r,options:Hl(e.doc,t).map((s,o)=>({label:s,apply:s+n,type:"type",boost:99-o})),validFor:Sm}}function nk(e,t,i,r){let n=[],s=0;for(let o of vm(e.doc,i,t))n.push({label:"<"+o,type:"type"});for(let o of Hl(e.doc,i))n.push({label:"</"+o+">",type:"type",boost:99-s++});return{from:r,to:r,options:n,validFor:/^<\/?[:\-\.\w\u00b7-\uffff]*$/}}function sk(e,t,i,r,n){let s=er(i),o=s?t.tags[Ji(e.doc,s)]:null,a=o&&o.attrs?Object.keys(o.attrs):[],l=o&&o.globalAttrs===!1?a:a.length?a.concat(t.globalAttrNames):t.globalAttrNames;return{from:r,to:n,options:l.map(h=>({label:h,type:"property"})),validFor:Sm}}function ok(e,t,i,r,n){var s;let o=(s=i.parent)===null||s===void 0?void 0:s.getChild("AttributeName"),a=[],l;if(o){let h=e.sliceDoc(o.from,o.to),c=t.globalAttrs[h];if(!c){let u=er(i),d=u?t.tags[Ji(e.doc,u)]:null;c=d?.attrs&&d.attrs[h]}if(c){let u=e.sliceDoc(r,n).toLowerCase(),d='"',f='"';/^['"]/.test(u)?(l=u[0]=='"'?/^[^"]*$/:/^[^']*$/,d="",f=e.sliceDoc(n,n+1)==u[0]?"":u[0],u=u.slice(1),r++):l=/^[^\s<>='"]*$/;for(let p of c)a.push({label:p,apply:d+p+f,type:"constant"})}}return{from:r,to:n,options:a,validFor:l}}function xm(e,t){let{state:i,pos:r}=t,n=te(i).resolveInner(r,-1),s=n.resolve(r);for(let o=r,a;s==n&&(a=n.childBefore(o));){let l=a.lastChild;if(!l||!l.type.isError||l.from<l.to)break;s=n=a,o=l.from}return n.name=="TagName"?n.parent&&/CloseTag$/.test(n.parent.name)?gm(i,n,n.from,r):mm(i,e,n,n.from,r):n.name=="StartTag"?mm(i,e,n,r,r):n.name=="StartCloseTag"||n.name=="IncompleteCloseTag"?gm(i,n,r,r):n.name=="OpenTag"||n.name=="SelfClosingTag"||n.name=="AttributeName"?sk(i,e,n,n.name=="AttributeName"?n.from:r,r):n.name=="Is"||n.name=="AttributeValue"||n.name=="UnquotedAttributeValue"?ok(i,e,n,n.name=="Is"?r:n.from,r):t.explicit&&(s.name=="Element"||s.name=="Text"||s.name=="Document")?nk(i,e,n,r):null}function Pm(e){return xm(Br.default,e)}function ak(e){let{extraTags:t,extraGlobalAttributes:i}=e,r=i||t?new Br(t,i):Br.default;return n=>xm(r,n)}var lk=Ot.parser.configure({top:"SingleExpression"}),km=[{tag:"script",attrs:e=>e.type=="text/typescript"||e.lang=="ts",parser:_l.parser},{tag:"script",attrs:e=>e.type=="text/babel"||e.type=="text/jsx",parser:Ul.parser},{tag:"script",attrs:e=>e.type=="text/typescript-jsx",parser:zl.parser},{tag:"script",attrs(e){return/^(importmap|speculationrules|application\/(.+\+)?json)$/i.test(e.type)},parser:lk},{tag:"script",attrs(e){return!e.type||/^(?:text|application)\/(?:x-)?(?:java|ecma)script$|^module$|^$/i.test(e.type)},parser:Ot.parser},{tag:"style",attrs(e){return(!e.lang||e.lang=="css")&&(!e.type||/^(text\/)?(x-)?(stylesheet|css)$/i.test(e.type))},parser:_r.parser}],Qm=[{name:"style",parser:_r.parser.configure({top:"Styles"})}].concat(wm.map(e=>({name:e,parser:Ot.parser}))),$m=Bi.define({name:"html",parser:jO.configure({props:[ei.add({Element(e){let t=/^(\s*)(<\/)?/.exec(e.textAfter);return e.node.to<=e.pos+t[0].length?e.continue():e.lineIndent(e.node.from)+(t[2]?0:e.unit)},"OpenTag CloseTag SelfClosingTag"(e){return e.column(e.node.from)+e.unit},Document(e){if(e.pos+/\s*/.exec(e.textAfter)[0].length<e.node.to)return e.continue();let t=null,i;for(let r=e.node;;){let n=r.lastChild;if(!n||n.name!="Element"||n.to!=r.to)break;t=r=n}return t&&!((i=t.lastChild)&&(i.name=="CloseTag"||i.name=="SelfClosingTag"))?e.lineIndent(t.from)+e.unit:null}}),pt.add({Element(e){let t=e.firstChild,i=e.lastChild;return!t||t.name!="OpenTag"?null:{from:t.to,to:i.name=="CloseTag"?i.from:e.to}}}),fl.add({"OpenTag CloseTag":e=>e.getChild("TagName")})]}),languageData:{commentTokens:{block:{open:"<!--",close:"-->"}},indentOnInput:/^\s*<\/\w+\W$/,wordChars:"-._"}}),Ms=$m.configure({wrap:Il(km,Qm)});function Tm(e={}){let t="",i;e.matchClosingTags===!1&&(t="noMatch"),e.selfClosingTags===!0&&(t=(t?t+" ":"")+"selfClosing"),(e.nestedLanguages&&e.nestedLanguages.length||e.nestedAttributes&&e.nestedAttributes.length)&&(i=Il((e.nestedLanguages||[]).concat(km),(e.nestedAttributes||[]).concat(Qm)));let r=i?$m.configure({wrap:i,dialect:t}):t?Ms.configure({dialect:t}):Ms;return new It(r,[Ms.data.of({autocomplete:ak(e)}),e.autoCloseTags!==!1?hk:[],Om().support,tm().support])}var ym=new Set("area base br col command embed frame hr img input keygen link meta param source track wbr menuitem".split(" ")),hk=W.inputHandler.of((e,t,i,r,n)=>{if(e.composing||e.state.readOnly||t!=i||r!=">"&&r!="/"||!Ms.isActiveAt(e.state,t,-1))return!1;let s=n(),{state:o}=s,a=o.changeByRange(l=>{var h,c,u;let d=o.doc.sliceString(l.from-1,l.to)==r,{head:f}=l,p=te(o).resolveInner(f,-1),O;if(d&&r==">"&&p.name=="EndTag"){let g=p.parent;if(((c=(h=g.parent)===null||h===void 0?void 0:h.lastChild)===null||c===void 0?void 0:c.name)!="CloseTag"&&(O=Ji(o.doc,g.parent,f))&&!ym.has(O)){let y=f+(o.doc.sliceString(f,f+1)===">"?1:0),b=`</${O}>`;return{range:l,changes:{from:f,to:y,insert:b}}}}else if(d&&r=="/"&&p.name=="IncompleteCloseTag"){let g=p.parent;if(p.from==f-2&&((u=g.lastChild)===null||u===void 0?void 0:u.name)!="CloseTag"&&(O=Ji(o.doc,g,f))&&!ym.has(O)){let y=f+(o.doc.sliceString(f,f+1)===">"?1:0),b=`${O}>`;return{range:$.cursor(f+b.length,-1),changes:{from:f,to:y,insert:b}}}}return{range:l}});return a.changes.empty?!1:(e.dispatch([s,o.update(a,{userEvent:"input.complete",scrollIntoView:!0})]),!0)});var Zm=zi({commentTokens:{block:{open:"<!--",close:"-->"}}}),Em=new M,Rm=hu.configure({props:[pt.add(e=>!e.is("Block")||e.is("Document")||eh(e)!=null||ck(e)?void 0:(t,i)=>({from:i.doc.lineAt(t.from).to,to:t.to})),Em.add(eh),ei.add({Document:()=>null}),Yt.add({Document:Zm})]});function eh(e){let t=/^(?:ATX|Setext)Heading(\d)$/.exec(e.name);return t?+t[1]:void 0}function ck(e){return e.name=="OrderedList"||e.name=="BulletList"}function uk(e,t){let i=e;for(;;){let r=i.nextSibling,n;if(!r||(n=eh(r.type))!=null&&n<=t)break;i=r}return i.to}var dk=$p.of((e,t,i)=>{for(let r=te(e).resolveInner(i,-1);r&&!(r.from<t);r=r.parent){let n=r.type.prop(Em);if(n==null)continue;let s=uk(r,n);if(s>i)return{from:i,to:s}}return null});function ih(e){return new qe(Zm,e,[dk],"markdown")}var fk=ih(Rm),pk=Rm.configure([du,Xn,Rn,pu,{props:[pt.add({Table:(e,t)=>({from:t.doc.lineAt(e.from).to,to:e.to})})]}]),Xm=ih(pk);function Ok(e,t){return i=>{if(i&&e){let r=null;if(i=/\S*/.exec(i)[0],typeof e=="function"?r=e(i):r=dl.matchLanguageName(e,i,!0),r instanceof dl)return r.support?r.support.language.parser:Wr.getSkippingParser(r.load());if(r)return r.parser}return t?t.parser:null}}var Ws=class{constructor(e,t,i,r,n,s,o){this.node=e,this.from=t,this.to=i,this.spaceBefore=r,this.spaceAfter=n,this.type=s,this.item=o}blank(e,t=!0){let i=this.spaceBefore+(this.node.name=="Blockquote"?">":"");if(e!=null){for(;i.length<e;)i+=" ";return i}else{for(let r=this.to-this.from-i.length-this.spaceAfter.length;r>0;r--)i+=" ";return i+(t?this.spaceAfter:"")}}marker(e,t){let i=this.node.name=="OrderedList"?String(+Wm(this.item,e)[2]+t):"";return this.spaceBefore+i+this.type+this.spaceAfter}};function Mm(e,t){let i=[];for(let n=e;n&&n.name!="Document";n=n.parent)(n.name=="ListItem"||n.name=="Blockquote"||n.name=="FencedCode")&&i.push(n);let r=[];for(let n=i.length-1;n>=0;n--){let s=i[n],o,a=t.lineAt(s.from),l=s.from-a.from;if(s.name=="FencedCode")r.push(new Ws(s,l,l,"","","",null));else if(s.name=="Blockquote"&&(o=/^ *>( ?)/.exec(a.text.slice(l))))r.push(new Ws(s,l,l+o[0].length,"",o[1],">",null));else if(s.name=="ListItem"&&s.parent.name=="OrderedList"&&(o=/^( *)\d+([.)])( *)/.exec(a.text.slice(l)))){let h=o[3],c=o[0].length;h.length>=4&&(h=h.slice(0,h.length-4),c-=4),r.push(new Ws(s.parent,l,l+c,o[1],h,o[2],s))}else if(s.name=="ListItem"&&s.parent.name=="BulletList"&&(o=/^( *)([-+*])( {1,4}\[[ xX]\])?( +)/.exec(a.text.slice(l)))){let h=o[4],c=o[0].length;h.length>4&&(h=h.slice(0,h.length-4),c-=4);let u=o[2];o[3]&&(u+=o[3].replace(/[xX]/," ")),r.push(new Ws(s.parent,l,l+c,o[1],h,u,s))}}return r}function Wm(e,t){return/^(\s*)(\d+)(?=[.)])/.exec(t.sliceString(e.from,e.from+10))}function Kl(e,t,i,r=0){for(let n=-1,s=e;;){if(s.name=="ListItem"){let a=Wm(s,t),l=+a[2];if(n>=0){if(l!=n+1)return;i.push({from:s.from+a[1].length,to:s.from+a[0].length,insert:String(n+2+r)})}n=l}let o=s.nextSibling;if(!o)break;s=o}}function rh(e,t){let i=/^[ \t]*/.exec(e)[0].length;if(!i||t.facet(Yr)!="	")return e;let r=zt(e,4,i),n="";for(let s=r;s>0;)s>=4?(n+="	",s-=4):(n+=" ",s--);return n+e.slice(i)}var mk=({state:e,dispatch:t})=>{let i=te(e),{doc:r}=e,n=null,s=e.changeByRange(o=>{if(!o.empty||!Xm.isActiveAt(e,o.from))return n={range:o};let a=o.from,l=r.lineAt(a),h=Mm(i.resolveInner(a,-1),r);for(;h.length&&h[h.length-1].from>a-l.from;)h.pop();if(!h.length)return n={range:o};let c=h[h.length-1];if(c.to-c.spaceAfter.length>a-l.from)return n={range:o};let u=a>=c.to-c.spaceAfter.length&&!/\S/.test(l.text.slice(c.to));if(c.item&&u){let g=c.node.firstChild,y=c.node.getChild("ListItem","ListItem");if(g.to>=a||y&&y.to<a||l.from>0&&!/[^\s>]/.test(r.lineAt(l.from-1).text)){let b=h.length>1?h[h.length-2]:null,S,w="";b&&b.item?(S=l.from+b.from,w=b.marker(r,1)):S=l.from+(b?b.to:0);let k=[{from:S,to:a,insert:w}];return c.node.name=="OrderedList"&&Kl(c.item,r,k,-2),b&&b.node.name=="OrderedList"&&Kl(b.item,r,k),{range:$.cursor(S+w.length),changes:k}}else{let b=Am(h,e,l);return{range:$.cursor(a+b.length+1),changes:{from:l.from,insert:b+e.lineBreak}}}}if(c.node.name=="Blockquote"&&u&&l.from){let g=r.lineAt(l.from-1),y=/>\s*$/.exec(g.text);if(y&&y.index==c.from){let b=e.changes([{from:g.from+y.index,to:g.to},{from:l.from+c.from,to:l.to}]);return{range:o.map(b),changes:b}}}let d=[];c.node.name=="OrderedList"&&Kl(c.item,r,d);let f=c.item&&c.item.from<l.from,p="";if(!f||/^[\s\d.)\-+*>]*/.exec(l.text)[0].length>=c.to)for(let g=0,y=h.length-1;g<=y;g++)p+=g==y&&!f?h[g].marker(r,1):h[g].blank(g<y?zt(l.text,4,h[g+1].from)-p.length:null);let O=a;for(;O>l.from&&/\s/.test(l.text.charAt(O-l.from-1));)O--;return p=rh(p,e),gk(c.node,e.doc)&&(p=Am(h,e,l)+e.lineBreak+p),d.push({from:O,to:a,insert:e.lineBreak+p}),{range:$.cursor(O+p.length+1),changes:d}});return n?!1:(t(e.update(s,{scrollIntoView:!0,userEvent:"input"})),!0)};function Cm(e){return e.name=="QuoteMark"||e.name=="ListMark"}function gk(e,t){if(e.name!="OrderedList"&&e.name!="BulletList")return!1;let i=e.firstChild,r=e.getChild("ListItem","ListItem");if(!r)return!1;let n=t.lineAt(i.to),s=t.lineAt(r.from),o=/^[\s>]*$/.test(n.text);return n.number+(o?0:1)<s.number}function Am(e,t,i){let r="";for(let n=0,s=e.length-2;n<=s;n++)r+=e[n].blank(n<s?zt(i.text,4,e[n+1].from)-r.length:null,n<s);return rh(r,t)}function yk(e,t){let i=e.resolveInner(t,-1),r=t;Cm(i)&&(r=i.from,i=i.parent);for(let n;n=i.childBefore(r);)if(Cm(n))r=n.from;else if(n.name=="OrderedList"||n.name=="BulletList")i=n.lastChild,r=i.to;else break;return i}var bk=({state:e,dispatch:t})=>{let i=te(e),r=null,n=e.changeByRange(s=>{let o=s.from,{doc:a}=e;if(s.empty&&Xm.isActiveAt(e,s.from)){let l=a.lineAt(o),h=Mm(yk(i,o),a);if(h.length){let c=h[h.length-1],u=c.to-c.spaceAfter.length+(c.spaceAfter?1:0);if(o-l.from>u&&!/\S/.test(l.text.slice(u,o-l.from)))return{range:$.cursor(l.from+u),changes:{from:l.from+u,to:o}};if(o-l.from==u&&(!c.item||l.from<=c.item.from||!/\S/.test(l.text.slice(0,c.to)))){let d=l.from+c.from;if(c.item&&c.node.from<c.item.from&&/\S/.test(l.text.slice(c.from,c.to))){let f=c.blank(zt(l.text,4,c.to)-zt(l.text,4,c.from));return d==l.from&&(f=rh(f,e)),{range:$.cursor(d+f.length),changes:{from:d,to:l.from+c.to,insert:f}}}if(d<o)return{range:$.cursor(d),changes:{from:d,to:o}}}}}return r={range:s}});return r?!1:(t(e.update(n,{scrollIntoView:!0,userEvent:"delete"})),!0)},wk=[{key:"Enter",run:mk},{key:"Backspace",run:bk}],th=Tm({matchClosingTags:!1});function qm(e={}){let{codeLanguages:t,defaultCodeLanguage:i,addKeymap:r=!0,base:{parser:n}=fk,completeHTMLTags:s=!0}=e;if(!(n instanceof Mo))throw new RangeError("Base parser provided to `markdown` should be a Markdown parser");let o=e.extensions?[e.extensions]:[],a=[th.support],l;i instanceof It?(a.push(i.support),l=i.language):i&&(l=i);let h=t||l?Ok(t,l):void 0;o.push(cu({codeParser:h,htmlParser:th.language.parser})),r&&a.push(_e.high(_i.of(wk)));let c=ih(n.configure(o));return s&&a.push(c.data.of({autocomplete:vk})),new It(c,a)}function vk(e){let{state:t,pos:i}=e,r=/<[:\-\.\w\u00b7-\uffff]*$/.exec(t.sliceDoc(i-25,i));if(!r)return null;let n=te(t).resolveInner(i,-1);for(;n&&!n.type.isTop;){if(n.name=="CodeBlock"||n.name=="FencedCode"||n.name=="ProcessingInstructionBlock"||n.name=="CommentBlock"||n.name=="Link"||n.name=="Image")return null;n=n.parent}return{from:i-r[0].length,to:i,options:Sk(),validFor:/^<[:\-\.\w\u00b7-\uffff]*$/}}var Jl=null;function Sk(){if(Jl)return Jl;let e=Pm(new ks(he.create({extensions:th}),0,!0));return Jl=e?e.options:[]}var Ym=V.define(),nh=V.define(),Im=V.define(),sh=V.define(),qs=V.define(),Lm=V.define(),Vm=V.define(),kR=V.define(),QR=V.define(),$R=V.define(),Nm=V.define(),jm=V.define(),Dm=V.define(),_m=V.define(),Um=V.define(),oh=V.define(),zm=V.define(),Bm=V.define(),Gm=V.define(),ah=V.define(),lh=V.define(),Ys=V.define(),Fm=V.define(),ni=V.define(),Hm=V.define(),Km=V.define();var hh=class{constructor(t){this.status=t}nextLine(){return!1}finish(t,i){return t.addLeafElement(i,t.elt("Task",i.start,i.start+i.content.length,[t.elt("TaskState",i.start,i.start+2+this.status.length,[t.elt("TaskMark",i.start,i.start+1),t.elt("TaskMark",i.start+1+this.status.length,i.start+2+this.status.length)]),...t.parser.parseInline(i.content.slice(this.status.length+2),i.start+this.status.length+2)])),!0}},Jm={defineNodes:[{name:"Task",block:!0,style:m.list},{name:"TaskMark",style:m.atom},{name:"TaskState",style:Gm}],parseBlock:[{name:"TaskList",leaf(e,t){let i=/^\[([^\]]+)\][ \t]/.exec(t.content);return i&&e.parentType().name=="ListItem"?new hh(i[1]):null},after:"SetextHeading"}]};var Pk={__proto__:null,where:14,null:30,and:44,or:46,limit:70,select:84,as:88,render:92,each:94,all:96},eg=Qt.deserialize({version:14,states:",rOYQPOOOpQQO'#C_QOQPOOOzQQO'#DQOOQO'#D_'#D_O!{QQO,58yOzQQO'#CaOzQQO'#DOO#VQQO'#DVO$WQQO'#DZOOQO'#Ch'#ChO$cQQO'#ClOOQO'#Ce'#CeO%wQSO'#DSOOQO'#Co'#CoOzQQO'#CpO&hQPO'#C|OzQQO'#CuO(WQSO'#CdOOQO'#Cd'#CdO)QQQO'#ESOOQO,59l,59lOOQO-E7]-E7]O)lQSO,58{O*VQSO,59jO*pQSO'#DXO*wQSO'#CdO+eQQO'#ETOOQO,59q,59qOOQO,59u,59uO,PQPO,59uO,UQSO'#DhO,cQPO,59WOOQO,59W,59WO,hQQO,59YOzQQO,59cOzQQO,59cOzQQO,59cOzQQO,59cOzQQO,59eOOQO'#DT'#DTOOQO,59n,59nOzQQO,59]OzQQO,59]O,mQSO,59[O,tQPO,59`O,yQPO'#C}O-OQPO'#ERO-WQPO,59hOOQO,59h,59hO-]QSO,59aO/cQQO,59fOzQQO'#DbO/jQQO,5:nO0UQQO,59sO#VQQO'#DcO0ZQQO,5:oOOQO1G/a1G/aOzQQO'#D`O0uQPO,5:SOOQO1G.r1G.rOOQO1G.t1G.tO3QQSO1G.}O5XQSO1G.}O5fQSO1G.}O6wQSO1G.}O7zQSO1G/PO:UQSO1G.wO:]QSO1G.wOOQO1G.v1G.vOOQO1G.z1G.zOzQQO,59iO:dQPO'#DaO:iQPO,5:mOOQO1G/S1G/SO:qQPO1G/QOOQO1G/Q1G/QOOQO,59|,59|OOQO-E7`-E7`OOQO1G/_1G/_OOQO,59},59}OOQO-E7a-E7aO:vQSO,59zOOQO-E7^-E7^OzQQO7+$kO;TQSO1G/TOOQO,59{,59{OOQO-E7_-E7_OOQO7+$l7+$lO;_QSO<<HV",stateData:"=n~O!YOSPOS~OSPO~OVUOsVOuROzWO!OXO~O!WRX!cRX~P_OUbOY[OZ[O]YO^[O_[OacOjaOocO!ZZO!_^O!`_O!b`O!daO!eaO~O!WRa!cRa~P_OUjOY[OZ[O]YO^[O_[OacOjaOocO!ZZO!_^O!`_O!b`O!daO!eaO~OomO!PnO!QnO~O!^qO~PzOfzOg{OlsO!_rO!euO!fsO!gsO!hsO!isO!jsO!ksO!lsO!msO!ntO!otO!ptO!quO!rvO!swO~OxxOVvXsvXuvXzvX!OvX!WvX!]vX!cvX~P$jOSPOZ!OO!c!RO~O!`!TOfWXgWXlWX!_WX!eWX!fWX!gWX!hWX!iWX!jWX!kWX!lWX!mWX!nWX!oWX!pWX!qWX!rWX!sWX|WX~OVWXsWXuWXxWXzWX!OWX!WWX!]WX!^WX!aWX!tWX!cWX~P&sO!]!UOV!vXs!vXu!vXz!vX!O!vX!W!vX!c!vX~OVTasTauTazTa!OTa!WTa!cTa~P$jOVrasraurazra!Ora!Wra!cra~P$jO|!WO~P$jOV{Xs{Xu{Xz{X!O{X!W{X!]{X!c{X~P&sO!]!XOV!wXs!wXu!wXz!wX!O!wX!W!wX!c!wX~Oo!ZO~O!]![O!^![X!a![X~P$jO!^!^O~OU!_O~O!a!gO~P$jO!c!hO~O!t!iO~O!]!jO!c!uX~O!c!lO~O!_rOViafiagialiasiauiaxiazia!Oia!Wia!]ia!eia!fia!gia!hia!iia!jia!kia!lia!mia!nia!oia!pia!qia!ria!sia|ia!^ia!aia!tia!cia~O!a!nO~PzO!]!UOV!vas!vau!vaz!va!O!va!W!va!c!va~OU!qO~O!]!XOV!was!wau!waz!wa!O!wa!W!wa!c!wa~O!]![O!^![a!a![a~O!_rO!ntO!otO!ptOVkifkigkilkiskiukixkizki!Oki!Wki!]ki!fki!gki!hki!iki!jki!kki!lki!mki!rki!ski|ki!^ki!aki!tki!cki~O!euO!quO~P1QO!_rOVkifkigkilkiskiukixkizki!Oki!Wki!]ki!eki!fki!gki!hki!iki!jki!kki!lki!mki!qki!rki!ski|ki!^ki!aki!tki!cki~O!nki!oki!pki~P3[O!eki!qki~P1QOfzOlsO!_rO!euO!fsO!gsO!hsO!isO!jsO!ksO!lsO!msO!ntO!otO!ptO!quO!swO~OVkigkiskiukixkizki!Oki!Wki!]ki!rki|ki!^ki!aki!tki!cki~P5pO!t!vO~P$jOlsO!_rO!euO!fsO!gsO!hsO!isO!jsO!ksO!lsO!msO!ntO!otO!ptO!quO!swOVeigeiseiueixeizei!Oei!Wei!]ei!rei|ei!^ei!aei!tei!cei~Ofei~P8ROfzO~P8ROZ!OO~O!]!jO!c!ua~O!a!zO~O!]!Sa!^!Sa!a!Sa~P$jO!]qi!cqi~P$jOlsO!_rO!euO!fsO!gsO!hsO!isO!jsO!ksO!lsO!msO!ntO!otO!ptO!quOVmyfmygmysmyumyxmyzmy!Omy!Wmy!]my!rmy!smy|my!^my!amy!tmy!cmy~Ou]lxjUYx~",goto:"&o!xPPP!yP#PPP#T$]PP$sPPP$sP$]$]$]$]PP$]$]P$]P$]$]P$]%Z#PP#PP%a%gP#PP%jP#PPPP%p%v%|&S&YPPPP&`PPPPPPPPPPPPPPPPPPPPPPPP&f&i&lQQOR}`TSPTS]R!UQgUQhVSiW!XSoZ!TQ|_Q!SaQ!`sQ!atQ!buQ!cvQ!dwQ!ezQ!f{Q!t![Q!w!iR!{!vycRUVWZ_astuvwz{!T!U!X![!i!vy[RUVWZ_astuvwz{!T!U!X![!i!vQ!P`R!x!jQdRR!o!URy]QkWR!r!XQTPRfTQ!]oR!u!]Q!k!PR!y!kQ!VdR!p!VQ!YkR!s!YQpZR!m!TR!Q`ReRRlW",nodeNames:"\u26A0 LineComment Program Query TagIdentifier WhereClause Identifier where Expression Value Number String Bool BooleanKW Regex null List GlobalIdentifier Attribute TopLevelVal ParenthesizedExpression LogicalExpression and or QueryExpression UnaryExpression NotKW BinExpression InKW TernaryExpression Call PageRef Object KeyVal LimitClause limit OrderClause Order OrderBy OrderDirection OrderKW SelectClause select Select as RenderClause render each all",maxTerm:85,skippedNodes:[0,1],repeatNodeCount:5,tokenData:"=h~R!RX^$[pq$[qr%Prs%fst&Tuv&lwx&qxy'Zyz'`z{'e{|'j|}'o}!O't!O!P'y!P!Q(O!Q![*g![!]*o!^!_*t!_!`+R!`!a+`!a!b+m!b!c+z!c!},i!}#O-k#P#Q.h#S#T.m#T#U/[#U#W,i#W#X1X#X#Y,i#Y#Z1x#Z#],i#]#^5S#^#b,i#b#c6`#c#d8]#d#h,i#h#i;|#i#o,i#o#p=^#q#r=c#y#z$[$f$g$[#BY#BZ$[$IS$I_$[$I|$JO$[$JT$JU$[$KV$KW$[&FU&FV$[~$aY!Y~X^$[pq$[#y#z$[$f$g$[#BY#BZ$[$IS$I_$[$I|$JO$[$JT$JU$[$KV$KW$[&FU&FV$[U%UP!dQ!_!`%XS%^P!iS#r#s%aS%fO!mS~%iTOr%frs%xs;'S%f;'S;=`%}<%lO%f~%}OZ~~&QP;=`<%l%f~&YSP~OY&TZ;'S&T;'S;=`&f<%lO&T~&iP;=`<%l&T~&qO!p~~&tTOw&qwx%xx;'S&q;'S;=`'T<%lO&q~'WP;=`<%l&q~'`O!`~~'eO!a~~'jO!n~~'oO!q~~'tO!]~~'yO!e~~(OO!_~U(TW!oSOY(mZ](m^!P(m!Q#O(m#O#P)b#P;'S(m;'S;=`*a<%lO(mQ(pXOY(mZ](m^!P(m!P!Q)]!Q#O(m#O#P)b#P;'S(m;'S;=`*a<%lO(mQ)bO^QQ)eRO;'S(m;'S;=`)n;=`O(mQ)qYOY(mZ](m^!P(m!P!Q)]!Q#O(m#O#P)b#P;'S(m;'S;=`*a;=`<%l(m<%lO(mQ*dP;=`<%l(m~*lPY~!Q![*g~*tO!t~~*yP!f~!_!`*|~+RO!g~~+WP!h~#r#s+Z~+`O!l~~+eP!k~!_!`+h~+mO!j~~+rP!s~!a!b+u~+zO!r~~+}Q!c!},T#T#o,T~,YTa~}!O,T!Q![,T!c!},T#R#S,T#T#o,TV,pUSPUU}!O,i!P!Q-S!Q![,i!c!},i#R#S,i#T#o,iP-XUSP}!O-S!P!Q-S!Q![-S!c!}-S#R#S-S#T#o-S~-pP!Z~!}#O-s~-vTO#P-s#P#Q.V#Q;'S-s;'S;=`.b<%lO-s~.YP#P#Q.]~.bOo~~.eP;=`<%l-s~.mO!^~U.pTO#S.m#S#T/P#T;'S.m;'S;=`/U<%lO.mU/UOUUU/XP;=`<%l.mV/cWSPUU}!O,i!P!Q-S!Q![,i!c!},i#R#S,i#T#g,i#g#h/{#h#o,iV0SWSPUU}!O,i!P!Q-S!Q![,i!c!},i#R#S,i#T#V,i#V#W0l#W#o,iV0uUSPxSUU}!O,i!P!Q-S!Q![,i!c!},i#R#S,i#T#o,iV1`WSPUU}!O,i!P!Q-S!Q![,i!c!},i#R#S,i#T#X,i#X#Y/[#Y#o,iV2PVSPUU}!O,i!P!Q-S!Q![,i!c!},i#R#S,i#T#U2f#U#o,iV2mWSPUU}!O,i!P!Q-S!Q![,i!c!},i#R#S,i#T#`,i#`#a3V#a#o,iV3^WSPUU}!O,i!P!Q-S!Q![,i!c!},i#R#S,i#T#g,i#g#h3v#h#o,iV3}WSPUU}!O,i!P!Q-S!Q![,i!c!},i#R#S,i#T#X,i#X#Y4g#Y#o,iV4pUSP]QUU}!O,i!P!Q-S!Q![,i!c!},i#R#S,i#T#o,iV5ZWSPUU}!O,i!P!Q-S!Q![,i!c!},i#R#S,i#T#b,i#b#c5s#c#o,iV5|USPlSUU}!O,i!P!Q-S!Q![,i!c!},i#R#S,i#T#o,iV6gWSPUU}!O,i!P!Q-S!Q![,i!c!},i#R#S,i#T#c,i#c#d7P#d#o,iV7WWSPUU}!O,i!P!Q-S!Q![,i!c!},i#R#S,i#T#h,i#h#i7p#i#o,iV7yUSPjQUU}!O,i!P!Q-S!Q![,i!c!},i#R#S,i#T#o,iV8dWSPUU}!O,i!P!Q-S!Q![,i!c!},i#R#S,i#T#f,i#f#g8|#g#o,iV9TWSPUU}!O,i!P!Q-S!Q![,i!c!},i#R#S,i#T#W,i#W#X9m#X#o,iV9tWSPUU}!O,i!P!Q-S!Q![,i!c!},i#R#S,i#T#X,i#X#Y:^#Y#o,iV:eWSPUU}!O,i!P!Q-S!Q![,i!c!},i#R#S,i#T#f,i#f#g:}#g#o,iV;UVSPUUpq;k}!O,i!P!Q-S!Q![,i!c!},i#R#S,i#T#o,iU;nP#U#V;qU;tP#m#n;wU;|OuUV<TWSPUU}!O,i!P!Q-S!Q![,i!c!},i#R#S,i#T#f,i#f#g<m#g#o,iV<tWSPUU}!O,i!P!Q-S!Q![,i!c!},i#R#S,i#T#i,i#i#j3v#j#o,i~=cO!b~~=hO!c~",tokenizers:[0,1,2],topRules:{Program:[0,2]},specialized:[{term:6,get:e=>Pk[e]||-1}],tokenPrec:1309});var kk={__proto__:null,null:22,and:36,or:38,where:48,limit:52,select:66,as:70,render:74,each:76,all:78},tg=Qt.deserialize({version:14,states:",rOYQPOOOOQO'#Cc'#CcO!ZQPO'#ChOOQO'#C`'#C`Q!bQQOOOOQO'#Ck'#CkOYQPO'#ClO#oQSO'#D]OYQPO'#DVO%_QQO'#C_OOQO'#C_'#C_O&XQQO'#DhO&fQPO,59SOOQO,59S,59SO&kQPO,59UOYQPO,59sOYQPO,59sOYQPO,59sOYQPO,59sOYQPO,59uOYQPO,59XOYQPO,59XO&pQQO,59WO'YQPO'#CqO'aQPO,59[O'fQPO'#D^O'kQPO'#ETO'sQPO,59wOOQO,59w,59wO'xQQO,59qO*OQPO,59vOYQPO'#D_O*VQPO,5:SOOQO1G.n1G.nOOQO1G.p1G.pO,bQQO1G/_O.iQQO1G/_O.vQQO1G/_O0XQQO1G/_O1[QQO1G/aO3fQQO1G.sO3mQQO1G.sOOQO1G.r1G.rOYQPO'#CwOOQO'#D`'#D`O3tQPO,59]OYQPO'#CsOYQPO'#CuO3{QPO'#C|O4|QPO'#DQOOQO1G.v1G.vOYQPO,59xO5XQPO'#DcO5^QPO,5:oOOQO1G/c1G/cO5fQPO1G/bOOQO1G/b1G/bO5kQQO,59yOOQO-E7]-E7]OYQPO7+${O5xQQO'#CyO6fQPO'#DoOOQO,59c,59cOOQO-E7^-E7^O6}QQO,59_O7eQQO,59aO7{QQO'#DOO8SQQO'#DOO8mQPO'#DpOOQO,59h,59hOOQO,59l,59lO9UQPO,59lO9ZQQO1G/dOOQO,59},59}OOQO-E7a-E7aOOQO7+$|7+$|O9eQQO<<HgOOQO'#Cz'#CzOOQO,59e,59eOYQPO'#DaO;kQPO,5:ZO<SQPO,59jO3{QPO'#DbO<XQPO,5:[OOQO1G/W1G/WOOQO,59{,59{OOQO-E7_-E7_OOQO1G/U1G/UOOQO,59|,59|OOQO-E7`-E7`",stateData:"<y~O!YOSPOS~OTROUROWPOXROYXOZRO]YOxYOzWO!ZQO!_TO!`UO!bVO!fWO!gWO~O!^]O~PYObdOceO|_O!_^O!gaO!h_O!i_O!j_O!k_O!l_O!m_O!n_O!o_O!p`O!q`O!r`O!saO!tbO!ucO~OUiOfgO!elO~O!`nObRXcRX|RX!_RX!gRX!hRX!iRX!jRX!kRX!lRX!mRX!nRX!oRX!pRX!qRX!rRX!sRX!tRX!uRXsRX~O!WRX!]RX!^RX!aRX!vRXhRXjRXlRXoRXqRXuRX!eRX~P#zO!]oO!^![X!a![X~P!bO!^qO~OYrO~O!azO~P!bOh!OOj!POl{Oq!QOu!RO~O!eeX~P&wO!e!SO~O!v!TO~O!]!UO!e!wX~O!e!WO~O!_^Obyacya|ya!Wya!gya!hya!iya!jya!kya!lya!mya!nya!oya!pya!qya!rya!sya!tya!uya!]ya!^ya!aya!vyahyajyalyaoyaqyauya!eyasya~O!a!YO~PYO!]oO!^![a!a![a~O!_^O!p`O!q`O!r`Ob{ic{i|{i!W{i!h{i!i{i!j{i!k{i!l{i!m{i!n{i!o{i!t{i!u{i!]{i!^{i!a{i!v{ih{ij{il{io{iq{iu{i!e{is{i~O!gaO!saO~P*bO!_^Ob{ic{i|{i!W{i!g{i!h{i!i{i!j{i!k{i!l{i!m{i!n{i!o{i!s{i!t{i!u{i!]{i!^{i!a{i!v{ih{ij{il{io{iq{iu{i!e{is{i~O!p{i!q{i!r{i~P,lO!g{i!s{i~P*bObdO|_O!_^O!gaO!h_O!i_O!j_O!k_O!l_O!m_O!n_O!o_O!p`O!q`O!r`O!saO!ucO~Oc{i!W{i!t{i!]{i!^{i!a{i!v{ih{ij{il{io{iq{iu{i!e{is{i~P/QO!v!]O~P!bO|_O!_^O!gaO!h_O!i_O!j_O!k_O!l_O!m_O!n_O!o_O!p`O!q`O!r`O!saO!ucOcai!Wai!tai!]ai!^ai!aai!vaihaijailaioaiqaiuai!eaisai~Obai~P1cObdO~P1cO!eea~P&wOTROUROWPOXROY!eOZRO]YOxYOzWO!ZQO!_TO!`UO!bVO!fWO!gWO~Ov!iOw!iOx!hO~OUiO~O!]!UO!e!wa~O!a!mO~O!]!Ra!^!Ra!a!Ra~P!bOo!oOhmXjmXlmXqmXumX!]mX!emX~P!bO!]!qOh!cXj!cXl!cXq!cXu!cX!e!cX~Ohgajgalgaqgauga!ega~P!bOhiajialiaqiauia!eia~P!bOs!sO~P!bOhrXjrXlrXqrXurX!]rX!erX~P#zO!]!tOh!dXj!dXl!dXq!dXu!dX!e!dX~Ox!vO~O!]!Qi!e!Qi~P!bO|_O!_^O!gaO!h_O!i_O!j_O!k_O!l_O!m_O!n_O!o_O!p`O!q`O!r`O!saOb}yc}y!W}y!t}y!u}y!]}y!^}y!a}y!v}yh}yj}yl}yo}yq}yu}y!e}ys}y~O!]!qOh!caj!cal!caq!cau!ca!e!ca~OY!yO~O!]!tOh!daj!dal!daq!dau!da!e!da~OlW|ozYTo~",goto:"&q!xPPP!y$UPP$mPPPP$mP$U$U$U$UPP$U%UP%XP%XP%XP%]%cP%XP%fP%XPPPP$UP$UP$U$U$U%l%r%x&O&U&[PPPP&bPPPPPP&h&kPPPPPPPPPPPPPPPPPP&nQSOSZQnQfUQmWQs_Qt`QuaQvbQwcQxdQyeQ!ZoS!^{!qQ!b!OQ!c!PS!d!Q!tQ!j!TR!n!]{YOQUW_`abcdeno{!O!P!Q!T!]!q!t{ROQUW_`abcdeno{!O!P!Q!T!]!q!tRhVT|g}Q!_{R!w!qR!p!^Q!f!QR!z!tQjVR!k!UQpZR![pQ}gR!a}Q!r!_R!x!rQ!u!fR!{!uQ!VjR!l!VQ[QR!XnR!`{R!g!QRkV",nodeNames:"\u26A0 LineComment Program Expression Value Number String Bool BooleanKW Regex Identifier null List GlobalIdentifier Attribute TopLevelVal ParenthesizedExpression LogicalExpression and or QueryExpression Query TagIdentifier WhereClause where LimitClause limit OrderClause Order OrderBy OrderDirection OrderKW SelectClause select Select as RenderClause render each all PageRef UnaryExpression NotKW BinExpression InKW TernaryExpression Call Object KeyVal",maxTerm:85,skippedNodes:[0,1],repeatNodeCount:5,tokenData:"=h~R!RX^$[pq$[qr%Prs%fst&Tuv&lwx&qxy'Zyz'`z{'e{|'j|}'o}!O't!O!P'y!P!Q(O!Q![*g![!]*o!^!_*t!_!`+R!`!a+`!a!b+m!b!c+z!c!},i!}#O-k#P#Q.h#S#T.m#T#U/[#U#W,i#W#X1X#X#Y,i#Y#Z1x#Z#],i#]#^5S#^#b,i#b#c6`#c#d8]#d#h,i#h#i;|#i#o,i#o#p=^#q#r=c#y#z$[$f$g$[#BY#BZ$[$IS$I_$[$I|$JO$[$JT$JU$[$KV$KW$[&FU&FV$[~$aY!Y~X^$[pq$[#y#z$[$f$g$[#BY#BZ$[$IS$I_$[$I|$JO$[$JT$JU$[$KV$KW$[&FU&FV$[R%UP!fP!_!`%XQ%^P!kQ#r#s%aQ%fO!oQ~%iTOr%frs%xs;'S%f;'S;=`%}<%lO%f~%}OU~~&QP;=`<%l%f~&YSP~OY&TZ;'S&T;'S;=`&f<%lO&T~&iP;=`<%l&T~&qO!r~~&tTOw&qwx%xx;'S&q;'S;=`'T<%lO&q~'WP;=`<%l&q~'`O!`~~'eO!a~~'jO!p~~'oO!s~~'tO!]~~'yO!g~~(OO!_~R(TW!qQOY(mZ](m^!P(m!Q#O(m#O#P)b#P;'S(m;'S;=`*a<%lO(mP(pXOY(mZ](m^!P(m!P!Q)]!Q#O(m#O#P)b#P;'S(m;'S;=`*a<%lO(mP)bOXPP)eRO;'S(m;'S;=`)n;=`O(mP)qYOY(mZ](m^!P(m!P!Q)]!Q#O(m#O#P)b#P;'S(m;'S;=`*a;=`<%l(m<%lO(mP*dP;=`<%l(m~*lPT~!Q![*g~*tO!v~~*yP!h~!_!`*|~+RO!i~~+WP!j~#r#s+Z~+`O!n~~+eP!m~!_!`+h~+mO!l~~+rP!u~!a!b+u~+zO!t~~+}Q!c!},T#T#o,T~,YT]~}!O,T!Q![,T!c!},T#R#S,T#T#o,TV,pUfSYR}!O,i!P!Q-S!Q![,i!c!},i#R#S,i#T#o,iS-XUfS}!O-S!P!Q-S!Q![-S!c!}-S#R#S-S#T#o-S~-pP!Z~!}#O-s~-vTO#P-s#P#Q.V#Q;'S-s;'S;=`.b<%lO-s~.YP#P#Q.]~.bOx~~.eP;=`<%l-s~.mO!^~R.pTO#S.m#S#T/P#T;'S.m;'S;=`/U<%lO.mR/UOYRR/XP;=`<%l.mV/cWfSYR}!O,i!P!Q-S!Q![,i!c!},i#R#S,i#T#g,i#g#h/{#h#o,iV0SWfSYR}!O,i!P!Q-S!Q![,i!c!},i#R#S,i#T#V,i#V#W0l#W#o,iV0uUfSoQYR}!O,i!P!Q-S!Q![,i!c!},i#R#S,i#T#o,iV1`WfSYR}!O,i!P!Q-S!Q![,i!c!},i#R#S,i#T#X,i#X#Y/[#Y#o,iV2PVfSYR}!O,i!P!Q-S!Q![,i!c!},i#R#S,i#T#U2f#U#o,iV2mWfSYR}!O,i!P!Q-S!Q![,i!c!},i#R#S,i#T#`,i#`#a3V#a#o,iV3^WfSYR}!O,i!P!Q-S!Q![,i!c!},i#R#S,i#T#g,i#g#h3v#h#o,iV3}WfSYR}!O,i!P!Q-S!Q![,i!c!},i#R#S,i#T#X,i#X#Y4g#Y#o,iV4pUfSWPYR}!O,i!P!Q-S!Q![,i!c!},i#R#S,i#T#o,iV5ZWfSYR}!O,i!P!Q-S!Q![,i!c!},i#R#S,i#T#b,i#b#c5s#c#o,iV5|UfS|QYR}!O,i!P!Q-S!Q![,i!c!},i#R#S,i#T#o,iV6gWfSYR}!O,i!P!Q-S!Q![,i!c!},i#R#S,i#T#c,i#c#d7P#d#o,iV7WWfSYR}!O,i!P!Q-S!Q![,i!c!},i#R#S,i#T#h,i#h#i7p#i#o,iV7yUfSzPYR}!O,i!P!Q-S!Q![,i!c!},i#R#S,i#T#o,iV8dWfSYR}!O,i!P!Q-S!Q![,i!c!},i#R#S,i#T#f,i#f#g8|#g#o,iV9TWfSYR}!O,i!P!Q-S!Q![,i!c!},i#R#S,i#T#W,i#W#X9m#X#o,iV9tWfSYR}!O,i!P!Q-S!Q![,i!c!},i#R#S,i#T#X,i#X#Y:^#Y#o,iV:eWfSYR}!O,i!P!Q-S!Q![,i!c!},i#R#S,i#T#f,i#f#g:}#g#o,iV;UVfSYRpq;k}!O,i!P!Q-S!Q![,i!c!},i#R#S,i#T#o,iR;nP#U#V;qR;tP#m#n;wR;|OlRV<TWfSYR}!O,i!P!Q-S!Q![,i!c!},i#R#S,i#T#f,i#f#g<m#g#o,iV<tWfSYR}!O,i!P!Q-S!Q![,i!c!},i#R#S,i#T#i,i#i#j3v#j#o,i~=cO!b~~=hO!e~",tokenizers:[0,1,2],topRules:{Program:[0,2]},specialized:[{term:10,get:e=>kk[e]||-1}],tokenPrec:1274});function Gr(e,t,i=0,r,n=0){let s=0,o=!0,a=-1,l=-1,h=!1,c=()=>{r.push(e.elt("TableCell",n+a,n+l,e.parser.parseInline(t.slice(a,l),n+a)))},u=!1;for(let d=i;d<t.length;d++){let f=t.charCodeAt(d);f===91&&t.charAt(d+1)==="["?u=!0:f===93&&t.charAt(d-1)==="]"&&u&&(u=!1),f==124&&!h&&!u?((!o||a>-1)&&s++,o=!1,r&&(a>-1&&c(),r.push(e.elt("TableDelimiter",d+n,d+n+1))),a=l=-1):(h||f!=32&&f!=9)&&(a<0&&(a=d),l=d+1),h=!h&&f==92}return a>-1&&(s++,r&&c()),s}function ig(e,t){for(let i=t;i<e.length;i++){let r=e.charCodeAt(i);if(r==124)return!0;r==92&&i++}return!1}var rg=/^\|?(\s*:?-+:?\s*\|)+(\s*:?-+:?\s*)?$/,Is=class{rows=null;nextLine(t,i,r){if(this.rows==null){this.rows=!1;let n;if((i.next==45||i.next==58||i.next==124)&&rg.test(n=i.text.slice(i.pos))){let s=[];Gr(t,r.content,0,s,r.start)==Gr(t,n,i.pos)&&(this.rows=[t.elt("TableHeader",r.start,r.start+r.content.length,s),t.elt("TableDelimiter",t.lineStart+i.pos,t.lineStart+i.text.length)])}}else if(this.rows){let n=[];Gr(t,i.text,i.pos,n,t.lineStart),this.rows.push(t.elt("TableRow",t.lineStart+i.pos,t.lineStart+i.text.length,n))}return!1}finish(t,i){return this.rows?(t.addLeafElement(i,t.elt("Table",i.start,i.start+i.content.length,this.rows)),!0):!1}},ng={defineNodes:[{name:"Table",block:!0},{name:"TableHeader",style:{"TableHeader/...":m.heading}},"TableRow",{name:"TableCell",style:m.content},{name:"TableDelimiter",style:m.processingInstruction}],parseBlock:[{name:"Table",leaf(e,t){return ig(t.content,0)?new Is:null},endLeaf(e,t,i){if(i.parsers.some(n=>n instanceof Is)||!ig(t.text,t.basePos))return!1;let r=e.scanLine(e.absoluteLineEnd+1).text;return rg.test(r)&&Gr(e,t.text,t.basePos)==Gr(e,r,t.basePos)},before:"SetextHeading"}]};var Qk=/(!?\[\[)([^\]\|]+)(?:\|([^\]]+))?(\]\])/g;var $k=/#[^\d\s!@#$%^&*(),.?":{}|<>\\][^\s!@#$%^&*(),.?":{}|<>\\]*/,Tk=new RegExp("^"+Qk.source),Ck={defineNodes:[{name:"WikiLink",style:sh},{name:"WikiLinkPage",style:qs},{name:"WikiLinkAlias",style:qs},{name:"WikiLinkDimensions",style:qs},{name:"WikiLinkMark",style:m.processingInstruction}],parseInline:[{name:"WikiLink",parse(e,t,i){let r;if(t!=91&&t!=33||!(r=Tk.exec(e.slice(i,e.end))))return-1;let[n,s,o,a,l]=r,h=i+n.length,c=[];if(a){let d=i+s.length+o.length;c=[e.elt("WikiLinkMark",d,d+1),e.elt("WikiLinkAlias",d+1,d+1+a.length)]}let u=e.elt("WikiLink",i,h,[e.elt("WikiLinkMark",i,i+s.length),e.elt("WikiLinkPage",i+s.length,i+s.length+o.length),...c,e.elt("WikiLinkMark",h-2,h)]);return t==33&&(u=e.elt("Image",i,h,[u])),e.addElement(u)},after:"Emphasis"}]},Ak={defineNodes:[{name:"CommandLink",style:{"CommandLink/...":Ym}},{name:"CommandLinkName",style:nh},{name:"CommandLinkAlias",style:nh},{name:"CommandLinkArgs",style:Im},{name:"CommandLinkMark",style:m.processingInstruction}],parseInline:[{name:"CommandLink",parse(e,t,i){let r;if(t!=123||!(r=rc.exec(e.slice(i,e.end))))return-1;let[n,s,o,a,l,h]=r,c=i+n.length,u=[];if(o){let f=i+2+s.length;u=[e.elt("CommandLinkMark",f,f+1),e.elt("CommandLinkAlias",f+1,f+1+a.length)]}let d=[];if(l){let f=i+2+s.length+(o?.length??0);d=[e.elt("CommandLinkMark",f,f+2),e.elt("CommandLinkArgs",f+2,f+2+h.length)]}return e.addElement(e.elt("CommandLink",i,c,[e.elt("CommandLinkMark",i,i+2),e.elt("CommandLinkName",i+2,i+2+s.length),...u,...d,e.elt("CommandLinkMark",c-2,c)]))},after:"Emphasis"}]},Zk={defineNodes:[{name:"TemplateDirective"},{name:"TemplateExpressionDirective"},{name:"TemplateIfStartDirective",style:ni},{name:"TemplateEachStartDirective",style:ni},{name:"TemplateEachVarStartDirective",style:ni},{name:"TemplateLetStartDirective",style:ni},{name:"TemplateIfEndDirective",style:ni},{name:"TemplateEachEndDirective",style:ni},{name:"TemplateLetEndDirective",style:ni},{name:"TemplateVar",style:m.variableName},{name:"TemplateDirectiveMark",style:Fm}],parseInline:[{name:"TemplateDirective",parse(e,t,i){let r=e.slice(i,e.end);if(t!=123||e.slice(i,i+2)!=="{{")return-1;let n=0,s=0;e:for(;s<r.length;s++)switch(r[s]){case"{":n++;break;case"}":if(n--,n===0)break e;break}if(n!==0)return-1;let o=r.slice(2,s-1),a=i+s+1,l,h=/^(\s*#let\s*)(@\w+)(\s*=\s*)(.+)$/s.exec(o);if(h){let[c,u,d,f,p]=h,O=Ls.parse(p);l=e.elt("TemplateLetStartDirective",i+2,a-2,[e.elt("TemplateVar",i+2+u.length,i+2+u.length+d.length),e.elt(O,i+2+u.length+d.length+f.length)])}if(!l){let c=/^(\s*#each\s*)(@\w+)(\s+in\s+)(.+)$/s.exec(o);if(c){let[u,d,f,p,O]=c,g=Ls.parse(O);l=e.elt("TemplateEachVarStartDirective",i+2,a-2,[e.elt("TemplateVar",i+2+d.length,i+2+d.length+f.length),e.elt(g,i+2+d.length+f.length+p.length)])}}if(!l){let c=/^(\s*#(if|each)\s*)(.+)$/s.exec(o);if(c){let[u,d,f,p]=c,O=Ls.parse(p);l=e.elt(f==="if"?"TemplateIfStartDirective":"TemplateEachStartDirective",i+2,a-2,[e.elt(O,i+2+d.length)])}}if(!l){let c=/^\s*\/(if|each|let)/.exec(o);if(c){let[u,d]=c,f=d[0].toUpperCase()+d.slice(1);l=e.elt(`Template${f}EndDirective`,i+2,a-2)}}if(!l){let c=Ls.parse(o);l=e.elt("TemplateExpressionDirective",i+2,a-2,[e.elt(c,i+2)])}return e.addElement(e.elt("TemplateDirective",i,a,[e.elt("TemplateDirectiveMark",i,i+2),l,e.elt("TemplateDirectiveMark",a-2,a)]))},after:"Emphasis"}]},Ek={resolve:"Highlight",mark:"HighlightMark"},Rk={defineNodes:[{name:"Highlight",style:{"Highlight/...":Nm}},{name:"HighlightMark",style:m.processingInstruction}],parseInline:[{name:"Highlight",parse(e,t,i){return t!=61||e.char(i+1)!=61?-1:e.addDelimiter(Ek,i,i+2,!0,!0)},after:"Emphasis"}]},sg=Re({Identifier:m.variableName,TagIdentifier:m.variableName,GlobalIdentifier:m.variableName,String:m.string,Number:m.number,PageRef:sh,BinExpression:m.operator,TernaryExpression:m.operator,Regex:m.regexp,"where limit select render Order OrderKW and or null as InKW NotKW BooleanKW each all":m.keyword}),KR=eg.configure({props:[sg]}),Ls=tg.configure({props:[sg]}),Xk=/^\[([\w\$]+)(::?\s*)/,Mk={defineNodes:[{name:"Attribute",style:{"Attribute/...":Dm}},{name:"AttributeName",style:_m},{name:"AttributeValue",style:Um},{name:"AttributeMark",style:m.processingInstruction},{name:"AttributeColon",style:m.processingInstruction}],parseInline:[{name:"Attribute",parse(e,t,i){let r,n=e.slice(i,e.end);if(t!=91||!(r=Xk.exec(n)))return-1;let[s,o,a]=r,l=1,h=s.length;e:for(;h<n.length;h++)switch(n[h]){case"[":l++;break;case"]":if(l--,l===0)break e;break}return l!==0?(console.log("Failed to parse attribute",s,n),-1):n[h+1]==="("?-1:e.addElement(e.elt("Attribute",i,i+h+1,[e.elt("AttributeMark",i,i+1),e.elt("AttributeName",i+1,i+1+o.length),e.elt("AttributeColon",i+1+o.length,i+1+o.length+a.length),e.elt("AttributeValue",i+1+o.length+a.length,i+h),e.elt("AttributeMark",i+h,i+h+1)]))},after:"Emphasis"}]},ch=class{nextLine(){return!1}finish(t,i){return t.addLeafElement(i,t.elt("Comment",i.start,i.start+i.content.length,[...t.parser.parseInline(i.content.slice(3),i.start+3)])),!0}},Wk={defineNodes:[{name:"Comment",block:!0}],parseBlock:[{name:"Comment",leaf(e,t){return/^%%\s/.test(t.content)?new ch:null},after:"SetextHeading"}]};function Vs({regex:e,firstCharCode:t,nodeType:i}){return{defineNodes:[i],parseInline:[{name:i,parse(r,n,s){if(t!==n)return-1;let o=e.exec(r.slice(s,r.end));return o?r.addElement(r.elt(i,s,s+o[0].length)):-1}}]}}var qk=Vs({firstCharCode:104,regex:/^https?:\/\/[-a-zA-Z0-9@:%._\+~#=]{1,256}([-a-zA-Z0-9()@:%_\+.~#?&=\/]*)/,nodeType:"NakedURL",className:"sb-naked-url",tag:Ys}),Yk=Vs({firstCharCode:35,regex:new RegExp(`^${$k.source}`),nodeType:"Hashtag",className:"sb-hashtag",tag:lh}),Ik=Vs({firstCharCode:55357,regex:/^📅\s*\d{4}\-\d{2}\-\d{2}/,className:"sb-task-deadline",nodeType:"DeadlineDate",tag:ah}),Lk=Vs({firstCharCode:36,regex:/^\$[a-zA-Z\.\-\/]+[\w\.\-\/]*/,className:"sb-named-anchor",nodeType:"NamedAnchor",tag:oh}),Vk=Wp.define(nc),Nk={defineNodes:[{name:"FrontMatter",block:!0},{name:"FrontMatterMarker"},{name:"FrontMatterCode"}],parseBlock:[{name:"FrontMatter",parse:(e,t)=>{if(e.parsedPos!==0||t.text!=="---")return!1;let i=e.parsedPos,r=[e.elt("FrontMatterMarker",e.parsedPos,e.parsedPos+t.text.length+1)];e.nextLine();let n=e.parsedPos,s=n,o="",a=e.parsedPos;do{if(o+=t.text+`
-`,s+=t.text.length+1,e.nextLine(),e.parsedPos===a)return!1;a=e.parsedPos}while(t.text!=="---");let l=Vk.parser.parse(o);return r.push(e.elt("FrontMatterCode",n,s,[e.elt(l,n)])),s=e.parsedPos+t.text.length,r.push(e.elt("FrontMatterMarker",e.parsedPos,e.parsedPos+t.text.length)),e.nextLine(),e.addElement(e.elt("FrontMatter",i,s,r)),!0},before:"HorizontalRule"}]},og=qm({extensions:[Ck,Ak,Mk,Nk,Jm,Wk,Rk,Zk,Wo,ng,qk,Yk,Ik,Lk,Rn,Xn,{props:[pt.add({BulletList:()=>null,OrderedList:()=>null,ListItem:(e,t)=>({from:t.doc.lineAt(e.from).to,to:e.to}),FrontMatter:e=>({from:e.from,to:e.to})}),Re({Task:zm,TaskMark:Bm,Comment:Vm,Subscript:Hm,Superscript:Km,"TableDelimiter StrikethroughMark":m.processingInstruction,"TableHeader/...":m.heading,TableCell:m.content,CodeInfo:Lm,HorizontalRule:jm,Hashtag:lh,NakedURL:Ys,DeadlineDate:ah,NamedAnchor:oh})]}]}).language;var uh="\u{1F916} ";function Fr(e){return!(["SETTINGS","SECRETS",...C.indexEmbeddingsExcludePages].includes(e)||e.startsWith("_")||e.startsWith("Library/")||/\.conflicted\.\d+$/.test(e))}async function ag(){return await ae(),C.indexEmbeddings&&He!==void 0&&Kr!==void 0&&C.embeddingModels.length>0&&await K.getEnv()==="server"}async function lg(){return await ae(),C.indexEmbeddings&&C.indexSummary&&He!==void 0&&Kr!==void 0&&C.embeddingModels.length>0&&await K.getEnv()==="server"}async function jk(e){if(!await ag()||!Fr(e))return;let t=await me.readPage(e),i=await Oe.parseMarkdown(t);if(!i.children)return;let r=i.children.filter(l=>l.type==="Paragraph"),n=[],s=Date.now();for(let l of r){let h=be(l).trim();if(!h||h.length<10||C.indexEmbeddingsExcludeStrings.some(f=>h.includes(f)))continue;let c=await He.generateEmbeddings({text:h}),u=l.from??0,d={ref:`${e}@${u}`,page:e,pos:u,embedding:c,text:h,tag:"embedding"};n.push(d)}await Oo(e,n);let a=(Date.now()-s)/1e3;Le("any",`AI: Indexed ${n.length} embedding objects for page ${e} in ${a} seconds`)}async function Dk(e){if(!await lg()||!Fr(e))return;let t=await me.readPage(e),i=await Oe.parseMarkdown(t);if(!i.children)return;let r=Date.now(),n=be(i),s=C.textModels.find(p=>p.name===C.indexSummaryModelName);if(!s)throw new Error(`Could not find summary model ${C.indexSummaryModelName}`);let o=await Jr(s),a;C.promptInstructions.indexSummaryPrompt!==""?a=C.promptInstructions.indexSummaryPrompt:a=`Provide a concise and informative summary of the above page. The summary should capture the key points and be useful for search purposes. Avoid any formatting or extraneous text.  No more than one paragraph.  Summary:
-`;let l=await wn(s.name,n,a),h=bn(l);h||(h=await o.singleMessageChat("Contents of "+e+`:
-`+n+`
+var __defProp = Object.defineProperty;
+var __export = (target, all) => {
+  for (var name in all)
+    __defProp(target, name, { get: all[name], enumerable: true });
+};
 
-`+a),yn(l,h));let c=await He.generateEmbeddings({text:h}),u={ref:`${e}@0`,page:e,embedding:c,text:h,tag:"aiSummary"};await Oo(e,[u]);let f=(Date.now()-r)/1e3;Le("any",`AI: Indexed summary for page ${e} in ${f} seconds`)}async function hg({name:e,tree:t}){await ae(),Fr(e)&&t.children&&(await ag()&&await hi.send("aiEmbeddingsQueue",e),await lg()&&await hi.send("aiSummaryQueue",e))}async function cg(e){await ae();for(let i of e){let r=i.body;console.log(`AI: Generating and indexing embeddings for file ${r}`),await jk(r)}let t=await hi.getQueueStats("aiEmbeddingsQueue");console.log(`AI: Embeddings queue stats: ${JSON.stringify(t)}`)}async function ug(e){await ae();for(let i of e){let r=i.body;console.log(`AI: Generating and indexing summary for ${r}`),await Dk(r)}let t=await hi.getQueueStats("aiSummaryQueue");console.log(`AI: Summary queue stats: ${JSON.stringify(t)}`)}async function fh(){return await mh()?await syscall("system.invokeFunctionOnServer","index.queryObjects","embedding",{}):await Ci("embedding",{})}async function dg(){return await mh()?await syscall("system.invokeFunctionOnServer","index.queryObjects","aiSummary",{}):await Ci("aiSummary",{})}async function fg(e){if(await ae(),!He||!Kr)throw new Error("No embedding provider found");return await He.generateEmbeddings({text:e})}async function Hr(e){return await syscall("system.invokeFunctionOnServer","silverbullet-ai.generateEmbeddings",e)}function dh(e,t){let i=e.reduce((s,o,a)=>s+o*t[a],0),r=Math.sqrt(e.reduce((s,o)=>s+o*o,0)),n=Math.sqrt(t.reduce((s,o)=>s+o*o,0));return i/(r*n)}async function ph(e,t=10,i=!1){await ae(),await K.getEnv()==="server"&&(i=!1);let r=Date.now(),n=typeof e=="string"?await Hr(e):e,s=Date.now();console.log(`searchEmbeddings: Query embedding generation took ${s-r} ms`);let o=Date.now(),a=await fh(),l=Date.now();console.log(`Retrieved ${a.length} embeddings in ${l-o} ms`);let h="",c=0;i&&(h=`Retrieved ${a.length} embeddings in ${l-o} ms
+// https://deno.land/x/silverbullet@0.9.4/lib/plugos/worker_runtime.ts
+var runningAsWebWorker = typeof window === "undefined" && // @ts-ignore: globalThis
+typeof globalThis.WebSocketPair === "undefined";
+if (typeof Deno === "undefined") {
+  self.Deno = {
+    args: [],
+    // @ts-ignore: Deno hack
+    build: {
+      arch: "x86_64"
+    },
+    env: {
+      // @ts-ignore: Deno hack
+      get() {
+      }
+    }
+  };
+}
+var pendingRequests = /* @__PURE__ */ new Map();
+var syscallReqId = 0;
+function workerPostMessage(msg) {
+  self.postMessage(msg);
+}
+if (runningAsWebWorker) {
+  globalThis.syscall = async (name, ...args) => {
+    return await new Promise((resolve, reject) => {
+      syscallReqId++;
+      pendingRequests.set(syscallReqId, { resolve, reject });
+      workerPostMessage({
+        type: "sys",
+        id: syscallReqId,
+        name,
+        args
+      });
+    });
+  };
+}
+function setupMessageListener(functionMapping2, manifest2) {
+  if (!runningAsWebWorker) {
+    return;
+  }
+  self.addEventListener("message", (event) => {
+    (async () => {
+      const data = event.data;
+      switch (data.type) {
+        case "inv":
+          {
+            const fn = functionMapping2[data.name];
+            if (!fn) {
+              throw new Error(`Function not loaded: ${data.name}`);
+            }
+            try {
+              const result = await Promise.resolve(fn(...data.args || []));
+              workerPostMessage({
+                type: "invr",
+                id: data.id,
+                result
+              });
+            } catch (e) {
+              console.error(
+                "An exception was thrown as a result of invoking function",
+                data.name,
+                "error:",
+                e.message
+              );
+              workerPostMessage({
+                type: "invr",
+                id: data.id,
+                error: e.message
+              });
+            }
+          }
+          break;
+        case "sysr":
+          {
+            const syscallId = data.id;
+            const lookup = pendingRequests.get(syscallId);
+            if (!lookup) {
+              throw Error("Invalid request id");
+            }
+            pendingRequests.delete(syscallId);
+            if (data.error) {
+              lookup.reject(new Error(data.error));
+            } else {
+              lookup.resolve(data.result);
+            }
+          }
+          break;
+      }
+    })().catch(console.error);
+  });
+  workerPostMessage({
+    type: "manifest",
+    manifest: manifest2
+  });
+}
+function base64Decode(s) {
+  const binString = atob(s);
+  const len = binString.length;
+  const bytes = new Uint8Array(len);
+  for (let i = 0; i < len; i++) {
+    bytes[i] = binString.charCodeAt(i);
+  }
+  return bytes;
+}
+function base64Encode(buffer) {
+  if (typeof buffer === "string") {
+    buffer = new TextEncoder().encode(buffer);
+  }
+  let binary2 = "";
+  const len = buffer.byteLength;
+  for (let i = 0; i < len; i++) {
+    binary2 += String.fromCharCode(buffer[i]);
+  }
+  return btoa(binary2);
+}
+async function sandboxFetch(reqInfo, options) {
+  if (typeof reqInfo !== "string") {
+    const body = new Uint8Array(await reqInfo.arrayBuffer());
+    const encodedBody = body.length > 0 ? base64Encode(body) : void 0;
+    options = {
+      method: reqInfo.method,
+      headers: Object.fromEntries(reqInfo.headers.entries()),
+      base64Body: encodedBody
+    };
+    reqInfo = reqInfo.url;
+  }
+  return syscall("sandboxFetch.fetch", reqInfo, options);
+}
+globalThis.nativeFetch = globalThis.fetch;
+function monkeyPatchFetch() {
+  globalThis.fetch = async function(reqInfo, init) {
+    const encodedBody = init && init.body ? base64Encode(
+      new Uint8Array(await new Response(init.body).arrayBuffer())
+    ) : void 0;
+    const r = await sandboxFetch(
+      reqInfo,
+      init && {
+        method: init.method,
+        headers: init.headers,
+        base64Body: encodedBody
+      }
+    );
+    return new Response(r.base64Body ? base64Decode(r.base64Body) : null, {
+      status: r.status,
+      headers: r.headers
+    });
+  };
+}
+if (runningAsWebWorker) {
+  monkeyPatchFetch();
+}
 
-`,c=(await x.getText()).length,await x.replaceRange(c,c,h));let u=[],d=Date.now();for(let f=0;f<a.length;f++){let p=a[f];if(Fr(p.page)){if(u.push({page:p.page,ref:p.ref,text:p.text,similarity:dh(n,p.embedding)}),i&&(f%100===0||Date.now()-d>=100)){let O=c+h.length;h=`
+// https://jsr.io/@silverbulletmd/silverbullet/0.9.4/plug-api/lib/tree.ts
+function addParentPointers(tree) {
+  if (!tree.children) {
+    return;
+  }
+  for (const child of tree.children) {
+    if (child.parent) {
+      return;
+    }
+    child.parent = tree;
+    addParentPointers(child);
+  }
+}
+function collectNodesOfType(tree, nodeType) {
+  return collectNodesMatching(tree, (n) => n.type === nodeType);
+}
+function collectNodesMatching(tree, matchFn) {
+  if (matchFn(tree)) {
+    return [tree];
+  }
+  let results = [];
+  if (tree.children) {
+    for (const child of tree.children) {
+      results = [...results, ...collectNodesMatching(child, matchFn)];
+    }
+  }
+  return results;
+}
+async function collectNodesMatchingAsync(tree, matchFn) {
+  if (await matchFn(tree)) {
+    return [tree];
+  }
+  let results = [];
+  if (tree.children) {
+    for (const child of tree.children) {
+      results = [
+        ...results,
+        ...await collectNodesMatchingAsync(child, matchFn)
+      ];
+    }
+  }
+  return results;
+}
+async function replaceNodesMatchingAsync(tree, substituteFn) {
+  if (tree.children) {
+    const children = tree.children.slice();
+    for (const child of children) {
+      const subst = await substituteFn(child);
+      if (subst !== void 0) {
+        const pos = tree.children.indexOf(child);
+        if (subst) {
+          tree.children.splice(pos, 1, subst);
+        } else {
+          tree.children.splice(pos, 1);
+        }
+      } else {
+        await replaceNodesMatchingAsync(child, substituteFn);
+      }
+    }
+  }
+}
+function findNodeOfType(tree, nodeType) {
+  return collectNodesMatching(tree, (n) => n.type === nodeType)[0];
+}
+async function traverseTreeAsync(tree, matchFn) {
+  await collectNodesMatchingAsync(tree, matchFn);
+}
+function renderToText(tree) {
+  if (!tree) {
+    return "";
+  }
+  const pieces = [];
+  if (tree.text !== void 0) {
+    return tree.text;
+  }
+  for (const child of tree.children) {
+    pieces.push(renderToText(child));
+  }
+  return pieces.join("");
+}
+function parseTreeToAST(tree, omitTrimmable = true) {
+  const parseErrorNodes = collectNodesOfType(tree, "\u26A0");
+  if (parseErrorNodes.length > 0) {
+    throw new Error(
+      `Parse error in: ${renderToText(tree)}`
+    );
+  }
+  if (tree.text !== void 0) {
+    return tree.text;
+  }
+  const ast = [tree.type];
+  for (const node of tree.children) {
+    if (node.type && !node.type.endsWith("Mark")) {
+      ast.push(parseTreeToAST(node, omitTrimmable));
+    }
+    if (node.text && (omitTrimmable && node.text.trim() || !omitTrimmable)) {
+      ast.push(node.text);
+    }
+  }
+  return ast;
+}
 
-Processed ${f+1} of ${a.length} embeddings...
+// https://jsr.io/@silverbulletmd/silverbullet/0.9.4/plug-api/lib/json.ts
+function cleanStringDate(d) {
+  if (d.getUTCHours() === 0 && d.getUTCMinutes() === 0 && d.getUTCSeconds() === 0) {
+    return d.getFullYear() + "-" + String(d.getMonth() + 1).padStart(2, "0") + "-" + String(d.getDate()).padStart(2, "0");
+  } else {
+    return d.toISOString();
+  }
+}
+function cleanupJSON(a) {
+  if (!a) {
+    return a;
+  }
+  if (typeof a !== "object") {
+    return a;
+  }
+  if (Array.isArray(a)) {
+    return a.map(cleanupJSON);
+  }
+  if (a instanceof Date) {
+    return cleanStringDate(a);
+  }
+  const expanded = {};
+  for (const key of Object.keys(a)) {
+    const parts = key.split(".");
+    let target = expanded;
+    for (let i = 0; i < parts.length - 1; i++) {
+      const part = parts[i];
+      if (!target[part]) {
+        target[part] = {};
+      }
+      target = target[part];
+    }
+    target[parts[parts.length - 1]] = cleanupJSON(a[key]);
+  }
+  return expanded;
+}
 
-`,await x.replaceRange(c,O,h),d=Date.now()}if(i&&f>=a.length-1){let O=c+h.length;await x.replaceRange(c,O,"")}}}if(console.log(`Finished searching embeddings in ${Date.now()-o} ms`),C.indexSummary){let f=Date.now(),p=await dg(),O=Date.now();console.log(`Retrieved ${p.length} summaries in ${O-f} ms`);let g="",y=0;i&&(g=`Retrieved ${p.length} summaries in ${O-f} ms
+// https://jsr.io/@silverbulletmd/silverbullet/0.9.4/plug-api/syscalls/editor.ts
+var editor_exports = {};
+__export(editor_exports, {
+  confirm: () => confirm,
+  copyToClipboard: () => copyToClipboard,
+  deleteLine: () => deleteLine,
+  dispatch: () => dispatch,
+  downloadFile: () => downloadFile,
+  filterBox: () => filterBox,
+  flashNotification: () => flashNotification,
+  fold: () => fold,
+  foldAll: () => foldAll,
+  getCurrentPage: () => getCurrentPage,
+  getCursor: () => getCursor,
+  getSelection: () => getSelection,
+  getText: () => getText,
+  getUiOption: () => getUiOption,
+  goHistory: () => goHistory,
+  hidePanel: () => hidePanel,
+  insertAtCursor: () => insertAtCursor,
+  insertAtPos: () => insertAtPos,
+  moveCursor: () => moveCursor,
+  moveCursorToLine: () => moveCursorToLine,
+  navigate: () => navigate,
+  openCommandPalette: () => openCommandPalette,
+  openPageNavigator: () => openPageNavigator,
+  openSearchPanel: () => openSearchPanel,
+  openUrl: () => openUrl,
+  prompt: () => prompt,
+  redo: () => redo,
+  reloadConfigAndCommands: () => reloadConfigAndCommands,
+  reloadPage: () => reloadPage,
+  reloadUI: () => reloadUI,
+  replaceRange: () => replaceRange,
+  save: () => save,
+  setSelection: () => setSelection,
+  setText: () => setText,
+  setUiOption: () => setUiOption,
+  showPanel: () => showPanel,
+  toggleFold: () => toggleFold,
+  undo: () => undo,
+  unfold: () => unfold,
+  unfoldAll: () => unfoldAll,
+  uploadFile: () => uploadFile,
+  vimEx: () => vimEx
+});
 
-`,y=(await x.getText()).length,await x.replaceRange(y,y,g));let b=[],S=Date.now();for(let w=0;w<p.length;w++){let k=p[w];if(Fr(k.page)){if(b.push({page:k.page,ref:k.ref,text:`Page Summary: ${k.text}`,similarity:dh(n,k.embedding)}),i&&(w%100===0||Date.now()-S>=100)){let Z=y+g.length;g=`
+// https://jsr.io/@silverbulletmd/silverbullet/0.9.4/plug-api/syscall.ts
+if (typeof self === "undefined") {
+  self = {
+    syscall: () => {
+      throw new Error("Not implemented here");
+    }
+  };
+}
+function syscall2(name, ...args) {
+  return globalThis.syscall(name, ...args);
+}
 
-Processed ${w+1} of ${p.length} summaries...
+// https://jsr.io/@silverbulletmd/silverbullet/0.9.4/plug-api/syscalls/editor.ts
+function getCurrentPage() {
+  return syscall2("editor.getCurrentPage");
+}
+function getText() {
+  return syscall2("editor.getText");
+}
+function setText(newText) {
+  return syscall2("editor.setText", newText);
+}
+function getCursor() {
+  return syscall2("editor.getCursor");
+}
+function getSelection() {
+  return syscall2("editor.getSelection");
+}
+function setSelection(from, to) {
+  return syscall2("editor.setSelection", from, to);
+}
+function save() {
+  return syscall2("editor.save");
+}
+function navigate(pageRef, replaceState = false, newWindow = false) {
+  return syscall2("editor.navigate", pageRef, replaceState, newWindow);
+}
+function openPageNavigator(mode = "page") {
+  return syscall2("editor.openPageNavigator", mode);
+}
+function openCommandPalette() {
+  return syscall2("editor.openCommandPalette");
+}
+function reloadPage() {
+  return syscall2("editor.reloadPage");
+}
+function reloadUI() {
+  return syscall2("editor.reloadUI");
+}
+function reloadConfigAndCommands() {
+  return syscall2("editor.reloadConfigAndCommands");
+}
+function openUrl(url, existingWindow = false) {
+  return syscall2("editor.openUrl", url, existingWindow);
+}
+function goHistory(delta) {
+  return syscall2("editor.goHistory", delta);
+}
+function downloadFile(filename, dataUrl) {
+  return syscall2("editor.downloadFile", filename, dataUrl);
+}
+function uploadFile(accept, capture) {
+  return syscall2("editor.uploadFile", accept, capture);
+}
+function flashNotification(message, type = "info") {
+  return syscall2("editor.flashNotification", message, type);
+}
+function filterBox(label, options, helpText = "", placeHolder = "") {
+  return syscall2("editor.filterBox", label, options, helpText, placeHolder);
+}
+function showPanel(id, mode, html, script = "") {
+  return syscall2("editor.showPanel", id, mode, html, script);
+}
+function hidePanel(id) {
+  return syscall2("editor.hidePanel", id);
+}
+function insertAtPos(text, pos) {
+  return syscall2("editor.insertAtPos", text, pos);
+}
+function replaceRange(from, to, text) {
+  return syscall2("editor.replaceRange", from, to, text);
+}
+function moveCursor(pos, center = false) {
+  return syscall2("editor.moveCursor", pos, center);
+}
+function moveCursorToLine(line, column = 1, center = false) {
+  return syscall2("editor.moveCursorToLine", line, column, center);
+}
+function insertAtCursor(text) {
+  return syscall2("editor.insertAtCursor", text);
+}
+function dispatch(change) {
+  return syscall2("editor.dispatch", change);
+}
+function prompt(message, defaultValue = "") {
+  return syscall2("editor.prompt", message, defaultValue);
+}
+function confirm(message) {
+  return syscall2("editor.confirm", message);
+}
+function getUiOption(key) {
+  return syscall2("editor.getUiOption", key);
+}
+function setUiOption(key, value) {
+  return syscall2("editor.setUiOption", key, value);
+}
+function fold() {
+  return syscall2("editor.fold");
+}
+function unfold() {
+  return syscall2("editor.unfold");
+}
+function toggleFold() {
+  return syscall2("editor.toggleFold");
+}
+function foldAll() {
+  return syscall2("editor.foldAll");
+}
+function unfoldAll() {
+  return syscall2("editor.unfoldAll");
+}
+function undo() {
+  return syscall2("editor.undo");
+}
+function redo() {
+  return syscall2("editor.redo");
+}
+function openSearchPanel() {
+  return syscall2("editor.openSearchPanel");
+}
+function copyToClipboard(data) {
+  return syscall2("editor.copyToClipboard", data);
+}
+function deleteLine() {
+  return syscall2("editor.deleteLine");
+}
+function vimEx(exCommand) {
+  return syscall2("editor.vimEx", exCommand);
+}
 
-`,await x.replaceRange(y,Z,g),S=Date.now()}if(i&&w>=p.length-1){let Z=y+g.length;await x.replaceRange(y,Z,"")}}}console.log(`Finished searching summaries in ${Date.now()-f} ms`),u.push(...b)}return u.sort((f,p)=>p.similarity-f.similarity).slice(0,t)}async function pg(e,t=10){await ae();let i=await Hr(e);return(await dg()).map(s=>({page:s.page,ref:s.ref,text:s.text,similarity:dh(i,s.embedding)})).sort((s,o)=>o.similarity-s.similarity).slice(0,t)}async function Ns(e,t=10,i=.15,r=!1){let n;n=await ph(e,-1,r);let s={};for(let a of n)a.similarity<i||(s[a.page]?(s[a.page].score+=a.similarity,s[a.page].children.push(a)):s[a.page]={page:a.page,score:a.similarity,children:[a]});for(let a in s)s[a].children=s[a].children.sort((l,h)=>h.similarity-l.similarity).slice(0,t);return Object.values(s).sort((a,l)=>l.score-a.score).slice(0,t)}async function js(e,t=10){try{let i=await Ns(e,t),r="";if(i.length>0)for(let n of i){r+=`>>${n.page}<<
-`;for(let s of n.children)r+=`> ${s.text}
+// https://jsr.io/@silverbulletmd/silverbullet/0.9.4/plug-api/syscalls/markdown.ts
+var markdown_exports = {};
+__export(markdown_exports, {
+  parseMarkdown: () => parseMarkdown,
+  renderParseTree: () => renderParseTree
+});
+function parseMarkdown(text) {
+  return syscall2("markdown.parseMarkdown", text);
+}
+function renderParseTree(tree) {
+  return syscall2("markdown.renderParseTree", tree);
+}
 
-`}else return"No relevant pages found.";return r}catch(i){return console.error("Error in searchEmbeddingsForChat:",i),"An error occurred during the search."}}function Og(e){return{data:new TextEncoder().encode(""),meta:{name:e,contentType:"text/markdown",size:0,created:0,lastModified:0,perm:"ro"}}}function Oh(e){return{name:e,contentType:"text/markdown",size:-1,created:0,lastModified:0,perm:"ro"}}function mg(e){return Oh(e)}async function gg(){let e=await x.getCurrentPage();if(e.startsWith(uh)){await ae();let t=e.substring(uh.length),i=`# Search results for "${t}"`,r=i+`
+// https://jsr.io/@silverbulletmd/silverbullet/0.9.4/plug-api/syscalls/space.ts
+var space_exports = {};
+__export(space_exports, {
+  deleteAttachment: () => deleteAttachment,
+  deleteFile: () => deleteFile,
+  deletePage: () => deletePage,
+  fileExists: () => fileExists,
+  getAttachmentMeta: () => getAttachmentMeta,
+  getFileMeta: () => getFileMeta,
+  getPageMeta: () => getPageMeta,
+  listAttachments: () => listAttachments,
+  listFiles: () => listFiles,
+  listPages: () => listPages,
+  listPlugs: () => listPlugs,
+  readAttachment: () => readAttachment,
+  readFile: () => readFile,
+  readPage: () => readPage,
+  writeAttachment: () => writeAttachment,
+  writeFile: () => writeFile,
+  writePage: () => writePage
+});
+function listPages() {
+  return syscall2("space.listPages");
+}
+function getPageMeta(name) {
+  return syscall2("space.getPageMeta", name);
+}
+function readPage(name) {
+  return syscall2("space.readPage", name);
+}
+function writePage(name, text) {
+  return syscall2("space.writePage", name, text);
+}
+function deletePage(name) {
+  return syscall2("space.deletePage", name);
+}
+function listPlugs() {
+  return syscall2("space.listPlugs");
+}
+function listAttachments() {
+  return syscall2("space.listAttachments");
+}
+function getAttachmentMeta(name) {
+  return syscall2("space.getAttachmentMeta", name);
+}
+function readAttachment(name) {
+  return syscall2("space.readAttachment", name);
+}
+function writeAttachment(name, data) {
+  return syscall2("space.writeAttachment", name, data);
+}
+function deleteAttachment(name) {
+  return syscall2("space.deleteAttachment", name);
+}
+function listFiles() {
+  return syscall2("space.listFiles");
+}
+function readFile(name) {
+  return syscall2("space.readFile", name);
+}
+function getFileMeta(name) {
+  return syscall2("space.getFileMeta", name);
+}
+function writeFile(name, data) {
+  return syscall2("space.writeFile", name, data);
+}
+function deleteFile(name) {
+  return syscall2("space.deleteFile", name);
+}
+function fileExists(name) {
+  return syscall2("space.fileExists", name);
+}
 
-`;if(!C.indexEmbeddings){r+=`> **warning** Embeddings generation is disabled.
-`,r+=`> You can enable it in the AI settings.
+// https://jsr.io/@silverbulletmd/silverbullet/0.9.4/plug-api/syscalls/system.ts
+var system_exports = {};
+__export(system_exports, {
+  applyAttributeExtractors: () => applyAttributeExtractors,
+  getEnv: () => getEnv,
+  getMode: () => getMode,
+  getSpaceConfig: () => getSpaceConfig,
+  getVersion: () => getVersion,
+  invokeCommand: () => invokeCommand,
+  invokeFunction: () => invokeFunction,
+  invokeSpaceFunction: () => invokeSpaceFunction,
+  listCommands: () => listCommands,
+  listSyscalls: () => listSyscalls,
+  reloadConfig: () => reloadConfig,
+  reloadPlugs: () => reloadPlugs
+});
+function invokeFunction(name, ...args) {
+  return syscall2("system.invokeFunction", name, ...args);
+}
+function invokeCommand(name, args) {
+  return syscall2("system.invokeCommand", name, args);
+}
+function listCommands() {
+  return syscall2("system.listCommands");
+}
+function listSyscalls() {
+  return syscall2("system.listSyscalls");
+}
+function invokeSpaceFunction(name, ...args) {
+  return syscall2("system.invokeSpaceFunction", name, ...args);
+}
+function applyAttributeExtractors(tags, text, tree) {
+  return syscall2("system.applyAttributeExtractors", tags, text, tree);
+}
+async function getSpaceConfig(key, defaultValue) {
+  return await syscall2("system.getSpaceConfig", key) ?? defaultValue;
+}
+function reloadPlugs() {
+  return syscall2("system.reloadPlugs");
+}
+function reloadConfig() {
+  return syscall2("system.reloadConfig");
+}
+function getEnv() {
+  return syscall2("system.getEnv");
+}
+function getMode() {
+  return syscall2("system.getMode");
+}
+function getVersion() {
+  return syscall2("system.getVersion");
+}
 
+// https://jsr.io/@silverbulletmd/silverbullet/0.9.4/plug-api/syscalls/clientStore.ts
+var clientStore_exports = {};
+__export(clientStore_exports, {
+  del: () => del,
+  get: () => get,
+  set: () => set
+});
+function set(key, value) {
+  return syscall2("clientStore.set", key, value);
+}
+function get(key) {
+  return syscall2("clientStore.get", key);
+}
+function del(key) {
+  return syscall2("clientStore.delete", key);
+}
 
-`,await x.setText(r);return}let n=`${i}
+// https://jsr.io/@silverbulletmd/silverbullet/0.9.4/plug-api/syscalls/language.ts
+var language_exports = {};
+__export(language_exports, {
+  listLanguages: () => listLanguages,
+  parseLanguage: () => parseLanguage
+});
+function parseLanguage(language, code) {
+  return syscall2("language.parseLanguage", language, code);
+}
+function listLanguages() {
+  return syscall2("language.listLanguages");
+}
 
-Searching for "${t}"...`;n+=`
-Generating query vector embeddings..`,await x.setText(n);let s=[];try{s=await Hr(t)}catch(l){console.error("Error generating query vector embeddings",l),n+=`
+// https://jsr.io/@silverbulletmd/silverbullet/0.9.4/plug-api/syscalls/template.ts
+var template_exports = {};
+__export(template_exports, {
+  parseTemplate: () => parseTemplate,
+  renderTemplate: () => renderTemplate
+});
+function renderTemplate(template, obj, globals = {}) {
+  return syscall2("template.renderTemplate", template, obj, globals);
+}
+function parseTemplate(template) {
+  return syscall2("template.parseTemplate", template);
+}
 
-> **error** \u26A0\uFE0F Failed to generate query vector embeddings.
-`,n+=`> ${l}
+// https://jsr.io/@silverbulletmd/silverbullet/0.9.4/plug-api/syscalls/event.ts
+var event_exports = {};
+__export(event_exports, {
+  dispatchEvent: () => dispatchEvent,
+  listEvents: () => listEvents
+});
+function dispatchEvent(eventName, data, timeout) {
+  return new Promise((resolve, reject) => {
+    let timeouter = -1;
+    if (timeout) {
+      timeouter = setTimeout(() => {
+        console.log("Timeout!");
+        reject("timeout");
+      }, timeout);
+    }
+    syscall2("event.dispatch", eventName, data).then((r) => {
+      if (timeouter !== -1) {
+        clearTimeout(timeouter);
+      }
+      resolve(r);
+    }).catch(reject);
+  });
+}
+function listEvents() {
+  return syscall2("event.list");
+}
 
-`,await x.setText(n);return}n+=`
-Searching for similar embeddings...`,await x.setText(n);let o=[];try{o=await Ns(s,void 0,void 0,!0)}catch(l){console.error("Error searching embeddings",l),n+=`
+// https://jsr.io/@silverbulletmd/silverbullet/0.9.4/plug-api/syscalls/yaml.ts
+var yaml_exports = {};
+__export(yaml_exports, {
+  parse: () => parse,
+  stringify: () => stringify
+});
+function parse(text) {
+  return syscall2("yaml.parse", text);
+}
+function stringify(obj) {
+  return syscall2("yaml.stringify", obj);
+}
 
-> **error** \u26A0\uFE0F Failed to search through embeddings.
-`,n+=`> ${l}
+// https://jsr.io/@silverbulletmd/silverbullet/0.9.4/plug-api/syscalls/mq.ts
+var mq_exports = {};
+__export(mq_exports, {
+  ack: () => ack,
+  batchAck: () => batchAck,
+  batchSend: () => batchSend,
+  getQueueStats: () => getQueueStats,
+  send: () => send
+});
+function send(queue, body) {
+  return syscall2("mq.send", queue, body);
+}
+function batchSend(queue, bodies) {
+  return syscall2("mq.batchSend", queue, bodies);
+}
+function ack(queue, id) {
+  return syscall2("mq.ack", queue, id);
+}
+function batchAck(queue, ids) {
+  return syscall2("mq.batchAck", queue, ids);
+}
+function getQueueStats(queue) {
+  return syscall2("mq.getQueueStats", queue);
+}
 
-`,await x.setText(n);return}let a=n.length;r=i+`
+// https://jsr.io/@silverbulletmd/silverbullet/0.9.4/plug-api/lib/frontmatter.ts
+async function extractFrontmatter(tree, options = {}) {
+  let data = {
+    tags: []
+  };
+  const tags = [];
+  addParentPointers(tree);
+  await replaceNodesMatchingAsync(tree, async (t) => {
+    if (t.type === "Paragraph" && t.parent?.type === "Document") {
+      let onlyTags = true;
+      const collectedTags = /* @__PURE__ */ new Set();
+      for (const child of t.children) {
+        if (child.text) {
+          if (child.text.startsWith("\n") && child.text !== "\n") {
+            break;
+          }
+          if (child.text.trim()) {
+            onlyTags = false;
+            break;
+          }
+        } else if (child.type === "Hashtag") {
+          const tagname = child.children[0].text.substring(1);
+          collectedTags.add(tagname);
+          if (options.removeTags === true || options.removeTags?.includes(tagname)) {
+            child.children[0].text = "";
+          }
+        } else if (child.type) {
+          onlyTags = false;
+          break;
+        }
+      }
+      if (onlyTags) {
+        tags.push(...collectedTags);
+      }
+    }
+    if (t.type === "FrontMatter") {
+      const yamlNode = t.children[1].children[0];
+      const yamlText = renderToText(yamlNode);
+      try {
+        const parsedData = await yaml_exports.parse(yamlText);
+        const newData = { ...parsedData };
+        data = { ...data, ...parsedData };
+        if (!data.tags) {
+          data.tags = [];
+        }
+        if (typeof data.tags === "string") {
+          tags.push(...data.tags.split(/,\s*|\s+/));
+        }
+        if (Array.isArray(data.tags)) {
+          tags.push(...data.tags);
+        }
+        if (options.removeKeys && options.removeKeys.length > 0) {
+          let removedOne = false;
+          for (const key of options.removeKeys) {
+            if (key in newData) {
+              delete newData[key];
+              removedOne = true;
+            }
+          }
+          if (removedOne) {
+            yamlNode.text = await yaml_exports.stringify(newData);
+          }
+        }
+        if (Object.keys(newData).length === 0 || options.removeFrontmatterSection) {
+          return null;
+        }
+      } catch {
+      }
+    }
+    return void 0;
+  });
+  try {
+    data.tags = [
+      .../* @__PURE__ */ new Set([...tags.map((t) => {
+        const tagAsString = String(t);
+        return tagAsString.replace(/^#/, "");
+      })])
+    ];
+  } catch (e) {
+    console.error("Error while processing tags", e);
+  }
+  data = cleanupJSON(data);
+  return data;
+}
+async function prepareFrontmatterDispatch(tree, data) {
+  let dispatchData = null;
+  await traverseTreeAsync(tree, async (t) => {
+    if (t.type === "FrontMatter") {
+      const bodyNode = t.children[1].children[0];
+      const yamlText = renderToText(bodyNode);
+      try {
+        let frontmatterText = "";
+        if (typeof data === "string") {
+          frontmatterText = yamlText + data + "\n";
+        } else {
+          const parsedYaml = await yaml_exports.parse(yamlText);
+          const newData = { ...parsedYaml, ...data };
+          frontmatterText = await yaml_exports.stringify(newData);
+        }
+        dispatchData = {
+          changes: {
+            from: bodyNode.from,
+            to: bodyNode.to,
+            insert: frontmatterText
+          }
+        };
+      } catch (e) {
+        console.error("Error parsing YAML", e);
+      }
+      return true;
+    }
+    return false;
+  });
+  if (!dispatchData) {
+    let frontmatterText = "";
+    if (typeof data === "string") {
+      frontmatterText = data + "\n";
+    } else {
+      frontmatterText = await yaml_exports.stringify(data);
+    }
+    const fullFrontmatterText = "---\n" + frontmatterText + "---\n";
+    dispatchData = {
+      changes: {
+        from: 0,
+        to: 0,
+        insert: fullFrontmatterText
+      }
+    };
+  }
+  return dispatchData;
+}
 
-`,o.length===0&&(r+=`No results found.
+// https://jsr.io/@silverbulletmd/silverbullet/0.9.4/plug-api/lib/parse_query.ts
+function astToKvQuery(node) {
+  const query2 = {
+    querySource: ""
+  };
+  const [queryType, querySource, ...clauses] = node;
+  if (queryType !== "Query") {
+    throw new Error(`Expected query type, got ${queryType}`);
+  }
+  query2.querySource = querySource[1];
+  for (const clause of clauses) {
+    const [clauseType] = clause;
+    switch (clauseType) {
+      case "WhereClause": {
+        if (query2.filter) {
+          query2.filter = [
+            "and",
+            query2.filter,
+            expressionToKvQueryExpression(clause[2])
+          ];
+        } else {
+          query2.filter = expressionToKvQueryExpression(clause[2]);
+        }
+        break;
+      }
+      case "OrderClause": {
+        if (!query2.orderBy) {
+          query2.orderBy = [];
+        }
+        for (const orderBy of clause.slice(2)) {
+          if (orderBy[0] === "OrderBy") {
+            const expr = orderBy[1][1];
+            if (orderBy[2]) {
+              query2.orderBy.push({
+                expr: expressionToKvQueryExpression(expr),
+                desc: orderBy[2][1][1] === "desc"
+              });
+            } else {
+              query2.orderBy.push({
+                expr: expressionToKvQueryExpression(expr),
+                desc: false
+              });
+            }
+          }
+        }
+        break;
+      }
+      case "LimitClause": {
+        query2.limit = expressionToKvQueryExpression(clause[2][1]);
+        break;
+      }
+      case "SelectClause": {
+        for (const select of clause.slice(2)) {
+          if (select[0] === "Select") {
+            if (!query2.select) {
+              query2.select = [];
+            }
+            if (select.length === 2) {
+              query2.select.push({
+                name: cleanIdentifier(select[1][1])
+              });
+            } else {
+              query2.select.push({
+                name: cleanIdentifier(select[3][1]),
+                expr: expressionToKvQueryExpression(select[1])
+              });
+            }
+          }
+        }
+        break;
+      }
+      case "RenderClause": {
+        const pageRef = clause.find((c) => c[0] === "PageRef");
+        query2.render = pageRef[1].slice(2, -2);
+        query2.renderAll = !!clause.find((c) => c[0] === "all");
+        break;
+      }
+      default:
+        throw new Error(`Unknown clause type: ${clauseType}`);
+    }
+  }
+  return query2;
+}
+function cleanIdentifier(s) {
+  if (s.startsWith("`") && s.endsWith("`")) {
+    return s.slice(1, -1);
+  }
+  return s;
+}
+function expressionToKvQueryExpression(node) {
+  if (["LVal", "Expression", "Value"].includes(node[0])) {
+    return expressionToKvQueryExpression(node[1]);
+  }
+  switch (node[0]) {
+    case "Attribute": {
+      return [
+        "attr",
+        expressionToKvQueryExpression(node[1]),
+        cleanIdentifier(node[3][1])
+      ];
+    }
+    case "Identifier":
+      return ["attr", cleanIdentifier(node[1])];
+    case "String":
+      return ["string", node[1].slice(1, -1)];
+    case "Number":
+      return ["number", +node[1]];
+    case "Bool":
+      return ["boolean", node[1][1] === "true"];
+    case "null":
+      return ["null"];
+    case "Regex":
+      return ["regexp", node[1].slice(1, -1), "i"];
+    case "List": {
+      const exprs = [];
+      for (const expr of node.slice(2)) {
+        if (expr[0] === "Expression") {
+          exprs.push(expr);
+        }
+      }
+      return ["array", exprs.map(expressionToKvQueryExpression)];
+    }
+    case "Object": {
+      const objAttrs = [];
+      for (const kv of node.slice(2)) {
+        if (typeof kv === "string") {
+          continue;
+        }
+        const [_, key, _colon, expr] = kv;
+        objAttrs.push([
+          key[1].slice(1, -1),
+          expressionToKvQueryExpression(
+            expr
+          )
+        ]);
+      }
+      return ["object", objAttrs];
+    }
+    case "BinExpression": {
+      const lval = expressionToKvQueryExpression(node[1]);
+      const binOp = node[2][0] === "InKW" ? "in" : node[2].trim();
+      const val = expressionToKvQueryExpression(node[3]);
+      return [binOp, lval, val];
+    }
+    case "LogicalExpression": {
+      const op1 = expressionToKvQueryExpression(node[1]);
+      const op = node[2];
+      const op2 = expressionToKvQueryExpression(node[3]);
+      return [op[1], op1, op2];
+    }
+    case "ParenthesizedExpression": {
+      return expressionToKvQueryExpression(node[2]);
+    }
+    case "Call": {
+      const fn = cleanIdentifier(node[1][1]);
+      const args = [];
+      for (const expr of node.slice(2)) {
+        if (expr[0] === "Expression") {
+          args.push(expr);
+        }
+      }
+      return ["call", fn, args.map(expressionToKvQueryExpression)];
+    }
+    case "UnaryExpression": {
+      if (node[1][0] === "NotKW" || node[1][0] === "!") {
+        return ["not", expressionToKvQueryExpression(node[2])];
+      } else if (node[1][0] === "-") {
+        return ["-", expressionToKvQueryExpression(node[2])];
+      }
+      throw new Error(`Unknown unary expression: ${node[1][0]}`);
+    }
+    case "TopLevelVal": {
+      return ["attr"];
+    }
+    case "GlobalIdentifier": {
+      return ["global", node[1].substring(1)];
+    }
+    case "TernaryExpression": {
+      const [_, condition, _space, ifTrue, _space2, ifFalse] = node;
+      return [
+        "?",
+        expressionToKvQueryExpression(condition),
+        expressionToKvQueryExpression(ifTrue),
+        expressionToKvQueryExpression(ifFalse)
+      ];
+    }
+    case "QueryExpression": {
+      return ["query", astToKvQuery(node[2])];
+    }
+    case "PageRef": {
+      return ["pageref", node[1].slice(2, -2)];
+    }
+    default:
+      throw new Error(`Not supported: ${node[0]}`);
+  }
+}
+async function parseQuery(query2) {
+  const queryAST = parseTreeToAST(
+    await language_exports.parseLanguage(
+      "query",
+      query2
+    )
+  );
+  return astToKvQuery(queryAST[1]);
+}
 
-`);for(let l of o){r+=`## [[${l.page}]]
-`;for(let h of l.children){let u=h.ref.split("@")[1].padStart(4," ");r+=`> [[${h.ref}|${u}]] | ${h.text}
-`}}await x.replaceRange(0,a,r)}}async function yg(){let e=await x.prompt("Search for: ");e&&await x.navigate({page:`${uh}${e}`})}function bg(e){return e.split("/").slice(0,-1).join("/")}async function Le(e,...t){(await K.getEnv()===e||e==="any")&&console.log(...t)}async function Ds(e){e||(e=await x.getText());let t=await Oe.parseMarkdown(e);await At(t,{removeFrontmatterSection:!0}),e=be(t);let i=e.split(`
-`),r=[],n="user",s="";return i.forEach(o=>{if(o.trim()==="")return;let a=o.match(/^\*\*(\w+)\*\*:/);if(a){let l=a[1].toLowerCase();n&&n!==l&&s.trim()!==""&&(r.push({role:n,content:s.trim()}),s=""),n=l,s+=o.replace(/^\*\*(\w+)\*\*:/,"").trim()+`
-`}else n&&(s+=o.trim()+`
-`)}),s&&n&&r.push({role:n,content:s.trim()}),r}async function wg(){try{let e=await syscall("system.getVersion"),[t,i,r]=e.split(".").map(Number),[n,s,o]="0.7.2".split(".").map(Number);return t>n||t===n&&i>s||t===n&&i===s&&r>=o}catch{return!1}}async function mh(){try{return(await K.listSyscalls()).some(t=>t.name==="system.invokeFunctionOnServer")}catch{return!1}}async function tr(e){let t=[],i,r;try{i=await x.getCurrentPage(),r=await me.getPageMeta(i)}catch(n){return console.error("Error fetching page metadata",n),await x.flashNotification("Error fetching page metadata","error"),[]}for(let n of e){if(n.role==="assistant"||n.role==="system"){t.push(n);continue}let s=ic(og,n.content),o=await ec([],s,!0);if(n.content=n.content.replace(/\[enrich:\s*(false|true)\s*\]\s*/g,""),o.enrich!==void 0&&o.enrich===!1){console.log("Skipping message enrichment due to enrich=false attribute",o),t.push(n);continue}let a=n.content;if(n.role==="user"&&(r?(console.log("Rendering template",n.content,r),a=(await fn(n.content,r,{page:r})).text):console.log("No page metadata found, skipping template rendering")),C.chat.searchEmbeddings&&C.indexEmbeddings){let u=await js(a);u!=="No relevant pages found."&&(a+=`
+// https://jsr.io/@silverbulletmd/silverbullet/0.9.4/plug-api/lib/attribute.ts
+async function extractAttributes(tags, tree) {
+  let attributes = {};
+  await traverseTreeAsync(tree, async (n) => {
+    if (tree !== n && n.type === "ListItem") {
+      return true;
+    }
+    if (n.type === "Attribute") {
+      const nameNode = findNodeOfType(n, "AttributeName");
+      const valueNode = findNodeOfType(n, "AttributeValue");
+      if (nameNode && valueNode) {
+        const name = nameNode.children[0].text;
+        const val = valueNode.children[0].text;
+        try {
+          attributes[name] = cleanupJSON(await yaml_exports.parse(val));
+        } catch (e) {
+          console.error("Error parsing attribute value as YAML", val, e);
+        }
+      }
+      return true;
+    }
+    return false;
+  });
+  const text = renderToText(tree);
+  const spaceScriptAttributes = await system_exports.applyAttributeExtractors(
+    tags,
+    text,
+    tree
+  );
+  attributes = {
+    ...attributes,
+    ...spaceScriptAttributes
+  };
+  return attributes;
+}
+
+// https://deno.land/x/silverbullet@0.9.4/plug-api/lib/tree.ts
+function collectNodesMatching2(tree, matchFn) {
+  if (matchFn(tree)) {
+    return [tree];
+  }
+  let results = [];
+  if (tree.children) {
+    for (const child of tree.children) {
+      results = [...results, ...collectNodesMatching2(child, matchFn)];
+    }
+  }
+  return results;
+}
+function findNodeOfType2(tree, nodeType) {
+  return collectNodesMatching2(tree, (n) => n.type === nodeType)[0];
+}
+function traverseTree(tree, matchFn) {
+  collectNodesMatching2(tree, matchFn);
+}
+
+// https://deno.land/x/silverbullet@0.9.4/plug-api/syscall.ts
+if (typeof self === "undefined") {
+  self = {
+    syscall: () => {
+      throw new Error("Not implemented here");
+    }
+  };
+}
+function syscall3(name, ...args) {
+  return globalThis.syscall(name, ...args);
+}
+
+// https://deno.land/x/silverbullet@0.9.4/plug-api/syscalls/markdown.ts
+var markdown_exports2 = {};
+__export(markdown_exports2, {
+  parseMarkdown: () => parseMarkdown2,
+  renderParseTree: () => renderParseTree2
+});
+function parseMarkdown2(text) {
+  return syscall3("markdown.parseMarkdown", text);
+}
+function renderParseTree2(tree) {
+  return syscall3("markdown.renderParseTree", tree);
+}
+
+// https://deno.land/x/silverbullet@0.9.4/plug-api/syscalls/space.ts
+var space_exports2 = {};
+__export(space_exports2, {
+  deleteAttachment: () => deleteAttachment2,
+  deleteFile: () => deleteFile2,
+  deletePage: () => deletePage2,
+  fileExists: () => fileExists2,
+  getAttachmentMeta: () => getAttachmentMeta2,
+  getFileMeta: () => getFileMeta2,
+  getPageMeta: () => getPageMeta2,
+  listAttachments: () => listAttachments2,
+  listFiles: () => listFiles2,
+  listPages: () => listPages2,
+  listPlugs: () => listPlugs2,
+  readAttachment: () => readAttachment2,
+  readFile: () => readFile2,
+  readPage: () => readPage2,
+  writeAttachment: () => writeAttachment2,
+  writeFile: () => writeFile2,
+  writePage: () => writePage2
+});
+function listPages2() {
+  return syscall3("space.listPages");
+}
+function getPageMeta2(name) {
+  return syscall3("space.getPageMeta", name);
+}
+function readPage2(name) {
+  return syscall3("space.readPage", name);
+}
+function writePage2(name, text) {
+  return syscall3("space.writePage", name, text);
+}
+function deletePage2(name) {
+  return syscall3("space.deletePage", name);
+}
+function listPlugs2() {
+  return syscall3("space.listPlugs");
+}
+function listAttachments2() {
+  return syscall3("space.listAttachments");
+}
+function getAttachmentMeta2(name) {
+  return syscall3("space.getAttachmentMeta", name);
+}
+function readAttachment2(name) {
+  return syscall3("space.readAttachment", name);
+}
+function writeAttachment2(name, data) {
+  return syscall3("space.writeAttachment", name, data);
+}
+function deleteAttachment2(name) {
+  return syscall3("space.deleteAttachment", name);
+}
+function listFiles2() {
+  return syscall3("space.listFiles");
+}
+function readFile2(name) {
+  return syscall3("space.readFile", name);
+}
+function getFileMeta2(name) {
+  return syscall3("space.getFileMeta", name);
+}
+function writeFile2(name, data) {
+  return syscall3("space.writeFile", name, data);
+}
+function deleteFile2(name) {
+  return syscall3("space.deleteFile", name);
+}
+function fileExists2(name) {
+  return syscall3("space.fileExists", name);
+}
+
+// https://deno.land/x/silverbullet@0.9.4/plug-api/syscalls/yaml.ts
+var yaml_exports2 = {};
+__export(yaml_exports2, {
+  parse: () => parse2,
+  stringify: () => stringify2
+});
+function parse2(text) {
+  return syscall3("yaml.parse", text);
+}
+function stringify2(obj) {
+  return syscall3("yaml.stringify", obj);
+}
+
+// https://deno.land/x/silverbullet@0.9.4/plug-api/lib/yaml_page.ts
+async function readCodeBlockPage(pageName, allowedLanguages) {
+  const text = await space_exports2.readPage(pageName);
+  const tree = await markdown_exports2.parseMarkdown(text);
+  let codeText;
+  traverseTree(tree, (t) => {
+    if (t.type !== "FencedCode") {
+      return false;
+    }
+    const codeInfoNode = findNodeOfType2(t, "CodeInfo");
+    if (allowedLanguages && !codeInfoNode) {
+      return false;
+    }
+    if (allowedLanguages && !allowedLanguages.includes(codeInfoNode.children[0].text)) {
+      return false;
+    }
+    const codeTextNode = findNodeOfType2(t, "CodeText");
+    if (!codeTextNode) {
+      return false;
+    }
+    codeText = codeTextNode.children[0].text;
+    return true;
+  });
+  return codeText;
+}
+async function readYamlPage(pageName, allowedLanguages = ["yaml"]) {
+  const codeText = await readCodeBlockPage(pageName, allowedLanguages);
+  if (codeText === void 0) {
+    return void 0;
+  }
+  try {
+    return yaml_exports2.parse(codeText);
+  } catch (e) {
+    console.error("YAML Page parser error", e);
+    throw new Error(`YAML Error: ${e.message}`);
+  }
+}
+
+// https://deno.land/x/silverbullet@0.9.4/plug-api/lib/secrets_page.ts
+async function readSecret(key) {
+  try {
+    const allSecrets = await readYamlPage("SECRETS", ["yaml", "secrets"]);
+    const val = allSecrets[key];
+    if (val === void 0) {
+      throw new Error(`No such secret: ${key}`);
+    }
+    return val;
+  } catch (e) {
+    if (e.message === "Not found") {
+      throw new Error(`No such secret: ${key}`);
+    }
+    throw e;
+  }
+}
+
+// ../../../../../../Users/justyns/dev/silverbullet-ai/use-space-config/src/interfaces/ImageProvider.ts
+var AbstractImageProvider = class {
+  apiKey;
+  baseUrl;
+  name;
+  modelName;
+  requireAuth;
+  constructor(apiKey2, baseUrl, name, modelName, requireAuth = true) {
+    this.apiKey = apiKey2;
+    this.baseUrl = baseUrl;
+    this.name = name;
+    this.modelName = modelName;
+    this.requireAuth = requireAuth;
+  }
+};
+
+// ../../../../../../Users/justyns/dev/silverbullet-ai/use-space-config/src/providers/dalle.ts
+var DallEProvider = class extends AbstractImageProvider {
+  constructor(apiKey2, modelName, baseUrl) {
+    super(apiKey2, baseUrl, "DALL-E", modelName);
+  }
+  async generateImage(options) {
+    try {
+      if (!apiKey)
+        await initializeOpenAI();
+      const response = await nativeFetch(
+        `${this.baseUrl}/images/generations`,
+        {
+          method: "POST",
+          headers: {
+            "Authorization": `Bearer ${this.apiKey}`,
+            "Content-Type": "application/json"
+          },
+          body: JSON.stringify({
+            model: this.modelName,
+            prompt: options.prompt,
+            n: options.numImages,
+            size: options.size,
+            quality: options.quality,
+            response_format: "b64_json"
+          })
+        }
+      );
+      if (!response.ok) {
+        throw new Error(`HTTP error, status: ${response.status}`);
+      }
+      const data = await response.json();
+      if (!data || data.length === 0) {
+        throw new Error("Invalid response from DALL-E.");
+      }
+      return data;
+    } catch (error) {
+      console.error("Error calling DALL\xB7E image generation endpoint:", error);
+      throw error;
+    }
+  }
+};
+
+// ../../../../../../Users/justyns/Library/Caches/deno/deno_esbuild/sse.js@2.2.0/node_modules/sse.js/lib/sse.js
+var SSE = function(url, options) {
+  if (!(this instanceof SSE)) {
+    return new SSE(url, options);
+  }
+  this.INITIALIZING = -1;
+  this.CONNECTING = 0;
+  this.OPEN = 1;
+  this.CLOSED = 2;
+  this.url = url;
+  options = options || {};
+  this.headers = options.headers || {};
+  this.payload = options.payload !== void 0 ? options.payload : "";
+  this.method = options.method || (this.payload && "POST" || "GET");
+  this.withCredentials = !!options.withCredentials;
+  this.debug = !!options.debug;
+  this.FIELD_SEPARATOR = ":";
+  this.listeners = {};
+  this.xhr = null;
+  this.readyState = this.INITIALIZING;
+  this.progress = 0;
+  this.chunk = "";
+  this.addEventListener = function(type, listener) {
+    if (this.listeners[type] === void 0) {
+      this.listeners[type] = [];
+    }
+    if (this.listeners[type].indexOf(listener) === -1) {
+      this.listeners[type].push(listener);
+    }
+  };
+  this.removeEventListener = function(type, listener) {
+    if (this.listeners[type] === void 0) {
+      return;
+    }
+    var filtered = [];
+    this.listeners[type].forEach(function(element) {
+      if (element !== listener) {
+        filtered.push(element);
+      }
+    });
+    if (filtered.length === 0) {
+      delete this.listeners[type];
+    } else {
+      this.listeners[type] = filtered;
+    }
+  };
+  this.dispatchEvent = function(e) {
+    if (!e) {
+      return true;
+    }
+    if (this.debug) {
+      console.debug(e);
+    }
+    e.source = this;
+    var onHandler = "on" + e.type;
+    if (this.hasOwnProperty(onHandler)) {
+      this[onHandler].call(this, e);
+      if (e.defaultPrevented) {
+        return false;
+      }
+    }
+    if (this.listeners[e.type]) {
+      return this.listeners[e.type].every(function(callback) {
+        callback(e);
+        return !e.defaultPrevented;
+      });
+    }
+    return true;
+  };
+  this._setReadyState = function(state) {
+    var event = new CustomEvent("readystatechange");
+    event.readyState = state;
+    this.readyState = state;
+    this.dispatchEvent(event);
+  };
+  this._onStreamFailure = function(e) {
+    var event = new CustomEvent("error");
+    event.data = e.currentTarget.response;
+    this.dispatchEvent(event);
+    this.close();
+  };
+  this._onStreamAbort = function(e) {
+    this.dispatchEvent(new CustomEvent("abort"));
+    this.close();
+  };
+  this._onStreamProgress = function(e) {
+    if (!this.xhr) {
+      return;
+    }
+    if (this.xhr.status !== 200) {
+      this._onStreamFailure(e);
+      return;
+    }
+    if (this.readyState == this.CONNECTING) {
+      this.dispatchEvent(new CustomEvent("open"));
+      this._setReadyState(this.OPEN);
+    }
+    var data = this.xhr.responseText.substring(this.progress);
+    this.progress += data.length;
+    var parts = (this.chunk + data).split(/(\r\n\r\n|\r\r|\n\n)/g);
+    var lastPart = parts.pop();
+    parts.forEach(function(part) {
+      if (part.trim().length > 0) {
+        this.dispatchEvent(this._parseEventChunk(part));
+      }
+    }.bind(this));
+    this.chunk = lastPart;
+  };
+  this._onStreamLoaded = function(e) {
+    this._onStreamProgress(e);
+    this.dispatchEvent(this._parseEventChunk(this.chunk));
+    this.chunk = "";
+  };
+  this._parseEventChunk = function(chunk) {
+    if (!chunk || chunk.length === 0) {
+      return null;
+    }
+    if (this.debug) {
+      console.debug(chunk);
+    }
+    var e = { "id": null, "retry": null, "data": null, "event": null };
+    chunk.split(/\n|\r\n|\r/).forEach(function(line) {
+      var index = line.indexOf(this.FIELD_SEPARATOR);
+      var field, value;
+      if (index > 0) {
+        var skip = line[index + 1] === " " ? 2 : 1;
+        field = line.substring(0, index);
+        value = line.substring(index + skip);
+      } else if (index < 0) {
+        field = line;
+        value = "";
+      } else {
+        return;
+      }
+      if (!(field in e)) {
+        return;
+      }
+      if (field === "data" && e[field] !== null) {
+        e["data"] += "\n" + value;
+      } else {
+        e[field] = value;
+      }
+    }.bind(this));
+    var event = new CustomEvent(e.event || "message");
+    event.data = e.data || "";
+    event.id = e.id;
+    return event;
+  };
+  this._checkStreamClosed = function() {
+    if (!this.xhr) {
+      return;
+    }
+    if (this.xhr.readyState === XMLHttpRequest.DONE) {
+      this._setReadyState(this.CLOSED);
+    }
+  };
+  this.stream = function() {
+    if (this.xhr) {
+      return;
+    }
+    this._setReadyState(this.CONNECTING);
+    this.xhr = new XMLHttpRequest();
+    this.xhr.addEventListener("progress", this._onStreamProgress.bind(this));
+    this.xhr.addEventListener("load", this._onStreamLoaded.bind(this));
+    this.xhr.addEventListener("readystatechange", this._checkStreamClosed.bind(this));
+    this.xhr.addEventListener("error", this._onStreamFailure.bind(this));
+    this.xhr.addEventListener("abort", this._onStreamAbort.bind(this));
+    this.xhr.open(this.method, this.url);
+    for (var header in this.headers) {
+      this.xhr.setRequestHeader(header, this.headers[header]);
+    }
+    this.xhr.withCredentials = this.withCredentials;
+    this.xhr.send(this.payload);
+  };
+  this.close = function() {
+    if (this.readyState === this.CLOSED) {
+      return;
+    }
+    this.xhr.abort();
+    this.xhr = null;
+    this._setReadyState(this.CLOSED);
+  };
+  if (options.start === void 0 || options.start) {
+    this.stream();
+  }
+};
+if (typeof exports !== "undefined") {
+  exports.SSE = SSE;
+}
+
+// ../../../../../../Users/justyns/dev/silverbullet-ai/use-space-config/src/cache.ts
+var cache = {};
+function setCache(key, value) {
+  cache[key] = value;
+}
+function getCache(key) {
+  return cache[key];
+}
+async function hashStrings(...inputs) {
+  const concatenatedInput = inputs.join("");
+  const textAsBuffer = new TextEncoder().encode(concatenatedInput);
+  const hashBuffer = await crypto.subtle.digest("SHA-256", textAsBuffer);
+  const hashArray = Array.from(new Uint8Array(hashBuffer));
+  const hash = hashArray.map((item) => item.toString(16).padStart(2, "0")).join("");
+  return hash;
+}
+
+// ../../../../../../Users/justyns/dev/silverbullet-ai/use-space-config/src/interfaces/EmbeddingProvider.ts
+var AbstractEmbeddingProvider = class {
+  apiKey;
+  baseUrl;
+  name;
+  modelName;
+  requireAuth;
+  constructor(apiKey2, baseUrl, name, modelName, requireAuth = true) {
+    this.apiKey = apiKey2;
+    this.baseUrl = baseUrl;
+    this.name = name;
+    this.modelName = modelName;
+    this.requireAuth = requireAuth;
+  }
+  async generateEmbeddings(options) {
+    const cacheKey = await hashStrings(
+      this.modelName,
+      options.text
+    );
+    const cachedEmbedding = getCache(cacheKey);
+    if (cachedEmbedding) {
+      return cachedEmbedding;
+    }
+    const embedding = await this._generateEmbeddings(options);
+    setCache(cacheKey, embedding);
+    return embedding;
+  }
+};
+
+// ../../../../../../Users/justyns/dev/silverbullet-ai/use-space-config/src/editorUtils.ts
+async function getSelectedText() {
+  const selectedRange = await editor_exports.getSelection();
+  let selectedText = "";
+  if (selectedRange.from === selectedRange.to) {
+    selectedText = "";
+  } else {
+    const pageText = await editor_exports.getText();
+    selectedText = pageText.slice(selectedRange.from, selectedRange.to);
+  }
+  return {
+    from: selectedRange.from,
+    to: selectedRange.to,
+    text: selectedText
+  };
+}
+async function getSelectedTextOrNote() {
+  const selectedTextInfo = await getSelectedText();
+  const pageText = await editor_exports.getText();
+  if (selectedTextInfo.text === "") {
+    return {
+      from: 0,
+      to: pageText.length,
+      text: pageText,
+      isWholeNote: true
+    };
+  }
+  const isWholeNote = selectedTextInfo.from === 0 && selectedTextInfo.to === pageText.length;
+  return {
+    ...selectedTextInfo,
+    isWholeNote
+  };
+}
+async function getPageLength() {
+  const pageText = await editor_exports.getText();
+  return pageText.length;
+}
+
+// ../../../../../../Users/justyns/dev/silverbullet-ai/use-space-config/src/interfaces/Provider.ts
+var AbstractProvider = class {
+  name;
+  apiKey;
+  baseUrl;
+  modelName;
+  constructor(name, apiKey2, baseUrl, modelName) {
+    this.name = name;
+    this.apiKey = apiKey2;
+    this.baseUrl = baseUrl;
+    this.modelName = modelName;
+  }
+  async streamChatIntoEditor(options, cursorStart) {
+    const { onDataReceived } = options;
+    const loadingMessage = "\u{1F914} Thinking \u2026 ";
+    let cursorPos = cursorStart ?? await getPageLength();
+    await editor_exports.insertAtPos(loadingMessage, cursorPos);
+    let stillLoading = true;
+    const onData = (data) => {
+      try {
+        if (!data) {
+          console.log("No data received from LLM");
+          return;
+        }
+        if (stillLoading) {
+          if (["`", "-", "*"].includes(data.charAt(0))) {
+            console.log("First character of response is:", data.charAt(0));
+            data = "\n" + data;
+          }
+          editor_exports.replaceRange(
+            cursorPos,
+            cursorPos + loadingMessage.length,
+            data
+          );
+          stillLoading = false;
+        } else {
+          editor_exports.insertAtPos(data, cursorPos);
+        }
+        cursorPos += data.length;
+        if (onDataReceived)
+          onDataReceived(data);
+      } catch (error) {
+        console.error("Error handling chat stream data:", error);
+        editor_exports.flashNotification(
+          "An error occurred while processing chat data.",
+          "error"
+        );
+      }
+    };
+    await this.chatWithAI({ ...options, onDataReceived: onData });
+  }
+  async singleMessageChat(userMessage, systemPrompt, enrichMessages = false) {
+    let messages = [
+      {
+        role: "user",
+        content: userMessage
+      }
+    ];
+    if (systemPrompt) {
+      messages.unshift({
+        role: "system",
+        content: systemPrompt
+      });
+    }
+    if (enrichMessages) {
+      messages = await enrichChatMessages(messages);
+    }
+    return await this.chatWithAI({
+      messages,
+      stream: false
+    });
+  }
+};
+
+// ../../../../../../Users/justyns/dev/silverbullet-ai/use-space-config/src/providers/gemini.ts
+var GeminiProvider = class extends AbstractProvider {
+  name = "Gemini";
+  constructor(apiKey2, modelName) {
+    const baseUrl = "https://generativelanguage.googleapis.com";
+    super("Gemini", apiKey2, baseUrl, modelName);
+  }
+  async listModels() {
+    const apiUrl = `${this.baseUrl}/v1beta/models?key=${this.apiKey}`;
+    try {
+      const response = await fetch(apiUrl);
+      if (!response.ok) {
+        throw new Error(`HTTP error! status: ${response.status}`);
+      }
+      const data = await response.json();
+      return data.models || [];
+    } catch (error) {
+      console.error("Failed to fetch models:", error);
+      throw error;
+    }
+  }
+  async chatWithAI({ messages, stream, onDataReceived }) {
+    if (stream) {
+      return await this.streamChat({ messages, stream, onDataReceived });
+    } else {
+      return await this.nonStreamingChat(messages);
+    }
+  }
+  mapRolesForGemini(messages) {
+    const payloadContents = [];
+    let previousRole = "";
+    messages.forEach((message) => {
+      let role = "user";
+      if (message.role === "system" || message.role === "user") {
+        role = "user";
+      } else if (message.role === "assistant") {
+        role = "model";
+      }
+      if (role === "model" && (payloadContents.length === 0 || previousRole === "model")) {
+      } else if (role === "user" && previousRole === "user") {
+        payloadContents[payloadContents.length - 1].parts[0].text += " " + message.content;
+      } else {
+        payloadContents.push({
+          role,
+          parts: [{ text: message.content }]
+        });
+      }
+      previousRole = role;
+    });
+    return payloadContents;
+  }
+  streamChat(options) {
+    const { messages, onDataReceived } = options;
+    try {
+      const sseUrl = `${this.baseUrl}/v1beta/models/${this.modelName}:streamGenerateContent?key=${this.apiKey}&alt=sse`;
+      const headers = {
+        "Content-Type": "application/json"
+      };
+      const payloadContents = this.mapRolesForGemini(
+        messages
+      );
+      const sseOptions = {
+        method: "POST",
+        headers,
+        payload: JSON.stringify({
+          contents: payloadContents
+        }),
+        withCredentials: false
+      };
+      const source = new SSE(sseUrl, sseOptions);
+      let fullMsg = "";
+      source.addEventListener("message", (e) => {
+        try {
+          if (e.data == "[DONE]") {
+            source.close();
+            return fullMsg;
+          } else if (!e.data) {
+            console.error("Received empty message from Gemini");
+            console.log("source: ", source);
+          } else {
+            const data = JSON.parse(e.data);
+            const msg = data.candidates[0].content.parts[0].text || data.text || "";
+            fullMsg += msg;
+            if (onDataReceived)
+              onDataReceived(msg);
+          }
+        } catch (error) {
+          console.error("Error processing message event:", error, e.data);
+        }
+      });
+      source.addEventListener("end", () => {
+        source.close();
+        return fullMsg;
+      });
+      source.addEventListener("error", (e) => {
+        console.error("SSE error:", e);
+        source.close();
+      });
+      source.stream();
+    } catch (error) {
+      console.error("Error streaming from Gemini chat endpoint:", error);
+      throw error;
+    }
+  }
+  async nonStreamingChat(messages) {
+    const payloadContents = this.mapRolesForGemini(
+      messages
+    );
+    const response = await nativeFetch(
+      `${this.baseUrl}/v1beta/models/${this.modelName}:generateContent?key=${this.apiKey}`,
+      {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json"
+        },
+        body: JSON.stringify({ contents: payloadContents })
+      }
+    );
+    if (!response.ok) {
+      throw new Error(`HTTP error! status: ${response.status}`);
+    }
+    const responseData = await response.json();
+    return responseData.candidates[0].content.parts[0].text;
+  }
+};
+var GeminiEmbeddingProvider = class extends AbstractEmbeddingProvider {
+  constructor(apiKey2, modelName, baseUrl = "https://generativelanguage.googleapis.com", requireAuth = true) {
+    super(apiKey2, baseUrl, "Gemini", modelName, requireAuth);
+  }
+  async _generateEmbeddings(options) {
+    const body = JSON.stringify({
+      model: this.modelName,
+      content: {
+        parts: [{ text: options.text }]
+      }
+    });
+    const headers = {
+      "Content-Type": "application/json"
+    };
+    if (this.requireAuth) {
+      headers["Authorization"] = `Bearer ${this.apiKey}`;
+    }
+    const response = await nativeFetch(
+      `${this.baseUrl}/v1beta/models/${this.modelName}:embedContent?key=${this.apiKey}`,
+      {
+        method: "POST",
+        headers,
+        body
+      }
+    );
+    if (!response.ok) {
+      console.error("HTTP response: ", response);
+      console.error("HTTP response body: ", await response.json());
+      throw new Error(`HTTP error, status: ${response.status}`);
+    }
+    const data = await response.json();
+    if (!data || !data.embedding || !data.embedding.values) {
+      throw new Error("Invalid response from Gemini.");
+    }
+    return data.embedding.values;
+  }
+};
+
+// ../../../../../../Users/justyns/dev/silverbullet-ai/use-space-config/src/providers/openai.ts
+var OpenAIProvider = class extends AbstractProvider {
+  name = "OpenAI";
+  requireAuth;
+  constructor(apiKey2, modelName, baseUrl, requireAuth) {
+    super("OpenAI", apiKey2, baseUrl, modelName);
+    this.requireAuth = requireAuth;
+  }
+  async chatWithAI({ messages, stream, onDataReceived }) {
+    if (stream) {
+      return await this.streamChat({ messages, onDataReceived });
+    } else {
+      return await this.nonStreamingChat(messages);
+    }
+  }
+  async streamChat(options) {
+    const { messages, onDataReceived } = options;
+    try {
+      const sseUrl = `${this.baseUrl}/chat/completions`;
+      const headers = {
+        "Content-Type": "application/json"
+      };
+      if (this.requireAuth) {
+        headers["Authorization"] = `Bearer ${this.apiKey}`;
+      }
+      const sseOptions = {
+        method: "POST",
+        headers,
+        payload: JSON.stringify({
+          model: this.modelName,
+          stream: true,
+          messages
+        }),
+        withCredentials: false
+      };
+      const source = new SSE(sseUrl, sseOptions);
+      let fullMsg = "";
+      source.addEventListener("message", function(e) {
+        try {
+          if (e.data == "[DONE]") {
+            source.close();
+            return fullMsg;
+          } else {
+            const data = JSON.parse(e.data);
+            const msg = data.choices[0]?.delta?.content || "";
+            fullMsg += msg;
+            if (onDataReceived) {
+              onDataReceived(msg);
+            }
+          }
+        } catch (error) {
+          console.error("Error processing message event:", error, e.data);
+        }
+      });
+      source.addEventListener("end", function() {
+        source.close();
+        return fullMsg;
+      });
+      source.addEventListener("error", (e) => {
+        console.error("SSE error:", e);
+        source.close();
+      });
+      source.stream();
+    } catch (error) {
+      console.error("Error streaming from OpenAI chat endpoint:", error);
+      await editor_exports.flashNotification(
+        "Error streaming from OpenAI chat endpoint.",
+        "error"
+      );
+      throw error;
+    }
+    return "";
+  }
+  async nonStreamingChat(messages) {
+    try {
+      const body = JSON.stringify({
+        model: this.modelName,
+        messages
+      });
+      const headers = {
+        "Authorization": `Bearer ${this.apiKey}`,
+        "Content-Type": "application/json"
+      };
+      const response = await nativeFetch(
+        this.baseUrl + "/chat/completions",
+        {
+          method: "POST",
+          headers,
+          body
+        }
+      );
+      if (!response.ok) {
+        console.error("http response: ", response);
+        console.error("http response body: ", await response.json());
+        throw new Error(`HTTP error, status: ${response.status}`);
+      }
+      const data = await response.json();
+      if (!data || !data.choices || data.choices.length === 0) {
+        throw new Error("Invalid response from OpenAI.");
+      }
+      return data.choices[0].message.content;
+    } catch (error) {
+      console.error("Error calling OpenAI chat endpoint:", error);
+      await editor_exports.flashNotification(
+        "Error calling OpenAI chat endpoint.",
+        "error"
+      );
+      throw error;
+    }
+  }
+};
+var OpenAIEmbeddingProvider = class extends AbstractEmbeddingProvider {
+  constructor(apiKey2, modelName, baseUrl, requireAuth = true) {
+    super(apiKey2, baseUrl, "OpenAI", modelName, requireAuth);
+  }
+  async _generateEmbeddings(options) {
+    const body = JSON.stringify({
+      model: this.modelName,
+      input: options.text,
+      encoding_format: "float"
+    });
+    const headers = {
+      "Content-Type": "application/json"
+    };
+    if (this.requireAuth) {
+      headers["Authorization"] = `Bearer ${this.apiKey}`;
+    }
+    const response = await nativeFetch(
+      `${this.baseUrl}/embeddings`,
+      {
+        method: "POST",
+        headers,
+        body
+      }
+    );
+    if (!response.ok) {
+      console.error("HTTP response: ", response);
+      console.error("HTTP response body: ", await response.json());
+      throw new Error(`HTTP error, status: ${response.status}`);
+    }
+    const data = await response.json();
+    if (!data || !data.data || data.data.length === 0) {
+      throw new Error("Invalid response from OpenAI.");
+    }
+    return data.data[0].embedding;
+  }
+};
+
+// ../../../../../../Users/justyns/dev/silverbullet-ai/use-space-config/src/providers/ollama.ts
+var OllamaProvider = class extends AbstractProvider {
+  name = "Ollama";
+  requireAuth;
+  openaiProvider;
+  constructor(apiKey2, modelName, baseUrl, requireAuth) {
+    super("Ollama", apiKey2, baseUrl, modelName);
+    this.requireAuth = requireAuth;
+    this.openaiProvider = new OpenAIProvider(
+      apiKey2,
+      modelName,
+      baseUrl,
+      requireAuth
+    );
+  }
+  async chatWithAI({ messages, stream, onDataReceived }) {
+    return await this.openaiProvider.chatWithAI({
+      messages,
+      stream,
+      onDataReceived
+    });
+  }
+};
+var OllamaEmbeddingProvider = class extends AbstractEmbeddingProvider {
+  constructor(apiKey2, modelName, baseUrl, requireAuth = false) {
+    super(apiKey2, baseUrl, "Ollama", modelName, requireAuth);
+  }
+  // Ollama doesn't have an openai compatible api for embeddings yet, so it gets its own provider
+  async _generateEmbeddings(options) {
+    const body = JSON.stringify({
+      model: this.modelName,
+      prompt: options.text
+    });
+    const headers = {
+      "Content-Type": "application/json"
+    };
+    if (this.requireAuth) {
+      headers["Authorization"] = `Bearer ${this.apiKey}`;
+    }
+    const response = await nativeFetch(
+      `${this.baseUrl}/api/embeddings`,
+      {
+        method: "POST",
+        headers,
+        body
+      }
+    );
+    if (!response.ok) {
+      console.error("HTTP response: ", response);
+      console.error("HTTP response body: ", await response.json());
+      throw new Error(`HTTP error, status: ${response.status}`);
+    }
+    const data = await response.json();
+    if (!data || !data.embedding || data.embedding.length === 0) {
+      throw new Error("Invalid response from Ollama.");
+    }
+    return data.embedding;
+  }
+};
+
+// ../../../../../../Users/justyns/dev/silverbullet-ai/use-space-config/src/mocks/mockproviders.ts
+var MockProvider = class extends AbstractProvider {
+  constructor(apiKey2, modelName, baseUrl = "http://localhost") {
+    super(apiKey2, baseUrl, "mock", modelName);
+  }
+  async chatWithAI(options) {
+    const mockResponse = "This is a mock response from the AI.";
+    if (options.onDataReceived) {
+      for (const char of mockResponse) {
+        await new Promise((resolve) => setTimeout(resolve, 50));
+        options.onDataReceived(char);
+      }
+    }
+    return mockResponse;
+  }
+};
+var MockImageProvider = class extends AbstractImageProvider {
+  constructor(apiKey2, modelName, baseUrl = "http://localhost") {
+    super(apiKey2, baseUrl, "mock", modelName);
+  }
+  generateImage(options) {
+    return new Promise((resolve) => {
+      setTimeout(() => {
+        resolve("https://example.com/mock-image.jpg");
+      }, 5);
+    });
+  }
+};
+var MockEmbeddingProvider = class extends AbstractEmbeddingProvider {
+  constructor(apiKey2, modelName, baseUrl = "http://localhost") {
+    super(apiKey2, baseUrl, "mock", modelName);
+  }
+  _generateEmbeddings(options) {
+    return new Promise((resolve) => {
+      setTimeout(() => {
+        const mockEmbedding = Array(1536).fill(0).map(() => Math.random());
+        resolve(mockEmbedding);
+      }, 5);
+    });
+  }
+};
+
+// ../../../../../../Users/justyns/dev/silverbullet-ai/use-space-config/src/init.ts
+var apiKey;
+var aiSettings;
+var chatSystemPrompt;
+var currentAIProvider;
+var currentImageProvider;
+var currentEmbeddingProvider;
+var currentModel;
+var currentImageModel;
+var currentEmbeddingModel;
+async function initIfNeeded() {
+  const selectedModel = await getSelectedTextModel();
+  if (!apiKey || !currentAIProvider || !aiSettings || !currentModel || JSON.stringify(selectedModel) !== JSON.stringify(currentModel)) {
+    await initializeOpenAI(true);
+  }
+}
+async function getSelectedTextModel() {
+  if (await system_exports.getEnv() == "server") {
+    return void 0;
+  }
+  try {
+    return await clientStore_exports.get("ai.selectedTextModel");
+  } catch (error) {
+    return void 0;
+  }
+}
+async function getSelectedImageModel() {
+  if (await system_exports.getEnv() == "server") {
+    return void 0;
+  }
+  try {
+    return await clientStore_exports.get("ai.selectedImageModel");
+  } catch (error) {
+    return void 0;
+  }
+}
+async function getSelectedEmbeddingModel() {
+  if (await system_exports.getEnv() == "server") {
+    return;
+  }
+  try {
+    return await clientStore_exports.get("ai.selectedEmbeddingModel");
+  } catch (error) {
+    return void 0;
+  }
+}
+async function setSelectedImageModel(model) {
+  if (await system_exports.getEnv() == "server") {
+    return;
+  }
+  await clientStore_exports.set("ai.selectedImageModel", model);
+}
+async function setSelectedTextModel(model) {
+  if (await system_exports.getEnv() == "server") {
+    return;
+  }
+  await clientStore_exports.set("ai.selectedTextModel", model);
+}
+async function setSelectedEmbeddingModel(model) {
+  if (await system_exports.getEnv() == "server") {
+    return;
+  }
+  await clientStore_exports.set("ai.selectedEmbeddingModel", model);
+}
+async function getAndConfigureModel() {
+  const selectedModel = await getSelectedTextModel() || aiSettings.textModels[0];
+  if (!selectedModel) {
+    throw new Error("No text model selected or available as default.");
+  }
+  await configureSelectedModel(selectedModel);
+}
+async function getAndConfigureImageModel() {
+  const selectedImageModel = await getSelectedImageModel() || aiSettings.imageModels[0];
+  if (!selectedImageModel) {
+    throw new Error("No image model selected or available as default.");
+  }
+  await configureSelectedImageModel(selectedImageModel);
+}
+async function getAndConfigureEmbeddingModel() {
+  const selectedEmbeddingModel = await getSelectedEmbeddingModel() || aiSettings.embeddingModels[0];
+  if (!selectedEmbeddingModel) {
+    throw new Error("No embedding model selected or available as default.");
+  }
+  await configureSelectedEmbeddingModel(selectedEmbeddingModel);
+}
+function setupImageProvider(model) {
+  const providerName = model.provider.toLowerCase();
+  log("client", "Provider name", providerName);
+  switch (providerName) {
+    case "dalle" /* DallE */:
+      currentImageProvider = new DallEProvider(
+        apiKey,
+        model.modelName,
+        model.baseUrl || aiSettings.dallEBaseUrl
+      );
+      break;
+    case "mock" /* Mock */:
+      currentImageProvider = new MockImageProvider(
+        apiKey,
+        model.modelName
+      );
+      break;
+    default:
+      throw new Error(
+        `Unsupported image provider: ${model.provider}. Please configure a supported provider.`
+      );
+  }
+}
+function setupAIProvider(model) {
+  const providerName = model.provider.toLowerCase();
+  switch (providerName) {
+    case "openai" /* OpenAI */:
+      currentAIProvider = new OpenAIProvider(
+        apiKey,
+        model.modelName,
+        model.baseUrl || aiSettings.openAIBaseUrl,
+        model.requireAuth || aiSettings.requireAuth
+      );
+      break;
+    case "gemini" /* Gemini */:
+      currentAIProvider = new GeminiProvider(apiKey, model.modelName);
+      break;
+    case "ollama" /* Ollama */:
+      currentAIProvider = new OllamaProvider(
+        apiKey,
+        model.modelName,
+        model.baseUrl || "http://localhost:11434/v1",
+        model.requireAuth
+      );
+      break;
+    case "mock" /* Mock */:
+      currentAIProvider = new MockProvider(
+        apiKey,
+        model.modelName,
+        model.baseUrl
+      );
+      break;
+    default:
+      throw new Error(
+        `Unsupported AI provider: ${model.provider}. Please configure a supported provider.`
+      );
+  }
+  return currentAIProvider;
+}
+function setupEmbeddingProvider(model) {
+  const providerName = model.provider.toLowerCase();
+  switch (providerName) {
+    case "openai" /* OpenAI */:
+      currentEmbeddingProvider = new OpenAIEmbeddingProvider(
+        apiKey,
+        model.modelName,
+        model.baseUrl || aiSettings.openAIBaseUrl
+      );
+      break;
+    case "gemini" /* Gemini */:
+      currentEmbeddingProvider = new GeminiEmbeddingProvider(
+        apiKey,
+        model.modelName
+      );
+      break;
+    case "ollama" /* Ollama */:
+      currentEmbeddingProvider = new OllamaEmbeddingProvider(
+        apiKey,
+        model.modelName,
+        model.baseUrl || "http://localhost:11434",
+        model.requireAuth
+      );
+      break;
+    case "mock" /* Mock */:
+      currentEmbeddingProvider = new MockEmbeddingProvider(
+        apiKey,
+        model.modelName,
+        model.baseUrl
+      );
+      break;
+    default:
+      throw new Error(
+        `Unsupported embedding provider: ${model.provider}. Please configure a supported provider.`
+      );
+  }
+}
+async function configureSelectedModel(model) {
+  log("client", "configureSelectedModel called with:", model);
+  if (!model) {
+    throw new Error("No model provided to configure");
+  }
+  model.requireAuth = model.requireAuth ?? aiSettings.requireAuth;
+  if (model.requireAuth) {
+    try {
+      const newApiKey = await readSecret(model.secretName || "OPENAI_API_KEY");
+      if (newApiKey !== apiKey) {
+        apiKey = newApiKey;
+        log("client", "API key updated");
+      }
+    } catch (error) {
+      console.error("Error reading secret:", error);
+      throw new Error(
+        "Failed to read the AI API key. Please check the SECRETS page."
+      );
+    }
+  }
+  if (model.requireAuth && !apiKey) {
+    throw new Error(
+      "AI API key is missing. Please set it in the secrets page."
+    );
+  }
+  currentModel = model;
+  return setupAIProvider(model);
+}
+async function configureSelectedImageModel(model) {
+  log("client", "configureSelectedImageModel called with:", model);
+  if (!model) {
+    throw new Error("No image model provided to configure");
+  }
+  if (model.requireAuth) {
+    const newApiKey = await readSecret(model.secretName || "OPENAI_API_KEY");
+    if (newApiKey !== apiKey) {
+      apiKey = newApiKey;
+      log("client", "API key updated for image model");
+    }
+  }
+  if (model.requireAuth && !apiKey) {
+    throw new Error(
+      "AI API key is missing for image model. Please set it in the secrets page."
+    );
+  }
+  currentImageModel = model;
+  setupImageProvider(model);
+}
+async function configureSelectedEmbeddingModel(model) {
+  log("client", "configureSelectedEmbeddingModel called with:", model);
+  if (!model) {
+    throw new Error("No embedding model provided to configure");
+  }
+  if (model.requireAuth) {
+    const newApiKey = await readSecret(model.secretName || "OPENAI_API_KEY");
+    if (newApiKey !== apiKey) {
+      apiKey = newApiKey;
+      log("client", "API key updated for embedding model");
+    }
+  }
+  if (model.requireAuth && !apiKey) {
+    throw new Error(
+      "AI API key is missing for embedding model. Please set it in the secrets page."
+    );
+  }
+  currentEmbeddingModel = model;
+  setupEmbeddingProvider(model);
+}
+async function loadAndMergeSettings() {
+  const defaultSettings = {
+    openAIBaseUrl: "https://api.openai.com/v1",
+    dallEBaseUrl: "https://api.openai.com/v1",
+    requireAuth: true,
+    secretName: "OPENAI_API_KEY",
+    provider: "OpenAI",
+    chat: {},
+    promptInstructions: {},
+    imageModels: [],
+    embeddingModels: [],
+    textModels: [],
+    indexEmbeddings: false,
+    indexSummary: false,
+    indexSummaryModelName: "",
+    indexEmbeddingsExcludePages: [],
+    indexEmbeddingsExcludeStrings: ["**user**:"]
+  };
+  const defaultChatSettings = {
+    userInformation: "",
+    userInstructions: "",
+    parseWikiLinks: true,
+    bakeMessages: true,
+    customEnrichFunctions: [],
+    searchEmbeddings: false
+  };
+  const defaultPromptInstructions = {
+    pageRenameSystem: "",
+    pageRenameRules: "",
+    tagRules: "",
+    indexSummaryPrompt: "",
+    enhanceFrontMatterPrompt: ""
+  };
+  const newSettings = await system_exports.getSpaceConfig("ai", {});
+  const newCombinedSettings = { ...defaultSettings, ...newSettings };
+  newCombinedSettings.chat = {
+    ...defaultChatSettings,
+    ...newSettings.chat || {}
+  };
+  newCombinedSettings.promptInstructions = {
+    ...defaultPromptInstructions,
+    ...newSettings.promptInstructions || {}
+  };
+  return newCombinedSettings;
+}
+async function initializeOpenAI(configure = true) {
+  const newCombinedSettings = await loadAndMergeSettings();
+  if (!aiSettings || JSON.stringify(aiSettings) !== JSON.stringify(newCombinedSettings)) {
+    log("client", "aiSettings updating from", aiSettings);
+    aiSettings = newCombinedSettings;
+    log("client", "aiSettings updated to", aiSettings);
+  } else {
+    log("client", "aiSettings unchanged", aiSettings);
+  }
+  if (aiSettings.textModels.length === 1) {
+    await setSelectedTextModel(aiSettings.textModels[0]);
+  }
+  if (aiSettings.imageModels.length === 1) {
+    await setSelectedImageModel(aiSettings.imageModels[0]);
+  }
+  if (aiSettings.embeddingModels.length === 1) {
+    await setSelectedEmbeddingModel(aiSettings.embeddingModels[0]);
+  }
+  if (configure) {
+    if (aiSettings.textModels.length > 0) {
+      await getAndConfigureModel();
+    }
+    if (aiSettings.imageModels.length > 0) {
+      await getAndConfigureImageModel();
+    }
+    if (aiSettings.embeddingModels.length > 0) {
+      await getAndConfigureEmbeddingModel();
+    }
+  }
+  chatSystemPrompt = {
+    role: "system",
+    content: `This is an interactive chat session with a user in a markdown-based note-taking tool called SilverBullet.`
+  };
+  if (aiSettings.chat.userInformation) {
+    chatSystemPrompt.content += `
+The user has provided the following information about themselves: ${aiSettings.chat.userInformation}`;
+  }
+  if (aiSettings.chat.userInstructions) {
+    chatSystemPrompt.content += `
+The user has provided the following instructions for the chat, follow them as closely as possible: ${aiSettings.chat.userInstructions}`;
+  }
+}
+
+// ../../../../../../Users/justyns/dev/silverbullet-ai/use-space-config/src/embeddings.ts
+var searchPrefix = "\u{1F916} ";
+function canIndexPage(pageName) {
+  const excludePages = [
+    "SETTINGS",
+    "SECRETS",
+    ...aiSettings.indexEmbeddingsExcludePages
+  ];
+  if (excludePages.includes(pageName) || pageName.startsWith("_") || pageName.startsWith("Library/") || /\.conflicted\.\d+$/.test(pageName)) {
+    return false;
+  }
+  return true;
+}
+async function shouldIndexEmbeddings() {
+  await initIfNeeded();
+  return aiSettings.indexEmbeddings && currentEmbeddingProvider !== void 0 && currentEmbeddingModel !== void 0 && aiSettings.embeddingModels.length > 0 && await system_exports.getEnv() === "server";
+}
+async function shouldIndexSummaries() {
+  await initIfNeeded();
+  return aiSettings.indexEmbeddings && aiSettings.indexSummary && currentEmbeddingProvider !== void 0 && currentEmbeddingModel !== void 0 && aiSettings.embeddingModels.length > 0 && await system_exports.getEnv() === "server";
+}
+async function indexEmbeddings(page) {
+  if (!await shouldIndexEmbeddings()) {
+    return;
+  }
+  if (!canIndexPage(page)) {
+    return;
+  }
+  const pageText = await space_exports.readPage(page);
+  const tree = await markdown_exports.parseMarkdown(pageText);
+  if (!tree.children) {
+    return;
+  }
+  const paragraphs = tree.children.filter((node) => node.type === "Paragraph");
+  const objects = [];
+  const startTime = Date.now();
+  for (const paragraph of paragraphs) {
+    const paragraphText = renderToText(paragraph).trim();
+    if (!paragraphText || paragraphText.length < 10) {
+      continue;
+    }
+    if (aiSettings.indexEmbeddingsExcludeStrings.some(
+      (s) => paragraphText.includes(s)
+    )) {
+      continue;
+    }
+    const embedding = await currentEmbeddingProvider.generateEmbeddings({
+      text: paragraphText
+    });
+    const pos = paragraph.from ?? 0;
+    const embeddingObject = {
+      ref: `${page}@${pos}`,
+      page,
+      pos,
+      embedding,
+      text: paragraphText,
+      tag: "embedding"
+    };
+    objects.push(embeddingObject);
+  }
+  await indexObjects(page, objects);
+  const endTime = Date.now();
+  const duration = (endTime - startTime) / 1e3;
+  log(
+    "any",
+    `AI: Indexed ${objects.length} embedding objects for page ${page} in ${duration} seconds`
+  );
+}
+async function indexSummary(page) {
+  if (!await shouldIndexSummaries()) {
+    return;
+  }
+  if (!canIndexPage(page)) {
+    return;
+  }
+  const text = await space_exports.readPage(page);
+  const tree = await markdown_exports.parseMarkdown(text);
+  if (!tree.children) {
+    return;
+  }
+  const startTime = Date.now();
+  const pageText = renderToText(tree);
+  const summaryModel = aiSettings.textModels.find(
+    (model) => model.name === aiSettings.indexSummaryModelName
+  );
+  if (!summaryModel) {
+    throw new Error(
+      `Could not find summary model ${aiSettings.indexSummaryModelName}`
+    );
+  }
+  const summaryProvider = await configureSelectedModel(summaryModel);
+  let summaryPrompt;
+  if (aiSettings.promptInstructions.indexSummaryPrompt !== "") {
+    summaryPrompt = aiSettings.promptInstructions.indexSummaryPrompt;
+  } else {
+    summaryPrompt = "Provide a concise and informative summary of the above page. The summary should capture the key points and be useful for search purposes. Avoid any formatting or extraneous text.  No more than one paragraph.  Summary:\n";
+  }
+  const cacheKey = await hashStrings(
+    summaryModel.name,
+    pageText,
+    summaryPrompt
+  );
+  let summary = getCache(cacheKey);
+  if (!summary) {
+    summary = await summaryProvider.singleMessageChat(
+      "Contents of " + page + ":\n" + pageText + "\n\n" + summaryPrompt
+    );
+    setCache(cacheKey, summary);
+  }
+  const summaryEmbeddings = await currentEmbeddingProvider.generateEmbeddings({
+    text: summary
+  });
+  const summaryObject = {
+    ref: `${page}@0`,
+    page,
+    embedding: summaryEmbeddings,
+    text: summary,
+    tag: "aiSummary"
+  };
+  await indexObjects(page, [summaryObject]);
+  const endTime = Date.now();
+  const duration = (endTime - startTime) / 1e3;
+  log(
+    "any",
+    `AI: Indexed summary for page ${page} in ${duration} seconds`
+  );
+}
+async function queueEmbeddingGeneration({ name: page, tree }) {
+  await initIfNeeded();
+  if (!canIndexPage(page)) {
+    return;
+  }
+  if (!tree.children) {
+    return;
+  }
+  if (await shouldIndexEmbeddings()) {
+    await mq_exports.send("aiEmbeddingsQueue", page);
+  }
+  if (await shouldIndexSummaries()) {
+    await mq_exports.send("aiSummaryQueue", page);
+  }
+}
+async function processEmbeddingsQueue(messages) {
+  await initIfNeeded();
+  for (const message of messages) {
+    const pageName = message.body;
+    console.log(`AI: Generating and indexing embeddings for file ${pageName}`);
+    await indexEmbeddings(pageName);
+  }
+  const queueStats = await mq_exports.getQueueStats("aiEmbeddingsQueue");
+  console.log(`AI: Embeddings queue stats: ${JSON.stringify(queueStats)}`);
+}
+async function processSummaryQueue(messages) {
+  await initIfNeeded();
+  for (const message of messages) {
+    const pageName = message.body;
+    console.log(`AI: Generating and indexing summary for ${pageName}`);
+    await indexSummary(pageName);
+  }
+  const queueStats = await mq_exports.getQueueStats("aiSummaryQueue");
+  console.log(`AI: Summary queue stats: ${JSON.stringify(queueStats)}`);
+}
+async function getAllEmbeddings() {
+  if (await supportsServerProxyCall()) {
+    return await syscall(
+      "system.invokeFunctionOnServer",
+      "index.queryObjects",
+      "embedding",
+      {}
+    );
+  } else {
+    return await queryObjects("embedding", {});
+  }
+}
+async function getAllAISummaries() {
+  if (await supportsServerProxyCall()) {
+    return await syscall(
+      "system.invokeFunctionOnServer",
+      "index.queryObjects",
+      "aiSummary",
+      {}
+    );
+  } else {
+    return await queryObjects("aiSummary", {});
+  }
+}
+async function generateEmbeddings(text) {
+  await initIfNeeded();
+  if (!currentEmbeddingProvider || !currentEmbeddingModel) {
+    throw new Error("No embedding provider found");
+  }
+  return await currentEmbeddingProvider.generateEmbeddings({ text });
+}
+async function generateEmbeddingsOnServer(text) {
+  return await syscall(
+    "system.invokeFunctionOnServer",
+    "silverbullet-ai.generateEmbeddings",
+    text
+  );
+}
+function cosineSimilarity(vecA, vecB) {
+  const dotProduct = vecA.reduce((sum, a, idx) => sum + a * vecB[idx], 0);
+  const magnitudeA = Math.sqrt(vecA.reduce((sum, val) => sum + val * val, 0));
+  const magnitudeB = Math.sqrt(vecB.reduce((sum, val) => sum + val * val, 0));
+  return dotProduct / (magnitudeA * magnitudeB);
+}
+async function searchEmbeddings(query2, numResults = 10, updateEditorProgress = false) {
+  await initIfNeeded();
+  if (await system_exports.getEnv() === "server") {
+    updateEditorProgress = false;
+  }
+  const startEmbeddingGeneration = Date.now();
+  const queryEmbedding = typeof query2 === "string" ? await generateEmbeddingsOnServer(query2) : query2;
+  const endEmbeddingGeneration = Date.now();
+  console.log(
+    `searchEmbeddings: Query embedding generation took ${endEmbeddingGeneration - startEmbeddingGeneration} ms`
+  );
+  const startRetrievingEmbeddings = Date.now();
+  const embeddings = await getAllEmbeddings();
+  const endRetrievingEmbeddings = Date.now();
+  console.log(
+    `Retrieved ${embeddings.length} embeddings in ${endRetrievingEmbeddings - startRetrievingEmbeddings} ms`
+  );
+  let progressText = "";
+  let progressStartPos = 0;
+  if (updateEditorProgress) {
+    progressText = `Retrieved ${embeddings.length} embeddings in ${endRetrievingEmbeddings - startRetrievingEmbeddings} ms
+
+`;
+    progressStartPos = (await editor_exports.getText()).length;
+    await editor_exports.replaceRange(progressStartPos, progressStartPos, progressText);
+  }
+  const results = [];
+  let lastUpdateTime = Date.now();
+  for (let i = 0; i < embeddings.length; i++) {
+    const embedding = embeddings[i];
+    if (!canIndexPage(embedding.page)) {
+      continue;
+    }
+    results.push({
+      page: embedding.page,
+      ref: embedding.ref,
+      text: embedding.text,
+      similarity: cosineSimilarity(queryEmbedding, embedding.embedding)
+    });
+    if (updateEditorProgress && (i % 100 === 0 || Date.now() - lastUpdateTime >= 100)) {
+      const pageLength = progressStartPos + progressText.length;
+      progressText = `
+
+Processed ${i + 1} of ${embeddings.length} embeddings...
+
+`;
+      await editor_exports.replaceRange(progressStartPos, pageLength, progressText);
+      lastUpdateTime = Date.now();
+    }
+    if (updateEditorProgress && i >= embeddings.length - 1) {
+      const pageLength = progressStartPos + progressText.length;
+      await editor_exports.replaceRange(progressStartPos, pageLength, "");
+    }
+  }
+  console.log(
+    `Finished searching embeddings in ${Date.now() - startRetrievingEmbeddings} ms`
+  );
+  if (aiSettings.indexSummary) {
+    const startRetrievingSummaries = Date.now();
+    const summaries = await getAllAISummaries();
+    const endRetrievingSummaries = Date.now();
+    console.log(
+      `Retrieved ${summaries.length} summaries in ${endRetrievingSummaries - startRetrievingSummaries} ms`
+    );
+    let progressText2 = "";
+    let progressStartPos2 = 0;
+    if (updateEditorProgress) {
+      progressText2 = `Retrieved ${summaries.length} summaries in ${endRetrievingSummaries - startRetrievingSummaries} ms
+
+`;
+      progressStartPos2 = (await editor_exports.getText()).length;
+      await editor_exports.replaceRange(
+        progressStartPos2,
+        progressStartPos2,
+        progressText2
+      );
+    }
+    const summaryResults = [];
+    let lastUpdateTime2 = Date.now();
+    for (let i = 0; i < summaries.length; i++) {
+      const summary = summaries[i];
+      if (!canIndexPage(summary.page)) {
+        continue;
+      }
+      summaryResults.push({
+        page: summary.page,
+        ref: summary.ref,
+        text: `Page Summary: ${summary.text}`,
+        similarity: cosineSimilarity(queryEmbedding, summary.embedding)
+      });
+      if (updateEditorProgress && (i % 100 === 0 || Date.now() - lastUpdateTime2 >= 100)) {
+        const pageLength = progressStartPos2 + progressText2.length;
+        progressText2 = `
+
+Processed ${i + 1} of ${summaries.length} summaries...
+
+`;
+        await editor_exports.replaceRange(progressStartPos2, pageLength, progressText2);
+        lastUpdateTime2 = Date.now();
+      }
+      if (updateEditorProgress && i >= summaries.length - 1) {
+        const pageLength = progressStartPos2 + progressText2.length;
+        await editor_exports.replaceRange(progressStartPos2, pageLength, "");
+      }
+    }
+    console.log(
+      `Finished searching summaries in ${Date.now() - startRetrievingSummaries} ms`
+    );
+    results.push(...summaryResults);
+  }
+  return results.sort((a, b) => b.similarity - a.similarity).slice(0, numResults);
+}
+async function searchSummaryEmbeddings(query2, numResults = 10) {
+  await initIfNeeded();
+  const queryEmbedding = await generateEmbeddingsOnServer(query2);
+  const summaries = await getAllAISummaries();
+  const results = summaries.map((summary) => ({
+    page: summary.page,
+    ref: summary.ref,
+    text: summary.text,
+    similarity: cosineSimilarity(queryEmbedding, summary.embedding)
+  }));
+  return results.sort((a, b) => b.similarity - a.similarity).slice(0, numResults);
+}
+async function searchCombinedEmbeddings(query2, numResults = 10, minSimilarity = 0.15, updateEditorProgress = false) {
+  let searchResults;
+  searchResults = await searchEmbeddings(query2, -1, updateEditorProgress);
+  const combinedResults = {};
+  for (const result of searchResults) {
+    if (result.similarity < minSimilarity) {
+      continue;
+    }
+    if (combinedResults[result.page]) {
+      combinedResults[result.page].score += result.similarity;
+      combinedResults[result.page].children.push(result);
+    } else {
+      combinedResults[result.page] = {
+        page: result.page,
+        score: result.similarity,
+        children: [result]
+      };
+    }
+  }
+  for (const page in combinedResults) {
+    combinedResults[page].children = combinedResults[page].children.sort((a, b) => b.similarity - a.similarity).slice(0, numResults);
+  }
+  const combinedResultsArray = Object.values(combinedResults);
+  return combinedResultsArray.sort((a, b) => b.score - a.score).slice(0, numResults);
+}
+async function searchEmbeddingsForChat(query2, numResults = 10) {
+  try {
+    const searchResults = await searchCombinedEmbeddings(query2, numResults);
+    let results = "";
+    if (searchResults.length > 0) {
+      for (const r of searchResults) {
+        results += `>>${r.page}<<
+`;
+        for (const child of r.children) {
+          results += `> ${child.text}
+
+`;
+        }
+      }
+    } else {
+      return "No relevant pages found.";
+    }
+    return results;
+  } catch (error) {
+    console.error("Error in searchEmbeddingsForChat:", error);
+    return "An error occurred during the search.";
+  }
+}
+function readFileEmbeddings(name) {
+  return {
+    data: new TextEncoder().encode(""),
+    meta: {
+      name,
+      contentType: "text/markdown",
+      size: 0,
+      created: 0,
+      lastModified: 0,
+      perm: "ro"
+    }
+  };
+}
+function getFileMetaEmbeddings(name) {
+  return {
+    name,
+    contentType: "text/markdown",
+    size: -1,
+    created: 0,
+    lastModified: 0,
+    perm: "ro"
+  };
+}
+function writeFileEmbeddings(name) {
+  return getFileMetaEmbeddings(name);
+}
+async function updateSearchPage() {
+  const page = await editor_exports.getCurrentPage();
+  if (page.startsWith(searchPrefix)) {
+    await initIfNeeded();
+    const phrase = page.substring(searchPrefix.length);
+    const pageHeader = `# Search results for "${phrase}"`;
+    let text = pageHeader + "\n\n";
+    if (!aiSettings.indexEmbeddings) {
+      text += "> **warning** Embeddings generation is disabled.\n";
+      text += "> You can enable it in the AI settings.\n\n\n";
+      await editor_exports.setText(text);
+      return;
+    }
+    let loadingText = `${pageHeader}
+
+Searching for "${phrase}"...`;
+    loadingText += "\nGenerating query vector embeddings..";
+    await editor_exports.setText(loadingText);
+    let queryEmbedding = [];
+    try {
+      queryEmbedding = await generateEmbeddingsOnServer(phrase);
+    } catch (error) {
+      console.error("Error generating query vector embeddings", error);
+      loadingText += "\n\n> **error** \u26A0\uFE0F Failed to generate query vector embeddings.\n";
+      loadingText += `> ${error}
+
+`;
+      await editor_exports.setText(loadingText);
+      return;
+    }
+    loadingText += "\nSearching for similar embeddings...";
+    await editor_exports.setText(loadingText);
+    let results = [];
+    try {
+      results = await searchCombinedEmbeddings(
+        queryEmbedding,
+        void 0,
+        void 0,
+        true
+      );
+    } catch (error) {
+      console.error("Error searching embeddings", error);
+      loadingText += "\n\n> **error** \u26A0\uFE0F Failed to search through embeddings.\n";
+      loadingText += `> ${error}
+
+`;
+      await editor_exports.setText(loadingText);
+      return;
+    }
+    const pageLength = loadingText.length;
+    text = pageHeader + "\n\n";
+    if (results.length === 0) {
+      text += "No results found.\n\n";
+    }
+    for (const r of results) {
+      text += `## [[${r.page}]]
+`;
+      for (const child of r.children) {
+        const childLineNo = child.ref.split("@")[1];
+        const childLineNoPadded = childLineNo.padStart(4, " ");
+        text += `> [[${child.ref}|${childLineNoPadded}]] | ${child.text}
+`;
+      }
+    }
+    await editor_exports.replaceRange(0, pageLength, text);
+  }
+}
+async function searchCommand() {
+  const phrase = await editor_exports.prompt("Search for: ");
+  if (phrase) {
+    await editor_exports.navigate({ page: `${searchPrefix}${phrase}` });
+  }
+}
+
+// ../../../../../../Users/justyns/dev/silverbullet-ai/use-space-config/src/utils.ts
+function folderName(path) {
+  return path.split("/").slice(0, -1).join("/");
+}
+async function log(env, ...args) {
+  const currentEnv = await system_exports.getEnv();
+  if (currentEnv === env || env === "any") {
+    console.log(...args);
+  }
+}
+async function query(query2, variables) {
+  const parsedQuery = await parseQuery(query2);
+  return queryParsed(parsedQuery, variables);
+}
+async function queryParsed(parsedQuery, variables) {
+  if (!parsedQuery.limit) {
+    parsedQuery.limit = ["number", 1e3];
+  }
+  const eventName = `query:${parsedQuery.querySource}`;
+  const event = { query: parsedQuery };
+  if (variables) {
+    event.variables = variables;
+  }
+  const results = await event_exports.dispatchEvent(eventName, event, 30 * 1e3);
+  if (results.length === 0) {
+    throw new Error(`Unsupported query source '${parsedQuery.querySource}'`);
+  }
+  return results.flat();
+}
+async function queryObjects(query2, variables) {
+  return await system_exports.invokeFunction("index.queryObjects", query2, variables);
+}
+async function indexObjects(page, objects) {
+  return await system_exports.invokeFunction("index.indexObjects", page, objects);
+}
+async function convertPageToMessages(pageText) {
+  if (!pageText) {
+    pageText = await editor_exports.getText();
+  }
+  const tree = await markdown_exports.parseMarkdown(pageText);
+  await extractFrontmatter(tree, {
+    removeFrontmatterSection: true
+  });
+  pageText = renderToText(tree);
+  const lines = pageText.split("\n");
+  const messages = [];
+  let currentRole = "user";
+  let contentBuffer = "";
+  lines.forEach((line) => {
+    if (line.trim() === "") {
+      return;
+    }
+    const match = line.match(/^\*\*(\w+)\*\*:/);
+    if (match) {
+      const newRole = match[1].toLowerCase();
+      if (currentRole && currentRole !== newRole && contentBuffer.trim() !== "") {
+        messages.push(
+          { role: currentRole, content: contentBuffer.trim() }
+        );
+        contentBuffer = "";
+      }
+      currentRole = newRole;
+      contentBuffer += line.replace(/^\*\*(\w+)\*\*:/, "").trim() + "\n";
+    } else if (currentRole) {
+      contentBuffer += line.trim() + "\n";
+    }
+  });
+  if (contentBuffer && currentRole) {
+    messages.push(
+      { role: currentRole, content: contentBuffer.trim() }
+    );
+  }
+  return messages;
+}
+async function supportsPlugSlashComplete() {
+  try {
+    const ver = await syscall("system.getVersion");
+    const [major, minor, patch] = ver.split(".").map(Number);
+    const [reqMajor, reqMinor, reqPatch] = "0.7.2".split(".").map(Number);
+    if (major > reqMajor)
+      return true;
+    if (major === reqMajor && minor > reqMinor)
+      return true;
+    if (major === reqMajor && minor === reqMinor && patch >= reqPatch) {
+      return true;
+    }
+    return false;
+  } catch (_err) {
+    return false;
+  }
+}
+async function supportsServerProxyCall() {
+  try {
+    const syscalls = await system_exports.listSyscalls();
+    return syscalls.some(
+      (syscall4) => syscall4.name === "system.invokeFunctionOnServer"
+    );
+  } catch (_err) {
+    return false;
+  }
+}
+async function enrichChatMessages(messages) {
+  const enrichedMessages = [];
+  let currentPage, pageMeta;
+  try {
+    currentPage = await editor_exports.getCurrentPage();
+    pageMeta = await space_exports.getPageMeta(currentPage);
+  } catch (error) {
+    console.error("Error fetching page metadata", error);
+    await editor_exports.flashNotification(
+      "Error fetching page metadata",
+      "error"
+    );
+    return [];
+  }
+  for (const message of messages) {
+    if (message.role === "assistant" || message.role === "system") {
+      enrichedMessages.push(message);
+      continue;
+    }
+    const messageTree = await markdown_exports.parseMarkdown(message.content);
+    const messageAttributes = await extractAttributes(
+      [],
+      messageTree
+    );
+    message.content = message.content.replace(
+      /\[enrich:\s*(false|true)\s*\]\s*/g,
+      ""
+    );
+    if (messageAttributes.enrich !== void 0 && messageAttributes.enrich === false) {
+      console.log(
+        "Skipping message enrichment due to enrich=false attribute",
+        messageAttributes
+      );
+      enrichedMessages.push(message);
+      continue;
+    }
+    let enrichedContent = message.content;
+    if (message.role === "user") {
+      if (pageMeta) {
+        console.log("Rendering template", message.content, pageMeta);
+        const templateResult = await template_exports.renderTemplate(
+          message.content,
+          pageMeta,
+          {
+            page: pageMeta
+          }
+        );
+        enrichedContent = templateResult;
+      } else {
+        console.log("No page metadata found, skipping template rendering");
+      }
+    }
+    if (aiSettings.chat.searchEmbeddings && aiSettings.indexEmbeddings) {
+      const searchResultsText = await searchEmbeddingsForChat(enrichedContent);
+      if (searchResultsText !== "No relevant pages found.") {
+        enrichedContent += `
 
 The following pages were found to be relevant to the question. You can use them as context to answer the question. Only partial content is shown. Ask for the whole page if needed. Page name is between >> and <<.
-`,a+=u)}if(C.chat.parseWikiLinks&&(a=await _k(a)),C.chat.bakeMessages){let u=await Oe.parseMarkdown(a),d=await K.invokeFunction("markdown.expandCodeWidgets",u,"");a=be(Jh(d)).trim()}let h=(await li.dispatchEvent("ai:enrichMessage",{enrichedContent:a,message:n})).flat().concat(C.chat.customEnrichFunctions),c=[...new Set(h)];console.log("Received custom enrich message functions",c);for(let u of c)a=await K.invokeSpaceFunction(u,a);t.push({...n,content:a})}return t}async function _k(e){let t=[],i=e,r=/\[\[([^\]]+)\]\]/g,n,s=!1;for(;(n=r.exec(e))!==null;){let o=n[1];if(!t.includes(o)){s||(i+=`
+`;
+        enrichedContent += searchResultsText;
+      }
+    }
+    if (aiSettings.chat.parseWikiLinks) {
+      enrichedContent = await enrichMesssageWithWikiLinks(enrichedContent);
+    }
+    if (aiSettings.chat.bakeMessages) {
+      const tree = await markdown_exports.parseMarkdown(enrichedContent);
+      const rendered = await system_exports.invokeFunction(
+        "markdown.expandCodeWidgets",
+        tree,
+        ""
+      );
+      enrichedContent = renderToText(rendered).trim();
+    }
+    const enrichFunctions = await event_exports.dispatchEvent(
+      "ai:enrichMessage",
+      {
+        enrichedContent,
+        message
+      }
+    );
+    const combinedEnrichFunctions = enrichFunctions.flat().concat(
+      aiSettings.chat.customEnrichFunctions
+    );
+    const finalEnrichFunctions = [...new Set(combinedEnrichFunctions)];
+    console.log(
+      "Received custom enrich message functions",
+      finalEnrichFunctions
+    );
+    for (const func2 of finalEnrichFunctions) {
+      enrichedContent = await system_exports.invokeSpaceFunction(func2, enrichedContent);
+    }
+    enrichedMessages.push({ ...message, content: enrichedContent });
+  }
+  return enrichedMessages;
+}
+async function enrichMesssageWithWikiLinks(content) {
+  const seenPages = [];
+  let enrichedContent = content;
+  const wikiLinkRegex = /\[\[([^\]]+)\]\]/g;
+  let match;
+  let hasMatch = false;
+  while ((match = wikiLinkRegex.exec(content)) !== null) {
+    const pageName = match[1];
+    if (seenPages.includes(pageName)) {
+      continue;
+    }
+    if (!hasMatch) {
+      enrichedContent += `
 
-Base your answer on the content of the following referenced pages (referenced above using the >>page name<< format). In these listings ~~~ is used to mark the page's content start and end. If context is missing, always ask me to link directly to a page mentioned in the context.`,s=!0);try{let a=await me.readPage(o);t.push(o),i+=`
+${"Base your answer on the content of the following referenced pages (referenced above using the >>page name<< format). In these listings ~~~ is used to mark the page's content start and end. If context is missing, always ask me to link directly to a page mentioned in the context."}`;
+      hasMatch = true;
+    }
+    try {
+      const pageContent = await space_exports.readPage(pageName);
+      seenPages.push(pageName);
+      enrichedContent += `
 
-Content of the [[${o}]] page:
+Content of the [[${pageName}]] page:
 ~~~
-${a}
+${pageContent}
 ~~~
-`}catch(a){console.error(`Error fetching page '${o}':`,a)}}}return i=i.replace(r,">>$1<<"),i}var $t=class{name;apiKey;baseUrl;modelName;constructor(t,i,r,n){this.name=t,this.apiKey=i,this.baseUrl=r,this.modelName=n}async streamChatIntoEditor(t,i){let{onDataReceived:r}=t,n="\u{1F914} Thinking \u2026 ",s=i??await ci();await x.insertAtPos(n,s);let o=!0,a=l=>{try{if(!l){console.log("No data received from LLM");return}o?(["`","-","*"].includes(l.charAt(0))&&(console.log("First character of response is:",l.charAt(0)),l=`
-`+l),x.replaceRange(s,s+n.length,l),o=!1):x.insertAtPos(l,s),s+=l.length,r&&r(l)}catch(h){console.error("Error handling chat stream data:",h),x.flashNotification("An error occurred while processing chat data.","error")}};await this.chatWithAI({...t,onDataReceived:a})}async singleMessageChat(t,i,r=!1){let n=[{role:"user",content:t}];return i&&n.unshift({role:"system",content:i}),r&&(n=await tr(n)),await this.chatWithAI({messages:n,stream:!1})}};var _s=class extends $t{name="Gemini";constructor(t,i){super("Gemini",t,"https://generativelanguage.googleapis.com",i)}async listModels(){let t=`${this.baseUrl}/v1beta/models?key=${this.apiKey}`;try{let i=await fetch(t);if(!i.ok)throw new Error(`HTTP error! status: ${i.status}`);return(await i.json()).models||[]}catch(i){throw console.error("Failed to fetch models:",i),i}}async chatWithAI({messages:t,stream:i,onDataReceived:r}){return i?await this.streamChat({messages:t,stream:i,onDataReceived:r}):await this.nonStreamingChat(t)}mapRolesForGemini(t){let i=[],r="";return t.forEach(n=>{let s="user";n.role==="system"||n.role==="user"?s="user":n.role==="assistant"&&(s="model"),s==="model"&&(i.length===0||r==="model")||(s==="user"&&r==="user"?i[i.length-1].parts[0].text+=" "+n.content:i.push({role:s,parts:[{text:n.content}]})),r=s}),i}streamChat(t){let{messages:i,onDataReceived:r}=t;try{let n=`${this.baseUrl}/v1beta/models/${this.modelName}:streamGenerateContent?key=${this.apiKey}&alt=sse`,s={"Content-Type":"application/json"},o=this.mapRolesForGemini(i),a={method:"POST",headers:s,payload:JSON.stringify({contents:o}),withCredentials:!1},l=new ui(n,a),h="";l.addEventListener("message",c=>{try{if(c.data=="[DONE]")return l.close(),h;if(!c.data)console.error("Received empty message from Gemini"),console.log("source: ",l);else{let u=JSON.parse(c.data),d=u.candidates[0].content.parts[0].text||u.text||"";h+=d,r&&r(d)}}catch(u){console.error("Error processing message event:",u,c.data)}}),l.addEventListener("end",()=>(l.close(),h)),l.addEventListener("error",c=>{console.error("SSE error:",c),l.close()}),l.stream()}catch(n){throw console.error("Error streaming from Gemini chat endpoint:",n),n}}async nonStreamingChat(t){let i=this.mapRolesForGemini(t),r=await nativeFetch(`${this.baseUrl}/v1beta/models/${this.modelName}:generateContent?key=${this.apiKey}`,{method:"POST",headers:{"Content-Type":"application/json"},body:JSON.stringify({contents:i})});if(!r.ok)throw new Error(`HTTP error! status: ${r.status}`);return(await r.json()).candidates[0].content.parts[0].text}},Us=class extends yt{constructor(t,i,r="https://generativelanguage.googleapis.com",n=!0){super(t,r,"Gemini",i,n)}async _generateEmbeddings(t){let i=JSON.stringify({model:this.modelName,content:{parts:[{text:t.text}]}}),r={"Content-Type":"application/json"};this.requireAuth&&(r.Authorization=`Bearer ${this.apiKey}`);let n=await nativeFetch(`${this.baseUrl}/v1beta/models/${this.modelName}:embedContent?key=${this.apiKey}`,{method:"POST",headers:r,body:i});if(!n.ok)throw console.error("HTTP response: ",n),console.error("HTTP response body: ",await n.json()),new Error(`HTTP error, status: ${n.status}`);let s=await n.json();if(!s||!s.embedding||!s.embedding.values)throw new Error("Invalid response from Gemini.");return s.embedding.values}};var ir=class extends $t{name="OpenAI";requireAuth;constructor(t,i,r,n){super("OpenAI",t,r,i),this.requireAuth=n}async chatWithAI({messages:t,stream:i,onDataReceived:r}){return i?await this.streamChat({messages:t,onDataReceived:r}):await this.nonStreamingChat(t)}async streamChat(t){let{messages:i,onDataReceived:r}=t;try{let n=`${this.baseUrl}/chat/completions`,s={"Content-Type":"application/json"};this.requireAuth&&(s.Authorization=`Bearer ${this.apiKey}`);let o={method:"POST",headers:s,payload:JSON.stringify({model:this.modelName,stream:!0,messages:i}),withCredentials:!1},a=new ui(n,o),l="";a.addEventListener("message",function(h){try{if(h.data=="[DONE]")return a.close(),l;{let u=JSON.parse(h.data).choices[0]?.delta?.content||"";l+=u,r&&r(u)}}catch(c){console.error("Error processing message event:",c,h.data)}}),a.addEventListener("end",function(){return a.close(),l}),a.addEventListener("error",h=>{console.error("SSE error:",h),a.close()}),a.stream()}catch(n){throw console.error("Error streaming from OpenAI chat endpoint:",n),await x.flashNotification("Error streaming from OpenAI chat endpoint.","error"),n}return""}async nonStreamingChat(t){try{let i=JSON.stringify({model:this.modelName,messages:t}),r={Authorization:`Bearer ${this.apiKey}`,"Content-Type":"application/json"},n=await nativeFetch(this.baseUrl+"/chat/completions",{method:"POST",headers:r,body:i});if(!n.ok)throw console.error("http response: ",n),console.error("http response body: ",await n.json()),new Error(`HTTP error, status: ${n.status}`);let s=await n.json();if(!s||!s.choices||s.choices.length===0)throw new Error("Invalid response from OpenAI.");return s.choices[0].message.content}catch(i){throw console.error("Error calling OpenAI chat endpoint:",i),await x.flashNotification("Error calling OpenAI chat endpoint.","error"),i}}},zs=class extends yt{constructor(t,i,r,n=!0){super(t,r,"OpenAI",i,n)}async _generateEmbeddings(t){let i=JSON.stringify({model:this.modelName,input:t.text,encoding_format:"float"}),r={"Content-Type":"application/json"};this.requireAuth&&(r.Authorization=`Bearer ${this.apiKey}`);let n=await nativeFetch(`${this.baseUrl}/embeddings`,{method:"POST",headers:r,body:i});if(!n.ok)throw console.error("HTTP response: ",n),console.error("HTTP response body: ",await n.json()),new Error(`HTTP error, status: ${n.status}`);let s=await n.json();if(!s||!s.data||s.data.length===0)throw new Error("Invalid response from OpenAI.");return s.data[0].embedding}};var Bs=class extends $t{name="Ollama";requireAuth;openaiProvider;constructor(t,i,r,n){super("Ollama",t,r,i),this.requireAuth=n,this.openaiProvider=new ir(t,i,r,n)}async chatWithAI({messages:t,stream:i,onDataReceived:r}){return await this.openaiProvider.chatWithAI({messages:t,stream:i,onDataReceived:r})}},Gs=class extends yt{constructor(t,i,r,n=!1){super(t,r,"Ollama",i,n)}async _generateEmbeddings(t){let i=JSON.stringify({model:this.modelName,prompt:t.text}),r={"Content-Type":"application/json"};this.requireAuth&&(r.Authorization=`Bearer ${this.apiKey}`);let n=await nativeFetch(`${this.baseUrl}/api/embeddings`,{method:"POST",headers:r,body:i});if(!n.ok)throw console.error("HTTP response: ",n),console.error("HTTP response body: ",await n.json()),new Error(`HTTP error, status: ${n.status}`);let s=await n.json();if(!s||!s.embedding||s.embedding.length===0)throw new Error("Invalid response from Ollama.");return s.embedding}};var Fs=class extends $t{constructor(t,i,r="http://localhost"){super(t,r,"mock",i)}async chatWithAI(t){let i="This is a mock response from the AI.";if(t.onDataReceived)for(let r of i)await new Promise(n=>setTimeout(n,50)),t.onDataReceived(r);return i}},Hs=class extends Ai{constructor(t,i,r="http://localhost"){super(t,r,"mock",i)}generateImage(t){return new Promise(i=>{setTimeout(()=>{i("https://example.com/mock-image.jpg")},5)})}},Ks=class extends yt{constructor(t,i,r="http://localhost"){super(t,r,"mock",i)}_generateEmbeddings(t){return new Promise(i=>{setTimeout(()=>{let r=Array(1536).fill(0).map(()=>Math.random());i(r)},5)})}};var oe,C,en,ye,Js,He,gh,Uk,Kr;async function ae(){let e=await vg();(!oe||!ye||!C||!gh||JSON.stringify(e)!==JSON.stringify(gh))&&await Nt(!0)}async function vg(){if(await K.getEnv()!="server")try{return await Ct.get("ai.selectedTextModel")}catch{return}}async function zk(){if(await K.getEnv()!="server")try{return await Ct.get("ai.selectedImageModel")}catch{return}}async function Bk(){if(await K.getEnv()!="server")try{return await Ct.get("ai.selectedEmbeddingModel")}catch{return}}async function yh(e){await K.getEnv()!="server"&&await Ct.set("ai.selectedImageModel",e)}async function bh(e){await K.getEnv()!="server"&&await Ct.set("ai.selectedTextModel",e)}async function wh(e){await K.getEnv()!="server"&&await Ct.set("ai.selectedEmbeddingModel",e)}async function Gk(){let e=await vg()||C.textModels[0];if(!e)throw new Error("No text model selected or available as default.");await Jr(e)}async function Fk(){let e=await zk()||C.imageModels[0];if(!e)throw new Error("No image model selected or available as default.");await vh(e)}async function Hk(){let e=await Bk()||C.embeddingModels[0];if(!e)throw new Error("No embedding model selected or available as default.");await Sh(e)}function Kk(e){let t=e.provider.toLowerCase();switch(Le("client","Provider name",t),t){case"dalle":Js=new gn(oe,e.modelName,e.baseUrl||C.dallEBaseUrl);break;case"mock":Js=new Hs(oe,e.modelName);break;default:throw new Error(`Unsupported image provider: ${e.provider}. Please configure a supported provider.`)}}function Jk(e){switch(e.provider.toLowerCase()){case"openai":ye=new ir(oe,e.modelName,e.baseUrl||C.openAIBaseUrl,e.requireAuth||C.requireAuth);break;case"gemini":ye=new _s(oe,e.modelName);break;case"ollama":ye=new Bs(oe,e.modelName,e.baseUrl||"http://localhost:11434/v1",e.requireAuth);break;case"mock":ye=new Fs(oe,e.modelName,e.baseUrl);break;default:throw new Error(`Unsupported AI provider: ${e.provider}. Please configure a supported provider.`)}return ye}function eQ(e){switch(e.provider.toLowerCase()){case"openai":He=new zs(oe,e.modelName,e.baseUrl||C.openAIBaseUrl);break;case"gemini":He=new Us(oe,e.modelName);break;case"ollama":He=new Gs(oe,e.modelName,e.baseUrl||"http://localhost:11434",e.requireAuth);break;case"mock":He=new Ks(oe,e.modelName,e.baseUrl);break;default:throw new Error(`Unsupported embedding provider: ${e.provider}. Please configure a supported provider.`)}}async function Jr(e){if(Le("client","configureSelectedModel called with:",e),!e)throw new Error("No model provided to configure");if(e.requireAuth=e.requireAuth??C.requireAuth,e.requireAuth)try{let t=await mn(e.secretName||"OPENAI_API_KEY");t!==oe&&(oe=t,Le("client","API key updated"))}catch(t){throw console.error("Error reading secret:",t),new Error("Failed to read the AI API key. Please check the SECRETS page.")}if(e.requireAuth&&!oe)throw new Error("AI API key is missing. Please set it in the secrets page.");return gh=e,Jk(e)}async function vh(e){if(Le("client","configureSelectedImageModel called with:",e),!e)throw new Error("No image model provided to configure");if(e.requireAuth){let t=await mn(e.secretName||"OPENAI_API_KEY");t!==oe&&(oe=t,Le("client","API key updated for image model"))}if(e.requireAuth&&!oe)throw new Error("AI API key is missing for image model. Please set it in the secrets page.");Uk=e,Kk(e)}async function Sh(e){if(Le("client","configureSelectedEmbeddingModel called with:",e),!e)throw new Error("No embedding model provided to configure");if(e.requireAuth){let t=await mn(e.secretName||"OPENAI_API_KEY");t!==oe&&(oe=t,Le("client","API key updated for embedding model"))}if(e.requireAuth&&!oe)throw new Error("AI API key is missing for embedding model. Please set it in the secrets page.");Kr=e,eQ(e)}async function tQ(){let e={openAIBaseUrl:"https://api.openai.com/v1",dallEBaseUrl:"https://api.openai.com/v1",requireAuth:!0,secretName:"OPENAI_API_KEY",provider:"OpenAI",chat:{},promptInstructions:{},imageModels:[],embeddingModels:[],textModels:[],indexEmbeddings:!1,indexSummary:!1,indexSummaryModelName:"",indexEmbeddingsExcludePages:[],indexEmbeddingsExcludeStrings:["**user**:"]},t={userInformation:"",userInstructions:"",parseWikiLinks:!0,bakeMessages:!0,customEnrichFunctions:[],searchEmbeddings:!1},i={pageRenameSystem:"",pageRenameRules:"",tagRules:"",indexSummaryPrompt:"",enhanceFrontMatterPrompt:""},r=await Uh("ai",{}),n={...e,...r};return n.chat={...t,...r.chat||{}},n.promptInstructions={...i,...r.promptInstructions||{}},n}async function Nt(e=!0){let t=await tQ();!C||JSON.stringify(C)!==JSON.stringify(t)?(Le("client","aiSettings updating from",C),C=t,Le("client","aiSettings updated to",C)):Le("client","aiSettings unchanged",C),C.textModels.length===1&&await bh(C.textModels[0]),C.imageModels.length===1&&await yh(C.imageModels[0]),C.embeddingModels.length===1&&await wh(C.embeddingModels[0]),e&&(C.textModels.length>0&&await Gk(),C.imageModels.length>0&&await Fk(),C.embeddingModels.length>0&&await Hk()),en={role:"system",content:"This is an interactive chat session with a user in a markdown-based note-taking tool called SilverBullet."},C.chat.userInformation&&(en.content+=`
-The user has provided the following information about themselves: ${C.chat.userInformation}`),C.chat.userInstructions&&(en.content+=`
-The user has provided the following instructions for the chat, follow them as closely as possible: ${C.chat.userInstructions}`)}async function Sg(e){return wg()?{options:(await Ci("template",{filter:["attr",["attr","aiprompt"],"slashCommand"]},5)).map(i=>{let r=i.aiprompt;return console.log("ai prompt template: ",r),{label:r.slashCommand,detail:r.description||i.description,order:r.order||0,templatePage:i.ref,pageName:e.pageName,invoke:"silverbullet-ai.insertAiPromptFromTemplate"}})}:void 0}async function xg(e){let t;if(!e||!e.templatePage){let l=await Ci("template",{filter:["attr",["attr","aiprompt"],"description"]});t=await x.filterBox("Prompt Template",l.map(h=>{let c=h.ref.split("/").pop();return{...h,description:h.aiprompt.description||h.ref,name:h.aiprompt.displayName||c,systemPrompt:h.aiprompt.systemPrompt||"You are an AI note assistant. Please follow the prompt instructions.",insertAt:h.aiprompt.insertAt||"cursor",chat:h.aiprompt.chat||!1,enrichMessages:h.aiprompt.enrichMessages||!1}}),"Select the template to use as the prompt.  The prompt will be rendered and sent to the LLM model.")}else{console.log("selectedTemplate from slash completion: ",e);let l=await me.readPage(e.templatePage),h=await Oe.parseMarkdown(l),{aiprompt:c}=await At(h);console.log("templatePage from slash completion: ",l),t={ref:e.templatePage,systemPrompt:c.systemPrompt||c.system||"You are an AI note assistant. Please follow the prompt instructions.",insertAt:c.insertAt||"cursor",chat:c.chat||!1,enrichMessages:c.enrichMessages||!1}}if(!t){await x.flashNotification("No template selected");return}console.log("User selected prompt template: ",t);let i=["cursor","page-start","page-end"];if(!i.includes(t.insertAt)){console.error(`Invalid insertAt value: ${t.insertAt}. It must be one of ${i.join(", ")}`),await x.flashNotification(`Invalid insertAt value: ${t.insertAt}. Please select a valid option.`,"error");return}await ae();let r,n,s;try{r=await me.readPage(t.ref),n=await x.getCurrentPage(),s=await me.getPageMeta(n)}catch(l){console.error("Error fetching template details or page metadata",l),await x.flashNotification("Error fetching template details or page metadata","error");return}let o;switch(t.insertAt){case"page-start":o=0;break;case"page-end":o=await ci();break;case"frontmatter":await x.flashNotification("rendering in frontmatter not supported yet","error");break;case"modal":break;case"replace":break;case"cursor":default:o=await x.getCursor()}o===void 0&&(o=await ci()),console.log("templatetext: ",r);let a=[];if(t.chat)a=await Ds(r),t.systemPrompt&&a.unshift({role:"system",content:t.systemPrompt}),t.chat&&t.enrichMessages&&(a=await tr(a));else{let l=await fn(r,s,{page:s});console.log("Rendered template:",l),t.systemPrompt&&a.push({role:"system",content:t.systemPrompt}),a.push({role:"user",content:l.text})}console.log("Messages: ",a),await ye.streamChatIntoEditor({messages:a,stream:!0},o)}function Pg(e){let t={querySource:""},[i,r,...n]=e;if(i!=="Query")throw new Error(`Expected query type, got ${i}`);t.querySource=r[1];for(let s of n){let[o]=s;switch(o){case"WhereClause":{t.filter?t.filter=["and",t.filter,ce(s[2])]:t.filter=ce(s[2]);break}case"OrderClause":{t.orderBy||(t.orderBy=[]);for(let a of s.slice(2))if(a[0]==="OrderBy"){let l=a[1][1];a[2]?t.orderBy.push({expr:ce(l),desc:a[2][1][1]==="desc"}):t.orderBy.push({expr:ce(l),desc:!1})}break}case"LimitClause":{t.limit=ce(s[2][1]);break}case"SelectClause":{for(let a of s.slice(2))a[0]==="Select"&&(t.select||(t.select=[]),a.length===2?t.select.push({name:tn(a[1][1])}):t.select.push({name:tn(a[3][1]),expr:ce(a[1])}));break}case"RenderClause":{let a=s.find(l=>l[0]==="PageRef");t.render=a[1].slice(2,-2),t.renderAll=!!s.find(l=>l[0]==="all");break}default:throw new Error(`Unknown clause type: ${o}`)}}return t}function tn(e){return e.startsWith("`")&&e.endsWith("`")?e.slice(1,-1):e}function ce(e){if(["LVal","Expression","Value"].includes(e[0]))return ce(e[1]);switch(e[0]){case"Attribute":return["attr",ce(e[1]),tn(e[3][1])];case"Identifier":return["attr",tn(e[1])];case"String":return["string",e[1].slice(1,-1)];case"Number":return["number",+e[1]];case"Bool":return["boolean",e[1][1]==="true"];case"null":return["null"];case"Regex":return["regexp",e[1].slice(1,-1),"i"];case"List":{let t=[];for(let i of e.slice(2))i[0]==="Expression"&&t.push(i);return["array",t.map(ce)]}case"Object":{let t=[];for(let i of e.slice(2)){if(typeof i=="string")continue;let[r,n,s,o]=i;t.push([n[1].slice(1,-1),ce(o)])}return["object",t]}case"BinExpression":{let t=ce(e[1]),i=e[2][0]==="InKW"?"in":e[2].trim(),r=ce(e[3]);return[i,t,r]}case"LogicalExpression":{let t=ce(e[1]),i=e[2],r=ce(e[3]);return[i[1],t,r]}case"ParenthesizedExpression":return ce(e[2]);case"Call":{let t=tn(e[1][1]),i=[];for(let r of e.slice(2))r[0]==="Expression"&&i.push(r);return["call",t,i.map(ce)]}case"UnaryExpression":{if(e[1][0]==="NotKW"||e[1][0]==="!")return["not",ce(e[2])];if(e[1][0]==="-")return["-",ce(e[2])];throw new Error(`Unknown unary expression: ${e[1][0]}`)}case"TopLevelVal":return["attr"];case"GlobalIdentifier":return["global",e[1].substring(1)];case"TernaryExpression":{let[t,i,r,n,s,o]=e;return["?",ce(i),ce(n),ce(o)]}case"QueryExpression":return["query",Pg(e[2])];case"PageRef":return["pageref",e[1].slice(2,-2)];default:throw new Error(`Not supported: ${e[0]}`)}}async function kg(e){let t=fo(await un.parseLanguage("query",e));return Pg(t[1])}async function Qg(e,t){let i=await kg(e);return iQ(i,t)}async function iQ(e,t){e.limit||(e.limit=["number",1e3]);let i=`query:${e.querySource}`,r={query:e};t&&(r.variables=t);let n=await li.dispatchEvent(i,r,30*1e3);if(n.length===0)throw new Error(`Unsupported query source '${e.querySource}'`);return n.flat()}var X5=new TextEncoder;function $g(e){let t=atob(e),i=t.length,r=new Uint8Array(i);for(let n=0;n<i;n++)r[n]=t.charCodeAt(n);return r}function jg(e){return typeof e>"u"||e===null}function rQ(e){return typeof e=="object"&&e!==null}function nQ(e){return Array.isArray(e)?e:jg(e)?[]:[e]}function sQ(e,t){var i,r,n,s;if(t)for(s=Object.keys(t),i=0,r=s.length;i<r;i+=1)n=s[i],e[n]=t[n];return e}function oQ(e,t){var i="",r;for(r=0;r<t;r+=1)i+=e;return i}function aQ(e){return e===0&&Number.NEGATIVE_INFINITY===1/e}var lQ=jg,hQ=rQ,cQ=nQ,uQ=oQ,dQ=aQ,fQ=sQ,pe={isNothing:lQ,isObject:hQ,toArray:cQ,repeat:uQ,isNegativeZero:dQ,extend:fQ};function Dg(e,t){var i="",r=e.reason||"(unknown reason)";return e.mark?(e.mark.name&&(i+='in "'+e.mark.name+'" '),i+="("+(e.mark.line+1)+":"+(e.mark.column+1)+")",!t&&e.mark.snippet&&(i+=`
+`;
+    } catch (error) {
+      console.error(`Error fetching page '${pageName}':`, error);
+    }
+  }
+  enrichedContent = enrichedContent.replace(wikiLinkRegex, ">>$1<<");
+  return enrichedContent;
+}
 
-`+e.mark.snippet),r+" "+i):r}function nn(e,t){Error.call(this),this.name="YAMLException",this.reason=e,this.mark=t,this.message=Dg(this,!1),Error.captureStackTrace?Error.captureStackTrace(this,this.constructor):this.stack=new Error().stack||""}nn.prototype=Object.create(Error.prototype);nn.prototype.constructor=nn;nn.prototype.toString=function(e){return this.name+": "+Dg(this,e)};var Ve=nn;function xh(e,t,i,r,n){var s="",o="",a=Math.floor(n/2)-1;return r-t>a&&(s=" ... ",t=r-a+s.length),i-r>a&&(o=" ...",i=r+a-o.length),{str:s+e.slice(t,i).replace(/\t/g,"\u2192")+o,pos:r-t+s.length}}function Ph(e,t){return pe.repeat(" ",t-e.length)+e}function pQ(e,t){if(t=Object.create(t||null),!e.buffer)return null;t.maxLength||(t.maxLength=79),typeof t.indent!="number"&&(t.indent=1),typeof t.linesBefore!="number"&&(t.linesBefore=3),typeof t.linesAfter!="number"&&(t.linesAfter=2);for(var i=/\r?\n|\r|\0/g,r=[0],n=[],s,o=-1;s=i.exec(e.buffer);)n.push(s.index),r.push(s.index+s[0].length),e.position<=s.index&&o<0&&(o=r.length-2);o<0&&(o=r.length-1);var a="",l,h,c=Math.min(e.line+t.linesAfter,n.length).toString().length,u=t.maxLength-(t.indent+c+3);for(l=1;l<=t.linesBefore&&!(o-l<0);l++)h=xh(e.buffer,r[o-l],n[o-l],e.position-(r[o]-r[o-l]),u),a=pe.repeat(" ",t.indent)+Ph((e.line-l+1).toString(),c)+" | "+h.str+`
-`+a;for(h=xh(e.buffer,r[o],n[o],e.position,u),a+=pe.repeat(" ",t.indent)+Ph((e.line+1).toString(),c)+" | "+h.str+`
-`,a+=pe.repeat("-",t.indent+c+3+h.pos)+`^
-`,l=1;l<=t.linesAfter&&!(o+l>=n.length);l++)h=xh(e.buffer,r[o+l],n[o+l],e.position-(r[o]-r[o+l]),u),a+=pe.repeat(" ",t.indent)+Ph((e.line+l+1).toString(),c)+" | "+h.str+`
-`;return a.replace(/\n$/,"")}var OQ=pQ,mQ=["kind","multi","resolve","construct","instanceOf","predicate","represent","representName","defaultStyle","styleAliases"],gQ=["scalar","sequence","mapping"];function yQ(e){var t={};return e!==null&&Object.keys(e).forEach(function(i){e[i].forEach(function(r){t[String(r)]=i})}),t}function bQ(e,t){if(t=t||{},Object.keys(t).forEach(function(i){if(mQ.indexOf(i)===-1)throw new Ve('Unknown option "'+i+'" is met in definition of "'+e+'" YAML type.')}),this.options=t,this.tag=e,this.kind=t.kind||null,this.resolve=t.resolve||function(){return!0},this.construct=t.construct||function(i){return i},this.instanceOf=t.instanceOf||null,this.predicate=t.predicate||null,this.represent=t.represent||null,this.representName=t.representName||null,this.defaultStyle=t.defaultStyle||null,this.multi=t.multi||!1,this.styleAliases=yQ(t.styleAliases||null),gQ.indexOf(this.kind)===-1)throw new Ve('Unknown kind "'+this.kind+'" is specified for "'+e+'" YAML type.')}var xe=bQ;function Tg(e,t){var i=[];return e[t].forEach(function(r){var n=i.length;i.forEach(function(s,o){s.tag===r.tag&&s.kind===r.kind&&s.multi===r.multi&&(n=o)}),i[n]=r}),i}function wQ(){var e={scalar:{},sequence:{},mapping:{},fallback:{},multi:{scalar:[],sequence:[],mapping:[],fallback:[]}},t,i;function r(n){n.multi?(e.multi[n.kind].push(n),e.multi.fallback.push(n)):e[n.kind][n.tag]=e.fallback[n.tag]=n}for(t=0,i=arguments.length;t<i;t+=1)arguments[t].forEach(r);return e}function Qh(e){return this.extend(e)}Qh.prototype.extend=function(e){var t=[],i=[];if(e instanceof xe)i.push(e);else if(Array.isArray(e))i=i.concat(e);else if(e&&(Array.isArray(e.implicit)||Array.isArray(e.explicit)))e.implicit&&(t=t.concat(e.implicit)),e.explicit&&(i=i.concat(e.explicit));else throw new Ve("Schema.extend argument should be a Type, [ Type ], or a schema definition ({ implicit: [...], explicit: [...] })");t.forEach(function(n){if(!(n instanceof xe))throw new Ve("Specified list of YAML types (or a single Type object) contains a non-Type object.");if(n.loadKind&&n.loadKind!=="scalar")throw new Ve("There is a non-scalar type in the implicit list of a schema. Implicit resolving of such types is not supported.");if(n.multi)throw new Ve("There is a multi type in the implicit list of a schema. Multi tags can only be listed as explicit.")}),i.forEach(function(n){if(!(n instanceof xe))throw new Ve("Specified list of YAML types (or a single Type object) contains a non-Type object.")});var r=Object.create(Qh.prototype);return r.implicit=(this.implicit||[]).concat(t),r.explicit=(this.explicit||[]).concat(i),r.compiledImplicit=Tg(r,"implicit"),r.compiledExplicit=Tg(r,"explicit"),r.compiledTypeMap=wQ(r.compiledImplicit,r.compiledExplicit),r};var vQ=Qh,SQ=new xe("tag:yaml.org,2002:str",{kind:"scalar",construct:function(e){return e!==null?e:""}}),xQ=new xe("tag:yaml.org,2002:seq",{kind:"sequence",construct:function(e){return e!==null?e:[]}}),PQ=new xe("tag:yaml.org,2002:map",{kind:"mapping",construct:function(e){return e!==null?e:{}}}),kQ=new vQ({explicit:[SQ,xQ,PQ]});function QQ(e){if(e===null)return!0;var t=e.length;return t===1&&e==="~"||t===4&&(e==="null"||e==="Null"||e==="NULL")}function $Q(){return null}function TQ(e){return e===null}var CQ=new xe("tag:yaml.org,2002:null",{kind:"scalar",resolve:QQ,construct:$Q,predicate:TQ,represent:{canonical:function(){return"~"},lowercase:function(){return"null"},uppercase:function(){return"NULL"},camelcase:function(){return"Null"},empty:function(){return""}},defaultStyle:"lowercase"});function AQ(e){if(e===null)return!1;var t=e.length;return t===4&&(e==="true"||e==="True"||e==="TRUE")||t===5&&(e==="false"||e==="False"||e==="FALSE")}function ZQ(e){return e==="true"||e==="True"||e==="TRUE"}function EQ(e){return Object.prototype.toString.call(e)==="[object Boolean]"}var RQ=new xe("tag:yaml.org,2002:bool",{kind:"scalar",resolve:AQ,construct:ZQ,predicate:EQ,represent:{lowercase:function(e){return e?"true":"false"},uppercase:function(e){return e?"TRUE":"FALSE"},camelcase:function(e){return e?"True":"False"}},defaultStyle:"lowercase"});function XQ(e){return 48<=e&&e<=57||65<=e&&e<=70||97<=e&&e<=102}function MQ(e){return 48<=e&&e<=55}function WQ(e){return 48<=e&&e<=57}function qQ(e){if(e===null)return!1;var t=e.length,i=0,r=!1,n;if(!t)return!1;if(n=e[i],(n==="-"||n==="+")&&(n=e[++i]),n==="0"){if(i+1===t)return!0;if(n=e[++i],n==="b"){for(i++;i<t;i++)if(n=e[i],n!=="_"){if(n!=="0"&&n!=="1")return!1;r=!0}return r&&n!=="_"}if(n==="x"){for(i++;i<t;i++)if(n=e[i],n!=="_"){if(!XQ(e.charCodeAt(i)))return!1;r=!0}return r&&n!=="_"}if(n==="o"){for(i++;i<t;i++)if(n=e[i],n!=="_"){if(!MQ(e.charCodeAt(i)))return!1;r=!0}return r&&n!=="_"}}if(n==="_")return!1;for(;i<t;i++)if(n=e[i],n!=="_"){if(!WQ(e.charCodeAt(i)))return!1;r=!0}return!(!r||n==="_")}function YQ(e){var t=e,i=1,r;if(t.indexOf("_")!==-1&&(t=t.replace(/_/g,"")),r=t[0],(r==="-"||r==="+")&&(r==="-"&&(i=-1),t=t.slice(1),r=t[0]),t==="0")return 0;if(r==="0"){if(t[1]==="b")return i*parseInt(t.slice(2),2);if(t[1]==="x")return i*parseInt(t.slice(2),16);if(t[1]==="o")return i*parseInt(t.slice(2),8)}return i*parseInt(t,10)}function IQ(e){return Object.prototype.toString.call(e)==="[object Number]"&&e%1===0&&!pe.isNegativeZero(e)}var LQ=new xe("tag:yaml.org,2002:int",{kind:"scalar",resolve:qQ,construct:YQ,predicate:IQ,represent:{binary:function(e){return e>=0?"0b"+e.toString(2):"-0b"+e.toString(2).slice(1)},octal:function(e){return e>=0?"0o"+e.toString(8):"-0o"+e.toString(8).slice(1)},decimal:function(e){return e.toString(10)},hexadecimal:function(e){return e>=0?"0x"+e.toString(16).toUpperCase():"-0x"+e.toString(16).toUpperCase().slice(1)}},defaultStyle:"decimal",styleAliases:{binary:[2,"bin"],octal:[8,"oct"],decimal:[10,"dec"],hexadecimal:[16,"hex"]}}),VQ=new RegExp("^(?:[-+]?(?:[0-9][0-9_]*)(?:\\.[0-9_]*)?(?:[eE][-+]?[0-9]+)?|\\.[0-9_]+(?:[eE][-+]?[0-9]+)?|[-+]?\\.(?:inf|Inf|INF)|\\.(?:nan|NaN|NAN))$");function NQ(e){return!(e===null||!VQ.test(e)||e[e.length-1]==="_")}function jQ(e){var t,i;return t=e.replace(/_/g,"").toLowerCase(),i=t[0]==="-"?-1:1,"+-".indexOf(t[0])>=0&&(t=t.slice(1)),t===".inf"?i===1?Number.POSITIVE_INFINITY:Number.NEGATIVE_INFINITY:t===".nan"?NaN:i*parseFloat(t,10)}var DQ=/^[-+]?[0-9]+e/;function _Q(e,t){var i;if(isNaN(e))switch(t){case"lowercase":return".nan";case"uppercase":return".NAN";case"camelcase":return".NaN"}else if(Number.POSITIVE_INFINITY===e)switch(t){case"lowercase":return".inf";case"uppercase":return".INF";case"camelcase":return".Inf"}else if(Number.NEGATIVE_INFINITY===e)switch(t){case"lowercase":return"-.inf";case"uppercase":return"-.INF";case"camelcase":return"-.Inf"}else if(pe.isNegativeZero(e))return"-0.0";return i=e.toString(10),DQ.test(i)?i.replace("e",".e"):i}function UQ(e){return Object.prototype.toString.call(e)==="[object Number]"&&(e%1!==0||pe.isNegativeZero(e))}var zQ=new xe("tag:yaml.org,2002:float",{kind:"scalar",resolve:NQ,construct:jQ,predicate:UQ,represent:_Q,defaultStyle:"lowercase"}),BQ=kQ.extend({implicit:[CQ,RQ,LQ,zQ]}),GQ=BQ,_g=new RegExp("^([0-9][0-9][0-9][0-9])-([0-9][0-9])-([0-9][0-9])$"),Ug=new RegExp("^([0-9][0-9][0-9][0-9])-([0-9][0-9]?)-([0-9][0-9]?)(?:[Tt]|[ \\t]+)([0-9][0-9]?):([0-9][0-9]):([0-9][0-9])(?:\\.([0-9]*))?(?:[ \\t]*(Z|([-+])([0-9][0-9]?)(?::([0-9][0-9]))?))?$");function FQ(e){return e===null?!1:_g.exec(e)!==null||Ug.exec(e)!==null}function HQ(e){var t,i,r,n,s,o,a,l=0,h=null,c,u,d;if(t=_g.exec(e),t===null&&(t=Ug.exec(e)),t===null)throw new Error("Date resolve error");if(i=+t[1],r=+t[2]-1,n=+t[3],!t[4])return new Date(Date.UTC(i,r,n));if(s=+t[4],o=+t[5],a=+t[6],t[7]){for(l=t[7].slice(0,3);l.length<3;)l+="0";l=+l}return t[9]&&(c=+t[10],u=+(t[11]||0),h=(c*60+u)*6e4,t[9]==="-"&&(h=-h)),d=new Date(Date.UTC(i,r,n,s,o,a,l)),h&&d.setTime(d.getTime()-h),d}function KQ(e){return e.toISOString()}var JQ=new xe("tag:yaml.org,2002:timestamp",{kind:"scalar",resolve:FQ,construct:HQ,instanceOf:Date,represent:KQ});function e$(e){return e==="<<"||e===null}var t$=new xe("tag:yaml.org,2002:merge",{kind:"scalar",resolve:e$}),Zh=`ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/=
-\r`;function i$(e){if(e===null)return!1;var t,i,r=0,n=e.length,s=Zh;for(i=0;i<n;i++)if(t=s.indexOf(e.charAt(i)),!(t>64)){if(t<0)return!1;r+=6}return r%8===0}function r$(e){var t,i,r=e.replace(/[\r\n=]/g,""),n=r.length,s=Zh,o=0,a=[];for(t=0;t<n;t++)t%4===0&&t&&(a.push(o>>16&255),a.push(o>>8&255),a.push(o&255)),o=o<<6|s.indexOf(r.charAt(t));return i=n%4*6,i===0?(a.push(o>>16&255),a.push(o>>8&255),a.push(o&255)):i===18?(a.push(o>>10&255),a.push(o>>2&255)):i===12&&a.push(o>>4&255),new Uint8Array(a)}function n$(e){var t="",i=0,r,n,s=e.length,o=Zh;for(r=0;r<s;r++)r%3===0&&r&&(t+=o[i>>18&63],t+=o[i>>12&63],t+=o[i>>6&63],t+=o[i&63]),i=(i<<8)+e[r];return n=s%3,n===0?(t+=o[i>>18&63],t+=o[i>>12&63],t+=o[i>>6&63],t+=o[i&63]):n===2?(t+=o[i>>10&63],t+=o[i>>4&63],t+=o[i<<2&63],t+=o[64]):n===1&&(t+=o[i>>2&63],t+=o[i<<4&63],t+=o[64],t+=o[64]),t}function s$(e){return Object.prototype.toString.call(e)==="[object Uint8Array]"}var o$=new xe("tag:yaml.org,2002:binary",{kind:"scalar",resolve:i$,construct:r$,predicate:s$,represent:n$}),a$=Object.prototype.hasOwnProperty,l$=Object.prototype.toString;function h$(e){if(e===null)return!0;var t=[],i,r,n,s,o,a=e;for(i=0,r=a.length;i<r;i+=1){if(n=a[i],o=!1,l$.call(n)!=="[object Object]")return!1;for(s in n)if(a$.call(n,s))if(!o)o=!0;else return!1;if(!o)return!1;if(t.indexOf(s)===-1)t.push(s);else return!1}return!0}function c$(e){return e!==null?e:[]}var u$=new xe("tag:yaml.org,2002:omap",{kind:"sequence",resolve:h$,construct:c$}),d$=Object.prototype.toString;function f$(e){if(e===null)return!0;var t,i,r,n,s,o=e;for(s=new Array(o.length),t=0,i=o.length;t<i;t+=1){if(r=o[t],d$.call(r)!=="[object Object]"||(n=Object.keys(r),n.length!==1))return!1;s[t]=[n[0],r[n[0]]]}return!0}function p$(e){if(e===null)return[];var t,i,r,n,s,o=e;for(s=new Array(o.length),t=0,i=o.length;t<i;t+=1)r=o[t],n=Object.keys(r),s[t]=[n[0],r[n[0]]];return s}var O$=new xe("tag:yaml.org,2002:pairs",{kind:"sequence",resolve:f$,construct:p$}),m$=Object.prototype.hasOwnProperty;function g$(e){if(e===null)return!0;var t,i=e;for(t in i)if(m$.call(i,t)&&i[t]!==null)return!1;return!0}function y$(e){return e!==null?e:{}}var b$=new xe("tag:yaml.org,2002:set",{kind:"mapping",resolve:g$,construct:y$}),zg=GQ.extend({implicit:[JQ,t$],explicit:[o$,u$,O$,b$]}),oi=Object.prototype.hasOwnProperty,eo=1,Bg=2,Gg=3,to=4,kh=1,w$=2,Cg=3,v$=/[\x00-\x08\x0B\x0C\x0E-\x1F\x7F-\x84\x86-\x9F\uFFFE\uFFFF]|[\uD800-\uDBFF](?![\uDC00-\uDFFF])|(?:[^\uD800-\uDBFF]|^)[\uDC00-\uDFFF]/,S$=/[\x85\u2028\u2029]/,x$=/[,\[\]\{\}]/,Fg=/^(?:!|!!|![a-z\-]+!)$/i,Hg=/^(?:!|[^,\[\]\{\}])(?:%[0-9a-f]{2}|[0-9a-z\-#;\/\?:@&=\+\$,_\.!~\*'\(\)\[\]])*$/i;function Ag(e){return Object.prototype.toString.call(e)}function Tt(e){return e===10||e===13}function ki(e){return e===9||e===32}function Ne(e){return e===9||e===32||e===10||e===13}function nr(e){return e===44||e===91||e===93||e===123||e===125}function P$(e){var t;return 48<=e&&e<=57?e-48:(t=e|32,97<=t&&t<=102?t-97+10:-1)}function k$(e){return e===120?2:e===117?4:e===85?8:0}function Q$(e){return 48<=e&&e<=57?e-48:-1}function Zg(e){return e===48?"\0":e===97?"\x07":e===98?"\b":e===116||e===9?"	":e===110?`
-`:e===118?"\v":e===102?"\f":e===114?"\r":e===101?"\x1B":e===32?" ":e===34?'"':e===47?"/":e===92?"\\":e===78?"\x85":e===95?"\xA0":e===76?"\u2028":e===80?"\u2029":""}function $$(e){return e<=65535?String.fromCharCode(e):String.fromCharCode((e-65536>>10)+55296,(e-65536&1023)+56320)}var Kg=new Array(256),Jg=new Array(256);for(Pi=0;Pi<256;Pi++)Kg[Pi]=Zg(Pi)?1:0,Jg[Pi]=Zg(Pi);var Pi;function T$(e,t){this.input=e,this.filename=t.filename||null,this.schema=t.schema||zg,this.onWarning=t.onWarning||null,this.legacy=t.legacy||!1,this.json=t.json||!1,this.listener=t.listener||null,this.implicitTypes=this.schema.compiledImplicit,this.typeMap=this.schema.compiledTypeMap,this.length=e.length,this.position=0,this.line=0,this.lineStart=0,this.lineIndent=0,this.firstTabInLine=-1,this.documents=[]}function e0(e,t){var i={name:e.filename,buffer:e.input.slice(0,-1),position:e.position,line:e.line,column:e.position-e.lineStart};return i.snippet=OQ(i),new Ve(t,i)}function X(e,t){throw e0(e,t)}function io(e,t){e.onWarning&&e.onWarning.call(null,e0(e,t))}var Eg={YAML:function(e,t,i){var r,n,s;e.version!==null&&X(e,"duplication of %YAML directive"),i.length!==1&&X(e,"YAML directive accepts exactly one argument"),r=/^([0-9]+)\.([0-9]+)$/.exec(i[0]),r===null&&X(e,"ill-formed argument of the YAML directive"),n=parseInt(r[1],10),s=parseInt(r[2],10),n!==1&&X(e,"unacceptable YAML version of the document"),e.version=i[0],e.checkLineBreaks=s<2,s!==1&&s!==2&&io(e,"unsupported YAML version of the document")},TAG:function(e,t,i){var r,n;i.length!==2&&X(e,"TAG directive accepts exactly two arguments"),r=i[0],n=i[1],Fg.test(r)||X(e,"ill-formed tag handle (first argument) of the TAG directive"),oi.call(e.tagMap,r)&&X(e,'there is a previously declared suffix for "'+r+'" tag handle'),Hg.test(n)||X(e,"ill-formed tag prefix (second argument) of the TAG directive");try{n=decodeURIComponent(n)}catch{X(e,"tag prefix is malformed: "+n)}e.tagMap[r]=n}};function si(e,t,i,r){var n,s,o,a;if(t<i){if(a=e.input.slice(t,i),r)for(n=0,s=a.length;n<s;n+=1)o=a.charCodeAt(n),o===9||32<=o&&o<=1114111||X(e,"expected valid JSON character");else v$.test(a)&&X(e,"the stream contains non-printable characters");e.result+=a}}function Rg(e,t,i,r){var n,s,o,a;for(pe.isObject(i)||X(e,"cannot merge mappings; the provided source object is unacceptable"),n=Object.keys(i),o=0,a=n.length;o<a;o+=1)s=n[o],oi.call(t,s)||(t[s]=i[s],r[s]=!0)}function sr(e,t,i,r,n,s,o,a,l){var h,c;if(Array.isArray(n))for(n=Array.prototype.slice.call(n),h=0,c=n.length;h<c;h+=1)Array.isArray(n[h])&&X(e,"nested arrays are not supported inside keys"),typeof n=="object"&&Ag(n[h])==="[object Object]"&&(n[h]="[object Object]");if(typeof n=="object"&&Ag(n)==="[object Object]"&&(n="[object Object]"),n=String(n),t===null&&(t={}),r==="tag:yaml.org,2002:merge")if(Array.isArray(s))for(h=0,c=s.length;h<c;h+=1)Rg(e,t,s[h],i);else Rg(e,t,s,i);else!e.json&&!oi.call(i,n)&&oi.call(t,n)&&(e.line=o||e.line,e.lineStart=a||e.lineStart,e.position=l||e.position,X(e,"duplicated mapping key")),n==="__proto__"?Object.defineProperty(t,n,{configurable:!0,enumerable:!0,writable:!0,value:s}):t[n]=s,delete i[n];return t}function Eh(e){var t;t=e.input.charCodeAt(e.position),t===10?e.position++:t===13?(e.position++,e.input.charCodeAt(e.position)===10&&e.position++):X(e,"a line break is expected"),e.line+=1,e.lineStart=e.position,e.firstTabInLine=-1}function de(e,t,i){for(var r=0,n=e.input.charCodeAt(e.position);n!==0;){for(;ki(n);)n===9&&e.firstTabInLine===-1&&(e.firstTabInLine=e.position),n=e.input.charCodeAt(++e.position);if(t&&n===35)do n=e.input.charCodeAt(++e.position);while(n!==10&&n!==13&&n!==0);if(Tt(n))for(Eh(e),n=e.input.charCodeAt(e.position),r++,e.lineIndent=0;n===32;)e.lineIndent++,n=e.input.charCodeAt(++e.position);else break}return i!==-1&&r!==0&&e.lineIndent<i&&io(e,"deficient indentation"),r}function so(e){var t=e.position,i;return i=e.input.charCodeAt(t),!!((i===45||i===46)&&i===e.input.charCodeAt(t+1)&&i===e.input.charCodeAt(t+2)&&(t+=3,i=e.input.charCodeAt(t),i===0||Ne(i)))}function Rh(e,t){t===1?e.result+=" ":t>1&&(e.result+=pe.repeat(`
-`,t-1))}function C$(e,t,i){var r,n,s,o,a,l,h,c,u=e.kind,d=e.result,f;if(f=e.input.charCodeAt(e.position),Ne(f)||nr(f)||f===35||f===38||f===42||f===33||f===124||f===62||f===39||f===34||f===37||f===64||f===96||(f===63||f===45)&&(n=e.input.charCodeAt(e.position+1),Ne(n)||i&&nr(n)))return!1;for(e.kind="scalar",e.result="",s=o=e.position,a=!1;f!==0;){if(f===58){if(n=e.input.charCodeAt(e.position+1),Ne(n)||i&&nr(n))break}else if(f===35){if(r=e.input.charCodeAt(e.position-1),Ne(r))break}else{if(e.position===e.lineStart&&so(e)||i&&nr(f))break;if(Tt(f))if(l=e.line,h=e.lineStart,c=e.lineIndent,de(e,!1,-1),e.lineIndent>=t){a=!0,f=e.input.charCodeAt(e.position);continue}else{e.position=o,e.line=l,e.lineStart=h,e.lineIndent=c;break}}a&&(si(e,s,o,!1),Rh(e,e.line-l),s=o=e.position,a=!1),ki(f)||(o=e.position+1),f=e.input.charCodeAt(++e.position)}return si(e,s,o,!1),e.result?!0:(e.kind=u,e.result=d,!1)}function A$(e,t){var i,r,n;if(i=e.input.charCodeAt(e.position),i!==39)return!1;for(e.kind="scalar",e.result="",e.position++,r=n=e.position;(i=e.input.charCodeAt(e.position))!==0;)if(i===39)if(si(e,r,e.position,!0),i=e.input.charCodeAt(++e.position),i===39)r=e.position,e.position++,n=e.position;else return!0;else Tt(i)?(si(e,r,n,!0),Rh(e,de(e,!1,t)),r=n=e.position):e.position===e.lineStart&&so(e)?X(e,"unexpected end of the document within a single quoted scalar"):(e.position++,n=e.position);X(e,"unexpected end of the stream within a single quoted scalar")}function Z$(e,t){var i,r,n,s,o,a;if(a=e.input.charCodeAt(e.position),a!==34)return!1;for(e.kind="scalar",e.result="",e.position++,i=r=e.position;(a=e.input.charCodeAt(e.position))!==0;){if(a===34)return si(e,i,e.position,!0),e.position++,!0;if(a===92){if(si(e,i,e.position,!0),a=e.input.charCodeAt(++e.position),Tt(a))de(e,!1,t);else if(a<256&&Kg[a])e.result+=Jg[a],e.position++;else if((o=k$(a))>0){for(n=o,s=0;n>0;n--)a=e.input.charCodeAt(++e.position),(o=P$(a))>=0?s=(s<<4)+o:X(e,"expected hexadecimal character");e.result+=$$(s),e.position++}else X(e,"unknown escape sequence");i=r=e.position}else Tt(a)?(si(e,i,r,!0),Rh(e,de(e,!1,t)),i=r=e.position):e.position===e.lineStart&&so(e)?X(e,"unexpected end of the document within a double quoted scalar"):(e.position++,r=e.position)}X(e,"unexpected end of the stream within a double quoted scalar")}function E$(e,t){var i=!0,r,n,s,o=e.tag,a,l=e.anchor,h,c,u,d,f,p=Object.create(null),O,g,y,b;if(b=e.input.charCodeAt(e.position),b===91)c=93,f=!1,a=[];else if(b===123)c=125,f=!0,a={};else return!1;for(e.anchor!==null&&(e.anchorMap[e.anchor]=a),b=e.input.charCodeAt(++e.position);b!==0;){if(de(e,!0,t),b=e.input.charCodeAt(e.position),b===c)return e.position++,e.tag=o,e.anchor=l,e.kind=f?"mapping":"sequence",e.result=a,!0;i?b===44&&X(e,"expected the node content, but found ','"):X(e,"missed comma between flow collection entries"),g=O=y=null,u=d=!1,b===63&&(h=e.input.charCodeAt(e.position+1),Ne(h)&&(u=d=!0,e.position++,de(e,!0,t))),r=e.line,n=e.lineStart,s=e.position,or(e,t,eo,!1,!0),g=e.tag,O=e.result,de(e,!0,t),b=e.input.charCodeAt(e.position),(d||e.line===r)&&b===58&&(u=!0,b=e.input.charCodeAt(++e.position),de(e,!0,t),or(e,t,eo,!1,!0),y=e.result),f?sr(e,a,p,g,O,y,r,n,s):u?a.push(sr(e,null,p,g,O,y,r,n,s)):a.push(O),de(e,!0,t),b=e.input.charCodeAt(e.position),b===44?(i=!0,b=e.input.charCodeAt(++e.position)):i=!1}X(e,"unexpected end of the stream within a flow collection")}function R$(e,t){var i,r,n=kh,s=!1,o=!1,a=t,l=0,h=!1,c,u;if(u=e.input.charCodeAt(e.position),u===124)r=!1;else if(u===62)r=!0;else return!1;for(e.kind="scalar",e.result="";u!==0;)if(u=e.input.charCodeAt(++e.position),u===43||u===45)kh===n?n=u===43?Cg:w$:X(e,"repeat of a chomping mode identifier");else if((c=Q$(u))>=0)c===0?X(e,"bad explicit indentation width of a block scalar; it cannot be less than one"):o?X(e,"repeat of an indentation width identifier"):(a=t+c-1,o=!0);else break;if(ki(u)){do u=e.input.charCodeAt(++e.position);while(ki(u));if(u===35)do u=e.input.charCodeAt(++e.position);while(!Tt(u)&&u!==0)}for(;u!==0;){for(Eh(e),e.lineIndent=0,u=e.input.charCodeAt(e.position);(!o||e.lineIndent<a)&&u===32;)e.lineIndent++,u=e.input.charCodeAt(++e.position);if(!o&&e.lineIndent>a&&(a=e.lineIndent),Tt(u)){l++;continue}if(e.lineIndent<a){n===Cg?e.result+=pe.repeat(`
-`,s?1+l:l):n===kh&&s&&(e.result+=`
-`);break}for(r?ki(u)?(h=!0,e.result+=pe.repeat(`
-`,s?1+l:l)):h?(h=!1,e.result+=pe.repeat(`
-`,l+1)):l===0?s&&(e.result+=" "):e.result+=pe.repeat(`
-`,l):e.result+=pe.repeat(`
-`,s?1+l:l),s=!0,o=!0,l=0,i=e.position;!Tt(u)&&u!==0;)u=e.input.charCodeAt(++e.position);si(e,i,e.position,!1)}return!0}function Xg(e,t){var i,r=e.tag,n=e.anchor,s=[],o,a=!1,l;if(e.firstTabInLine!==-1)return!1;for(e.anchor!==null&&(e.anchorMap[e.anchor]=s),l=e.input.charCodeAt(e.position);l!==0&&(e.firstTabInLine!==-1&&(e.position=e.firstTabInLine,X(e,"tab characters must not be used in indentation")),!(l!==45||(o=e.input.charCodeAt(e.position+1),!Ne(o))));){if(a=!0,e.position++,de(e,!0,-1)&&e.lineIndent<=t){s.push(null),l=e.input.charCodeAt(e.position);continue}if(i=e.line,or(e,t,Gg,!1,!0),s.push(e.result),de(e,!0,-1),l=e.input.charCodeAt(e.position),(e.line===i||e.lineIndent>t)&&l!==0)X(e,"bad indentation of a sequence entry");else if(e.lineIndent<t)break}return a?(e.tag=r,e.anchor=n,e.kind="sequence",e.result=s,!0):!1}function X$(e,t,i){var r,n,s,o,a,l,h=e.tag,c=e.anchor,u={},d=Object.create(null),f=null,p=null,O=null,g=!1,y=!1,b;if(e.firstTabInLine!==-1)return!1;for(e.anchor!==null&&(e.anchorMap[e.anchor]=u),b=e.input.charCodeAt(e.position);b!==0;){if(!g&&e.firstTabInLine!==-1&&(e.position=e.firstTabInLine,X(e,"tab characters must not be used in indentation")),r=e.input.charCodeAt(e.position+1),s=e.line,(b===63||b===58)&&Ne(r))b===63?(g&&(sr(e,u,d,f,p,null,o,a,l),f=p=O=null),y=!0,g=!0,n=!0):g?(g=!1,n=!0):X(e,"incomplete explicit mapping pair; a key node is missed; or followed by a non-tabulated empty line"),e.position+=1,b=r;else{if(o=e.line,a=e.lineStart,l=e.position,!or(e,i,Bg,!1,!0))break;if(e.line===s){for(b=e.input.charCodeAt(e.position);ki(b);)b=e.input.charCodeAt(++e.position);if(b===58)b=e.input.charCodeAt(++e.position),Ne(b)||X(e,"a whitespace character is expected after the key-value separator within a block mapping"),g&&(sr(e,u,d,f,p,null,o,a,l),f=p=O=null),y=!0,g=!1,n=!1,f=e.tag,p=e.result;else if(y)X(e,"can not read an implicit mapping pair; a colon is missed");else return e.tag=h,e.anchor=c,!0}else if(y)X(e,"can not read a block mapping entry; a multiline key may not be an implicit key");else return e.tag=h,e.anchor=c,!0}if((e.line===s||e.lineIndent>t)&&(g&&(o=e.line,a=e.lineStart,l=e.position),or(e,t,to,!0,n)&&(g?p=e.result:O=e.result),g||(sr(e,u,d,f,p,O,o,a,l),f=p=O=null),de(e,!0,-1),b=e.input.charCodeAt(e.position)),(e.line===s||e.lineIndent>t)&&b!==0)X(e,"bad indentation of a mapping entry");else if(e.lineIndent<t)break}return g&&sr(e,u,d,f,p,null,o,a,l),y&&(e.tag=h,e.anchor=c,e.kind="mapping",e.result=u),y}function M$(e){var t,i=!1,r=!1,n,s,o;if(o=e.input.charCodeAt(e.position),o!==33)return!1;if(e.tag!==null&&X(e,"duplication of a tag property"),o=e.input.charCodeAt(++e.position),o===60?(i=!0,o=e.input.charCodeAt(++e.position)):o===33?(r=!0,n="!!",o=e.input.charCodeAt(++e.position)):n="!",t=e.position,i){do o=e.input.charCodeAt(++e.position);while(o!==0&&o!==62);e.position<e.length?(s=e.input.slice(t,e.position),o=e.input.charCodeAt(++e.position)):X(e,"unexpected end of the stream within a verbatim tag")}else{for(;o!==0&&!Ne(o);)o===33&&(r?X(e,"tag suffix cannot contain exclamation marks"):(n=e.input.slice(t-1,e.position+1),Fg.test(n)||X(e,"named tag handle cannot contain such characters"),r=!0,t=e.position+1)),o=e.input.charCodeAt(++e.position);s=e.input.slice(t,e.position),x$.test(s)&&X(e,"tag suffix cannot contain flow indicator characters")}s&&!Hg.test(s)&&X(e,"tag name cannot contain such characters: "+s);try{s=decodeURIComponent(s)}catch{X(e,"tag name is malformed: "+s)}return i?e.tag=s:oi.call(e.tagMap,n)?e.tag=e.tagMap[n]+s:n==="!"?e.tag="!"+s:n==="!!"?e.tag="tag:yaml.org,2002:"+s:X(e,'undeclared tag handle "'+n+'"'),!0}function W$(e){var t,i;if(i=e.input.charCodeAt(e.position),i!==38)return!1;for(e.anchor!==null&&X(e,"duplication of an anchor property"),i=e.input.charCodeAt(++e.position),t=e.position;i!==0&&!Ne(i)&&!nr(i);)i=e.input.charCodeAt(++e.position);return e.position===t&&X(e,"name of an anchor node must contain at least one character"),e.anchor=e.input.slice(t,e.position),!0}function q$(e){var t,i,r;if(r=e.input.charCodeAt(e.position),r!==42)return!1;for(r=e.input.charCodeAt(++e.position),t=e.position;r!==0&&!Ne(r)&&!nr(r);)r=e.input.charCodeAt(++e.position);return e.position===t&&X(e,"name of an alias node must contain at least one character"),i=e.input.slice(t,e.position),oi.call(e.anchorMap,i)||X(e,'unidentified alias "'+i+'"'),e.result=e.anchorMap[i],de(e,!0,-1),!0}function or(e,t,i,r,n){var s,o,a,l=1,h=!1,c=!1,u,d,f,p,O,g;if(e.listener!==null&&e.listener("open",e),e.tag=null,e.anchor=null,e.kind=null,e.result=null,s=o=a=to===i||Gg===i,r&&de(e,!0,-1)&&(h=!0,e.lineIndent>t?l=1:e.lineIndent===t?l=0:e.lineIndent<t&&(l=-1)),l===1)for(;M$(e)||W$(e);)de(e,!0,-1)?(h=!0,a=s,e.lineIndent>t?l=1:e.lineIndent===t?l=0:e.lineIndent<t&&(l=-1)):a=!1;if(a&&(a=h||n),(l===1||to===i)&&(eo===i||Bg===i?O=t:O=t+1,g=e.position-e.lineStart,l===1?a&&(Xg(e,g)||X$(e,g,O))||E$(e,O)?c=!0:(o&&R$(e,O)||A$(e,O)||Z$(e,O)?c=!0:q$(e)?(c=!0,(e.tag!==null||e.anchor!==null)&&X(e,"alias node should not have any properties")):C$(e,O,eo===i)&&(c=!0,e.tag===null&&(e.tag="?")),e.anchor!==null&&(e.anchorMap[e.anchor]=e.result)):l===0&&(c=a&&Xg(e,g))),e.tag===null)e.anchor!==null&&(e.anchorMap[e.anchor]=e.result);else if(e.tag==="?"){for(e.result!==null&&e.kind!=="scalar"&&X(e,'unacceptable node kind for !<?> tag; it should be "scalar", not "'+e.kind+'"'),u=0,d=e.implicitTypes.length;u<d;u+=1)if(p=e.implicitTypes[u],p.resolve(e.result)){e.result=p.construct(e.result),e.tag=p.tag,e.anchor!==null&&(e.anchorMap[e.anchor]=e.result);break}}else if(e.tag!=="!"){if(oi.call(e.typeMap[e.kind||"fallback"],e.tag))p=e.typeMap[e.kind||"fallback"][e.tag];else for(p=null,f=e.typeMap.multi[e.kind||"fallback"],u=0,d=f.length;u<d;u+=1)if(e.tag.slice(0,f[u].tag.length)===f[u].tag){p=f[u];break}p||X(e,"unknown tag !<"+e.tag+">"),e.result!==null&&p.kind!==e.kind&&X(e,"unacceptable node kind for !<"+e.tag+'> tag; it should be "'+p.kind+'", not "'+e.kind+'"'),p.resolve(e.result,e.tag)?(e.result=p.construct(e.result,e.tag),e.anchor!==null&&(e.anchorMap[e.anchor]=e.result)):X(e,"cannot resolve a node with !<"+e.tag+"> explicit tag")}return e.listener!==null&&e.listener("close",e),e.tag!==null||e.anchor!==null||c}function Y$(e){var t=e.position,i,r,n,s=!1,o;for(e.version=null,e.checkLineBreaks=e.legacy,e.tagMap=Object.create(null),e.anchorMap=Object.create(null);(o=e.input.charCodeAt(e.position))!==0&&(de(e,!0,-1),o=e.input.charCodeAt(e.position),!(e.lineIndent>0||o!==37));){for(s=!0,o=e.input.charCodeAt(++e.position),i=e.position;o!==0&&!Ne(o);)o=e.input.charCodeAt(++e.position);for(r=e.input.slice(i,e.position),n=[],r.length<1&&X(e,"directive name must not be less than one character in length");o!==0;){for(;ki(o);)o=e.input.charCodeAt(++e.position);if(o===35){do o=e.input.charCodeAt(++e.position);while(o!==0&&!Tt(o));break}if(Tt(o))break;for(i=e.position;o!==0&&!Ne(o);)o=e.input.charCodeAt(++e.position);n.push(e.input.slice(i,e.position))}o!==0&&Eh(e),oi.call(Eg,r)?Eg[r](e,r,n):io(e,'unknown document directive "'+r+'"')}if(de(e,!0,-1),e.lineIndent===0&&e.input.charCodeAt(e.position)===45&&e.input.charCodeAt(e.position+1)===45&&e.input.charCodeAt(e.position+2)===45?(e.position+=3,de(e,!0,-1)):s&&X(e,"directives end mark is expected"),or(e,e.lineIndent-1,to,!1,!0),de(e,!0,-1),e.checkLineBreaks&&S$.test(e.input.slice(t,e.position))&&io(e,"non-ASCII line breaks are interpreted as content"),e.documents.push(e.result),e.position===e.lineStart&&so(e)){e.input.charCodeAt(e.position)===46&&(e.position+=3,de(e,!0,-1));return}if(e.position<e.length-1)X(e,"end of the stream or a document separator is expected");else return}function t0(e,t){e=String(e),t=t||{},e.length!==0&&(e.charCodeAt(e.length-1)!==10&&e.charCodeAt(e.length-1)!==13&&(e+=`
-`),e.charCodeAt(0)===65279&&(e=e.slice(1)));var i=new T$(e,t),r=e.indexOf("\0");for(r!==-1&&(i.position=r,X(i,"null byte is not allowed in input")),i.input+="\0";i.input.charCodeAt(i.position)===32;)i.lineIndent+=1,i.position+=1;for(;i.position<i.length-1;)Y$(i);return i.documents}function I$(e,t,i){t!==null&&typeof t=="object"&&typeof i>"u"&&(i=t,t=null);var r=t0(e,i);if(typeof t!="function")return r;for(var n=0,s=r.length;n<s;n+=1)t(r[n])}function L$(e,t){var i=t0(e,t);if(i.length!==0){if(i.length===1)return i[0];throw new Ve("expected a single document in the stream, but found more")}}var V$=I$,N$=L$,i0={loadAll:V$,load:N$},r0=Object.prototype.toString,n0=Object.prototype.hasOwnProperty,Xh=65279,j$=9,sn=10,D$=13,_$=32,U$=33,z$=34,$h=35,B$=37,G$=38,F$=39,H$=42,s0=44,K$=45,ro=58,J$=61,eT=62,tT=63,iT=64,o0=91,a0=93,rT=96,l0=123,nT=124,h0=125,Pe={};Pe[0]="\\0";Pe[7]="\\a";Pe[8]="\\b";Pe[9]="\\t";Pe[10]="\\n";Pe[11]="\\v";Pe[12]="\\f";Pe[13]="\\r";Pe[27]="\\e";Pe[34]='\\"';Pe[92]="\\\\";Pe[133]="\\N";Pe[160]="\\_";Pe[8232]="\\L";Pe[8233]="\\P";var sT=["y","Y","yes","Yes","YES","on","On","ON","n","N","no","No","NO","off","Off","OFF"],oT=/^[-+]?[0-9_]+(?::[0-9_]+)+(?:\.[0-9_]*)?$/;function aT(e,t){var i,r,n,s,o,a,l;if(t===null)return{};for(i={},r=Object.keys(t),n=0,s=r.length;n<s;n+=1)o=r[n],a=String(t[o]),o.slice(0,2)==="!!"&&(o="tag:yaml.org,2002:"+o.slice(2)),l=e.compiledTypeMap.fallback[o],l&&n0.call(l.styleAliases,a)&&(a=l.styleAliases[a]),i[o]=a;return i}function lT(e){var t,i,r;if(t=e.toString(16).toUpperCase(),e<=255)i="x",r=2;else if(e<=65535)i="u",r=4;else if(e<=4294967295)i="U",r=8;else throw new Ve("code point within a string may not be greater than 0xFFFFFFFF");return"\\"+i+pe.repeat("0",r-t.length)+t}var hT=1,on=2;function cT(e){this.schema=e.schema||zg,this.indent=Math.max(1,e.indent||2),this.noArrayIndent=e.noArrayIndent||!1,this.skipInvalid=e.skipInvalid||!1,this.flowLevel=pe.isNothing(e.flowLevel)?-1:e.flowLevel,this.styleMap=aT(this.schema,e.styles||null),this.sortKeys=e.sortKeys||!1,this.lineWidth=e.lineWidth||80,this.noRefs=e.noRefs||!1,this.noCompatMode=e.noCompatMode||!1,this.condenseFlow=e.condenseFlow||!1,this.quotingType=e.quotingType==='"'?on:hT,this.forceQuotes=e.forceQuotes||!1,this.replacer=typeof e.replacer=="function"?e.replacer:null,this.implicitTypes=this.schema.compiledImplicit,this.explicitTypes=this.schema.compiledExplicit,this.tag=null,this.result="",this.duplicates=[],this.usedDuplicates=null}function Mg(e,t){for(var i=pe.repeat(" ",t),r=0,n=-1,s="",o,a=e.length;r<a;)n=e.indexOf(`
-`,r),n===-1?(o=e.slice(r),r=a):(o=e.slice(r,n+1),r=n+1),o.length&&o!==`
-`&&(s+=i),s+=o;return s}function Th(e,t){return`
-`+pe.repeat(" ",e.indent*t)}function uT(e,t){var i,r,n;for(i=0,r=e.implicitTypes.length;i<r;i+=1)if(n=e.implicitTypes[i],n.resolve(t))return!0;return!1}function no(e){return e===_$||e===j$}function an(e){return 32<=e&&e<=126||161<=e&&e<=55295&&e!==8232&&e!==8233||57344<=e&&e<=65533&&e!==Xh||65536<=e&&e<=1114111}function Wg(e){return an(e)&&e!==Xh&&e!==D$&&e!==sn}function qg(e,t,i){var r=Wg(e),n=r&&!no(e);return(i?r:r&&e!==s0&&e!==o0&&e!==a0&&e!==l0&&e!==h0)&&e!==$h&&!(t===ro&&!n)||Wg(t)&&!no(t)&&e===$h||t===ro&&n}function dT(e){return an(e)&&e!==Xh&&!no(e)&&e!==K$&&e!==tT&&e!==ro&&e!==s0&&e!==o0&&e!==a0&&e!==l0&&e!==h0&&e!==$h&&e!==G$&&e!==H$&&e!==U$&&e!==nT&&e!==J$&&e!==eT&&e!==F$&&e!==z$&&e!==B$&&e!==iT&&e!==rT}function fT(e){return!no(e)&&e!==ro}function rn(e,t){var i=e.charCodeAt(t),r;return i>=55296&&i<=56319&&t+1<e.length&&(r=e.charCodeAt(t+1),r>=56320&&r<=57343)?(i-55296)*1024+r-56320+65536:i}function c0(e){var t=/^\n* /;return t.test(e)}var u0=1,Ch=2,d0=3,f0=4,rr=5;function pT(e,t,i,r,n,s,o,a){var l,h=0,c=null,u=!1,d=!1,f=r!==-1,p=-1,O=dT(rn(e,0))&&fT(rn(e,e.length-1));if(t||o)for(l=0;l<e.length;h>=65536?l+=2:l++){if(h=rn(e,l),!an(h))return rr;O=O&&qg(h,c,a),c=h}else{for(l=0;l<e.length;h>=65536?l+=2:l++){if(h=rn(e,l),h===sn)u=!0,f&&(d=d||l-p-1>r&&e[p+1]!==" ",p=l);else if(!an(h))return rr;O=O&&qg(h,c,a),c=h}d=d||f&&l-p-1>r&&e[p+1]!==" "}return!u&&!d?O&&!o&&!n(e)?u0:s===on?rr:Ch:i>9&&c0(e)?rr:o?s===on?rr:Ch:d?f0:d0}function OT(e,t,i,r,n){e.dump=function(){if(t.length===0)return e.quotingType===on?'""':"''";if(!e.noCompatMode&&(sT.indexOf(t)!==-1||oT.test(t)))return e.quotingType===on?'"'+t+'"':"'"+t+"'";var s=e.indent*Math.max(1,i),o=e.lineWidth===-1?-1:Math.max(Math.min(e.lineWidth,40),e.lineWidth-s),a=r||e.flowLevel>-1&&i>=e.flowLevel;function l(h){return uT(e,h)}switch(pT(t,a,e.indent,o,l,e.quotingType,e.forceQuotes&&!r,n)){case u0:return t;case Ch:return"'"+t.replace(/'/g,"''")+"'";case d0:return"|"+Yg(t,e.indent)+Ig(Mg(t,s));case f0:return">"+Yg(t,e.indent)+Ig(Mg(mT(t,o),s));case rr:return'"'+gT(t)+'"';default:throw new Ve("impossible error: invalid scalar style")}}()}function Yg(e,t){var i=c0(e)?String(t):"",r=e[e.length-1]===`
-`,n=r&&(e[e.length-2]===`
-`||e===`
-`),s=n?"+":r?"":"-";return i+s+`
-`}function Ig(e){return e[e.length-1]===`
-`?e.slice(0,-1):e}function mT(e,t){for(var i=/(\n+)([^\n]*)/g,r=function(){var h=e.indexOf(`
-`);return h=h!==-1?h:e.length,i.lastIndex=h,Lg(e.slice(0,h),t)}(),n=e[0]===`
-`||e[0]===" ",s,o;o=i.exec(e);){var a=o[1],l=o[2];s=l[0]===" ",r+=a+(!n&&!s&&l!==""?`
-`:"")+Lg(l,t),n=s}return r}function Lg(e,t){if(e===""||e[0]===" ")return e;for(var i=/ [^ ]/g,r,n=0,s,o=0,a=0,l="";r=i.exec(e);)a=r.index,a-n>t&&(s=o>n?o:a,l+=`
-`+e.slice(n,s),n=s+1),o=a;return l+=`
-`,e.length-n>t&&o>n?l+=e.slice(n,o)+`
-`+e.slice(o+1):l+=e.slice(n),l.slice(1)}function gT(e){for(var t="",i=0,r,n=0;n<e.length;i>=65536?n+=2:n++)i=rn(e,n),r=Pe[i],!r&&an(i)?(t+=e[n],i>=65536&&(t+=e[n+1])):t+=r||lT(i);return t}function yT(e,t,i){var r="",n=e.tag,s,o,a;for(s=0,o=i.length;s<o;s+=1)a=i[s],e.replacer&&(a=e.replacer.call(i,String(s),a)),(Vt(e,t,a,!1,!1)||typeof a>"u"&&Vt(e,t,null,!1,!1))&&(r!==""&&(r+=","+(e.condenseFlow?"":" ")),r+=e.dump);e.tag=n,e.dump="["+r+"]"}function Vg(e,t,i,r){var n="",s=e.tag,o,a,l;for(o=0,a=i.length;o<a;o+=1)l=i[o],e.replacer&&(l=e.replacer.call(i,String(o),l)),(Vt(e,t+1,l,!0,!0,!1,!0)||typeof l>"u"&&Vt(e,t+1,null,!0,!0,!1,!0))&&((!r||n!=="")&&(n+=Th(e,t)),e.dump&&sn===e.dump.charCodeAt(0)?n+="-":n+="- ",n+=e.dump);e.tag=s,e.dump=n||"[]"}function bT(e,t,i){var r="",n=e.tag,s=Object.keys(i),o,a,l,h,c;for(o=0,a=s.length;o<a;o+=1)c="",r!==""&&(c+=", "),e.condenseFlow&&(c+='"'),l=s[o],h=i[l],e.replacer&&(h=e.replacer.call(i,l,h)),Vt(e,t,l,!1,!1)&&(e.dump.length>1024&&(c+="? "),c+=e.dump+(e.condenseFlow?'"':"")+":"+(e.condenseFlow?"":" "),Vt(e,t,h,!1,!1)&&(c+=e.dump,r+=c));e.tag=n,e.dump="{"+r+"}"}function wT(e,t,i,r){var n="",s=e.tag,o=Object.keys(i),a,l,h,c,u,d;if(e.sortKeys===!0)o.sort();else if(typeof e.sortKeys=="function")o.sort(e.sortKeys);else if(e.sortKeys)throw new Ve("sortKeys must be a boolean or a function");for(a=0,l=o.length;a<l;a+=1)d="",(!r||n!=="")&&(d+=Th(e,t)),h=o[a],c=i[h],e.replacer&&(c=e.replacer.call(i,h,c)),Vt(e,t+1,h,!0,!0,!0)&&(u=e.tag!==null&&e.tag!=="?"||e.dump&&e.dump.length>1024,u&&(e.dump&&sn===e.dump.charCodeAt(0)?d+="?":d+="? "),d+=e.dump,u&&(d+=Th(e,t)),Vt(e,t+1,c,!0,u)&&(e.dump&&sn===e.dump.charCodeAt(0)?d+=":":d+=": ",d+=e.dump,n+=d));e.tag=s,e.dump=n||"{}"}function Ng(e,t,i){var r,n,s,o,a,l;for(n=i?e.explicitTypes:e.implicitTypes,s=0,o=n.length;s<o;s+=1)if(a=n[s],(a.instanceOf||a.predicate)&&(!a.instanceOf||typeof t=="object"&&t instanceof a.instanceOf)&&(!a.predicate||a.predicate(t))){if(i?a.multi&&a.representName?e.tag=a.representName(t):e.tag=a.tag:e.tag="?",a.represent){if(l=e.styleMap[a.tag]||a.defaultStyle,r0.call(a.represent)==="[object Function]")r=a.represent(t,l);else if(n0.call(a.represent,l))r=a.represent[l](t,l);else throw new Ve("!<"+a.tag+'> tag resolver accepts not "'+l+'" style');e.dump=r}return!0}return!1}function Vt(e,t,i,r,n,s,o){e.tag=null,e.dump=i,Ng(e,i,!1)||Ng(e,i,!0);var a=r0.call(e.dump),l=r,h;r&&(r=e.flowLevel<0||e.flowLevel>t);var c=a==="[object Object]"||a==="[object Array]",u,d;if(c&&(u=e.duplicates.indexOf(i),d=u!==-1),(e.tag!==null&&e.tag!=="?"||d||e.indent!==2&&t>0)&&(n=!1),d&&e.usedDuplicates[u])e.dump="*ref_"+u;else{if(c&&d&&!e.usedDuplicates[u]&&(e.usedDuplicates[u]=!0),a==="[object Object]")r&&Object.keys(e.dump).length!==0?(wT(e,t,e.dump,n),d&&(e.dump="&ref_"+u+e.dump)):(bT(e,t,e.dump),d&&(e.dump="&ref_"+u+" "+e.dump));else if(a==="[object Array]")r&&e.dump.length!==0?(e.noArrayIndent&&!o&&t>0?Vg(e,t-1,e.dump,n):Vg(e,t,e.dump,n),d&&(e.dump="&ref_"+u+e.dump)):(yT(e,t,e.dump),d&&(e.dump="&ref_"+u+" "+e.dump));else if(a==="[object String]")e.tag!=="?"&&OT(e,e.dump,t,s,l);else{if(a==="[object Undefined]"||e.skipInvalid)return!1;throw new Ve("unacceptable kind of an object to dump "+a)}e.tag!==null&&e.tag!=="?"&&(h=encodeURI(e.tag[0]==="!"?e.tag.slice(1):e.tag).replace(/!/g,"%21"),e.tag[0]==="!"?h="!"+h:h.slice(0,18)==="tag:yaml.org,2002:"?h="!!"+h.slice(18):h="!<"+h+">",e.dump=h+" "+e.dump)}return!0}function vT(e,t){var i=[],r=[],n,s;for(Ah(e,i,r),n=0,s=r.length;n<s;n+=1)t.duplicates.push(i[r[n]]);t.usedDuplicates=new Array(s)}function Ah(e,t,i){var r,n,s;if(e!==null&&typeof e=="object")if(n=t.indexOf(e),n!==-1)i.indexOf(n)===-1&&i.push(n);else if(t.push(e),Array.isArray(e))for(n=0,s=e.length;n<s;n+=1)Ah(e[n],t,i);else for(r=Object.keys(e),n=0,s=r.length;n<s;n+=1)Ah(e[r[n]],t,i)}function ST(e,t){t=t||{};var i=new cT(t);i.noRefs||vT(e,i);var r=e;return i.replacer&&(r=i.replacer.call({"":r},"",r)),Vt(i,0,r,!0,!0)?i.dump+`
-`:""}var xT=ST,PT={dump:xT};function Mh(e,t){return function(){throw new Error("Function yaml."+e+" is removed in js-yaml 4. Use yaml."+t+" instead, which is now safe by default.")}}var p0=i0.load,I5=i0.loadAll,L5=PT.dump;var V5=Mh("safeLoad","load"),N5=Mh("safeLoadAll","loadAll"),j5=Mh("safeDump","dump");async function O0(e){(e==="SETTINGS"||e==="SECRETS")&&await Nt(!0)}async function m0(){(!C||!C.textModels)&&await Nt(!1);let e=C.textModels.map(r=>({...r,name:r.name,description:r.description||`${r.modelName} on ${r.provider}`})),t=await x.filterBox("Select a model",e);if(!t){await x.flashNotification("No model selected.","error");return}let i=t.name;await bh(t),await Jr(t),await x.flashNotification(`Selected model: ${i}`),console.log("Selected model:",t)}async function g0(){(!C||!C.imageModels)&&await Nt(!1);let e=C.imageModels.map(r=>({...r,name:r.name,description:r.description||`${r.modelName} on ${r.provider}`})),t=await x.filterBox("Select an image model",e);if(!t){await x.flashNotification("No image model selected.","error");return}let i=t.name;await yh(t),await vh(t),await x.flashNotification(`Selected image model: ${i}`),console.log("Selected image model:",t)}async function y0(){(!C||!C.embeddingModels)&&await Nt(!1);let e=C.embeddingModels.map(r=>({...r,name:r.name,description:r.description||`${r.modelName} on ${r.provider}`})),t=await x.filterBox("Select an embedding model",e);if(!t){await x.flashNotification("No embedding model selected.","error");return}let i=t.name;await wh(t),await Sh(t),await x.flashNotification(`Selected embedding model: ${i}`),console.log("Selected embedding model:",t)}async function b0(){await ae();let e=await pn(),t=await x.prompt("Please enter a prompt to send to the LLM. Selected text or the entire note will also be sent as context."),i=await x.getCurrentPage(),r=new Date,n=r.toISOString().split("T")[0],s=r.toLocaleDateString("en-US",{weekday:"long"});await ye.streamChatIntoEditor({messages:[{role:"system",content:"You are an AI note assistant. Follow all user instructions and use the note context and note content to help follow those instructions. Use Markdown for any formatting."},{role:"user",content:`Note Context: Today is ${s}, ${n}. The current note name is "${i}".
-User Prompt: ${t}
+// https://deno.land/x/silverbullet@0.9.4/plugs/template/api.ts
+async function renderTemplate2(templateText, data = {}, variables = {}) {
+  try {
+    const tree = await markdown_exports.parseMarkdown(templateText);
+    const frontmatter = await extractFrontmatter(
+      tree,
+      {
+        removeFrontmatterSection: true,
+        removeTags: ["template"]
+      }
+    );
+    templateText = renderToText(tree).trimStart();
+    let frontmatterText;
+    if (frontmatter.frontmatter) {
+      if (typeof frontmatter.frontmatter === "string") {
+        frontmatterText = frontmatter.frontmatter;
+      } else {
+        frontmatterText = await yaml_exports.stringify(frontmatter.frontmatter);
+      }
+      frontmatterText = await template_exports.renderTemplate(
+        frontmatterText,
+        data,
+        variables
+      );
+    }
+    return {
+      frontmatter,
+      renderedFrontmatter: frontmatterText,
+      text: await template_exports.renderTemplate(templateText, data, variables)
+    };
+  } catch (e) {
+    console.error("Error rendering template", e);
+    throw e;
+  }
+}
+
+// ../../../../../../Users/justyns/dev/silverbullet-ai/use-space-config/src/prompts.ts
+async function aiPromptSlashComplete(completeEvent) {
+  if (!supportsPlugSlashComplete()) {
+    return;
+  }
+  const allTemplates = await queryObjects("template", {
+    filter: ["attr", ["attr", "aiprompt"], "slashCommand"]
+  }, 5);
+  return {
+    options: allTemplates.map((template) => {
+      const aiPromptTemplate = template.aiprompt;
+      console.log("ai prompt template: ", aiPromptTemplate);
+      return {
+        label: aiPromptTemplate.slashCommand,
+        detail: aiPromptTemplate.description || template.description,
+        order: aiPromptTemplate.order || 0,
+        templatePage: template.ref,
+        pageName: completeEvent.pageName,
+        invoke: "silverbullet-ai.insertAiPromptFromTemplate"
+      };
+    })
+  };
+}
+async function insertAiPromptFromTemplate(SlashCompletions) {
+  let selectedTemplate;
+  if (!SlashCompletions || !SlashCompletions.templatePage) {
+    const aiPromptTemplates = await queryObjects("template", {
+      filter: ["attr", ["attr", "aiprompt"], "description"]
+    });
+    selectedTemplate = await editor_exports.filterBox(
+      "Prompt Template",
+      aiPromptTemplates.map((templateObj) => {
+        const niceName = templateObj.ref.split("/").pop();
+        return {
+          ...templateObj,
+          description: templateObj.aiprompt.description || templateObj.ref,
+          name: templateObj.aiprompt.displayName || niceName,
+          systemPrompt: templateObj.aiprompt.systemPrompt || "You are an AI note assistant. Please follow the prompt instructions.",
+          insertAt: templateObj.aiprompt.insertAt || "cursor",
+          chat: templateObj.aiprompt.chat || false,
+          enrichMessages: templateObj.aiprompt.enrichMessages || false
+          // parseAs: templateObj.aiprompt.parseAs || "markdown",
+        };
+      }),
+      `Select the template to use as the prompt.  The prompt will be rendered and sent to the LLM model.`
+    );
+  } else {
+    console.log("selectedTemplate from slash completion: ", SlashCompletions);
+    const templatePage = await space_exports.readPage(SlashCompletions.templatePage);
+    const tree = await markdown_exports.parseMarkdown(templatePage);
+    const { aiprompt } = await extractFrontmatter(tree);
+    console.log("templatePage from slash completion: ", templatePage);
+    selectedTemplate = {
+      ref: SlashCompletions.templatePage,
+      systemPrompt: aiprompt.systemPrompt || aiprompt.system || "You are an AI note assistant. Please follow the prompt instructions.",
+      insertAt: aiprompt.insertAt || "cursor",
+      chat: aiprompt.chat || false,
+      enrichMessages: aiprompt.enrichMessages || false
+    };
+  }
+  if (!selectedTemplate) {
+    await editor_exports.flashNotification("No template selected");
+    return;
+  }
+  console.log("User selected prompt template: ", selectedTemplate);
+  const validInsertAtOptions = [
+    "cursor",
+    "page-start",
+    "page-end"
+    // "frontmatter",
+    // "modal",
+    // "replace",
+  ];
+  if (!validInsertAtOptions.includes(selectedTemplate.insertAt)) {
+    console.error(
+      `Invalid insertAt value: ${selectedTemplate.insertAt}. It must be one of ${validInsertAtOptions.join(", ")}`
+    );
+    await editor_exports.flashNotification(
+      `Invalid insertAt value: ${selectedTemplate.insertAt}. Please select a valid option.`,
+      "error"
+    );
+    return;
+  }
+  await initIfNeeded();
+  let templateText, currentPage, pageMeta;
+  try {
+    templateText = await space_exports.readPage(selectedTemplate.ref);
+    currentPage = await editor_exports.getCurrentPage();
+    pageMeta = await space_exports.getPageMeta(currentPage);
+  } catch (error) {
+    console.error("Error fetching template details or page metadata", error);
+    await editor_exports.flashNotification(
+      "Error fetching template details or page metadata",
+      "error"
+    );
+    return;
+  }
+  let cursorPos;
+  switch (selectedTemplate.insertAt) {
+    case "page-start":
+      cursorPos = 0;
+      break;
+    case "page-end":
+      cursorPos = await getPageLength();
+      break;
+    case "frontmatter":
+      await editor_exports.flashNotification(
+        `rendering in frontmatter not supported yet`,
+        "error"
+      );
+      break;
+    case "modal":
+      break;
+    case "replace":
+      break;
+    case "cursor":
+    default:
+      cursorPos = await editor_exports.getCursor();
+  }
+  if (cursorPos === void 0) {
+    cursorPos = await getPageLength();
+  }
+  console.log("templatetext: ", templateText);
+  let messages = [];
+  if (!selectedTemplate.chat) {
+    const renderedTemplate = await renderTemplate2(templateText, pageMeta, {
+      page: pageMeta
+    });
+    console.log("Rendered template:", renderedTemplate);
+    if (selectedTemplate.systemPrompt) {
+      messages.push({
+        role: "system",
+        content: selectedTemplate.systemPrompt
+      });
+    }
+    messages.push({
+      role: "user",
+      content: renderedTemplate.text
+    });
+  } else {
+    messages = await convertPageToMessages(templateText);
+    if (selectedTemplate.systemPrompt) {
+      messages.unshift({
+        role: "system",
+        content: selectedTemplate.systemPrompt
+      });
+    }
+    if (selectedTemplate.chat && selectedTemplate.enrichMessages) {
+      messages = await enrichChatMessages(messages);
+    }
+  }
+  console.log("Messages: ", messages);
+  await currentAIProvider.streamChatIntoEditor({
+    messages,
+    stream: true
+  }, cursorPos);
+}
+
+// https://deno.land/std@0.216.0/encoding/_util.ts
+var encoder = new TextEncoder();
+
+// https://deno.land/std@0.216.0/encoding/base64.ts
+function decodeBase64(b64) {
+  const binString = atob(b64);
+  const size = binString.length;
+  const bytes = new Uint8Array(size);
+  for (let i = 0; i < size; i++) {
+    bytes[i] = binString.charCodeAt(i);
+  }
+  return bytes;
+}
+
+// https://deno.land/std@0.216.0/yaml/_error.ts
+var YAMLError = class extends Error {
+  constructor(message = "(unknown reason)", mark = "") {
+    super(`${message} ${mark}`);
+    this.mark = mark;
+    this.name = this.constructor.name;
+  }
+  toString(_compact) {
+    return `${this.name}: ${this.message} ${this.mark}`;
+  }
+};
+
+// https://deno.land/std@0.216.0/yaml/_utils.ts
+function isBoolean(value) {
+  return typeof value === "boolean" || value instanceof Boolean;
+}
+function isObject(value) {
+  return value !== null && typeof value === "object";
+}
+function repeat(str2, count) {
+  let result = "";
+  for (let cycle = 0; cycle < count; cycle++) {
+    result += str2;
+  }
+  return result;
+}
+function isNegativeZero(i) {
+  return i === 0 && Number.NEGATIVE_INFINITY === 1 / i;
+}
+
+// https://deno.land/std@0.216.0/yaml/_mark.ts
+var Mark = class {
+  constructor(name, buffer, position, line, column) {
+    this.name = name;
+    this.buffer = buffer;
+    this.position = position;
+    this.line = line;
+    this.column = column;
+  }
+  getSnippet(indent = 4, maxLength = 75) {
+    if (!this.buffer)
+      return null;
+    let head = "";
+    let start = this.position;
+    while (start > 0 && "\0\r\n\x85\u2028\u2029".indexOf(this.buffer.charAt(start - 1)) === -1) {
+      start -= 1;
+      if (this.position - start > maxLength / 2 - 1) {
+        head = " ... ";
+        start += 5;
+        break;
+      }
+    }
+    let tail = "";
+    let end = this.position;
+    while (end < this.buffer.length && "\0\r\n\x85\u2028\u2029".indexOf(this.buffer.charAt(end)) === -1) {
+      end += 1;
+      if (end - this.position > maxLength / 2 - 1) {
+        tail = " ... ";
+        end -= 5;
+        break;
+      }
+    }
+    const snippet = this.buffer.slice(start, end);
+    return `${repeat(" ", indent)}${head}${snippet}${tail}
+${repeat(
+      " ",
+      indent + this.position - start + head.length
+    )}^`;
+  }
+  toString(compact) {
+    let snippet, where = "";
+    if (this.name) {
+      where += `in "${this.name}" `;
+    }
+    where += `at line ${this.line + 1}, column ${this.column + 1}`;
+    if (!compact) {
+      snippet = this.getSnippet();
+      if (snippet) {
+        where += `:
+${snippet}`;
+      }
+    }
+    return where;
+  }
+};
+
+// https://deno.land/std@0.216.0/yaml/schema.ts
+function compileList(schema, name, result) {
+  const exclude = [];
+  for (const includedSchema of schema.include) {
+    result = compileList(includedSchema, name, result);
+  }
+  for (const currentType of schema[name]) {
+    for (let previousIndex = 0; previousIndex < result.length; previousIndex++) {
+      const previousType = result[previousIndex];
+      if (previousType.tag === currentType.tag && previousType.kind === currentType.kind) {
+        exclude.push(previousIndex);
+      }
+    }
+    result.push(currentType);
+  }
+  return result.filter((_type, index) => !exclude.includes(index));
+}
+function compileMap(...typesList) {
+  const result = {
+    fallback: {},
+    mapping: {},
+    scalar: {},
+    sequence: {}
+  };
+  for (const types of typesList) {
+    for (const type of types) {
+      if (type.kind !== null) {
+        result[type.kind][type.tag] = result["fallback"][type.tag] = type;
+      }
+    }
+  }
+  return result;
+}
+var Schema = class _Schema {
+  static SCHEMA_DEFAULT;
+  implicit;
+  explicit;
+  include;
+  compiledImplicit;
+  compiledExplicit;
+  compiledTypeMap;
+  constructor(definition) {
+    this.explicit = definition.explicit || [];
+    this.implicit = definition.implicit || [];
+    this.include = definition.include || [];
+    for (const type of this.implicit) {
+      if (type.loadKind && type.loadKind !== "scalar") {
+        throw new YAMLError(
+          "There is a non-scalar type in the implicit list of a schema. Implicit resolving of such types is not supported."
+        );
+      }
+    }
+    this.compiledImplicit = compileList(this, "implicit", []);
+    this.compiledExplicit = compileList(this, "explicit", []);
+    this.compiledTypeMap = compileMap(
+      this.compiledImplicit,
+      this.compiledExplicit
+    );
+  }
+  /* Returns a new extended schema from current schema */
+  extend(definition) {
+    return new _Schema({
+      implicit: [
+        .../* @__PURE__ */ new Set([...this.implicit, ...definition?.implicit ?? []])
+      ],
+      explicit: [
+        .../* @__PURE__ */ new Set([...this.explicit, ...definition?.explicit ?? []])
+      ],
+      include: [.../* @__PURE__ */ new Set([...this.include, ...definition?.include ?? []])]
+    });
+  }
+  static create() {
+  }
+};
+
+// https://deno.land/std@0.216.0/yaml/type.ts
+function checkTagFormat(tag) {
+  return tag;
+}
+var Type = class {
+  tag;
+  kind = null;
+  instanceOf;
+  predicate;
+  represent;
+  defaultStyle;
+  styleAliases;
+  loadKind;
+  constructor(tag, options) {
+    this.tag = checkTagFormat(tag);
+    if (options) {
+      this.kind = options.kind;
+      this.resolve = options.resolve || (() => true);
+      this.construct = options.construct || ((data) => data);
+      this.instanceOf = options.instanceOf;
+      this.predicate = options.predicate;
+      this.represent = options.represent;
+      this.defaultStyle = options.defaultStyle;
+      this.styleAliases = options.styleAliases;
+    }
+  }
+  resolve = () => true;
+  construct = (data) => data;
+};
+
+// https://deno.land/std@0.216.0/yaml/_type/binary.ts
+var BASE64_MAP = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/=\n\r";
+function resolveYamlBinary(data) {
+  if (data === null)
+    return false;
+  let code;
+  let bitlen = 0;
+  const max = data.length;
+  const map2 = BASE64_MAP;
+  for (let idx = 0; idx < max; idx++) {
+    code = map2.indexOf(data.charAt(idx));
+    if (code > 64)
+      continue;
+    if (code < 0)
+      return false;
+    bitlen += 6;
+  }
+  return bitlen % 8 === 0;
+}
+function constructYamlBinary(data) {
+  const input = data.replace(/[\r\n=]/g, "");
+  const max = input.length;
+  const map2 = BASE64_MAP;
+  const result = [];
+  let bits = 0;
+  for (let idx = 0; idx < max; idx++) {
+    if (idx % 4 === 0 && idx) {
+      result.push(bits >> 16 & 255);
+      result.push(bits >> 8 & 255);
+      result.push(bits & 255);
+    }
+    bits = bits << 6 | map2.indexOf(input.charAt(idx));
+  }
+  const tailbits = max % 4 * 6;
+  if (tailbits === 0) {
+    result.push(bits >> 16 & 255);
+    result.push(bits >> 8 & 255);
+    result.push(bits & 255);
+  } else if (tailbits === 18) {
+    result.push(bits >> 10 & 255);
+    result.push(bits >> 2 & 255);
+  } else if (tailbits === 12) {
+    result.push(bits >> 4 & 255);
+  }
+  return new Uint8Array(result);
+}
+function representYamlBinary(object) {
+  const max = object.length;
+  const map2 = BASE64_MAP;
+  let result = "";
+  let bits = 0;
+  for (let idx = 0; idx < max; idx++) {
+    if (idx % 3 === 0 && idx) {
+      result += map2[bits >> 18 & 63];
+      result += map2[bits >> 12 & 63];
+      result += map2[bits >> 6 & 63];
+      result += map2[bits & 63];
+    }
+    bits = (bits << 8) + object[idx];
+  }
+  const tail = max % 3;
+  if (tail === 0) {
+    result += map2[bits >> 18 & 63];
+    result += map2[bits >> 12 & 63];
+    result += map2[bits >> 6 & 63];
+    result += map2[bits & 63];
+  } else if (tail === 2) {
+    result += map2[bits >> 10 & 63];
+    result += map2[bits >> 4 & 63];
+    result += map2[bits << 2 & 63];
+    result += map2[64];
+  } else if (tail === 1) {
+    result += map2[bits >> 2 & 63];
+    result += map2[bits << 4 & 63];
+    result += map2[64];
+    result += map2[64];
+  }
+  return result;
+}
+function isBinary(obj) {
+  return obj instanceof Uint8Array;
+}
+var binary = new Type("tag:yaml.org,2002:binary", {
+  construct: constructYamlBinary,
+  kind: "scalar",
+  predicate: isBinary,
+  represent: representYamlBinary,
+  resolve: resolveYamlBinary
+});
+
+// https://deno.land/std@0.216.0/yaml/_type/bool.ts
+function resolveYamlBoolean(data) {
+  const max = data.length;
+  return max === 4 && (data === "true" || data === "True" || data === "TRUE") || max === 5 && (data === "false" || data === "False" || data === "FALSE");
+}
+function constructYamlBoolean(data) {
+  return data === "true" || data === "True" || data === "TRUE";
+}
+var bool = new Type("tag:yaml.org,2002:bool", {
+  construct: constructYamlBoolean,
+  defaultStyle: "lowercase",
+  kind: "scalar",
+  predicate: isBoolean,
+  represent: {
+    lowercase(object) {
+      return object ? "true" : "false";
+    },
+    uppercase(object) {
+      return object ? "TRUE" : "FALSE";
+    },
+    camelcase(object) {
+      return object ? "True" : "False";
+    }
+  },
+  resolve: resolveYamlBoolean
+});
+
+// https://deno.land/std@0.216.0/yaml/_type/float.ts
+var YAML_FLOAT_PATTERN = new RegExp(
+  // 2.5e4, 2.5 and integers
+  "^(?:[-+]?(?:0|[1-9][0-9_]*)(?:\\.[0-9_]*)?(?:[eE][-+]?[0-9]+)?|\\.[0-9_]+(?:[eE][-+]?[0-9]+)?|[-+]?[0-9][0-9_]*(?::[0-5]?[0-9])+\\.[0-9_]*|[-+]?\\.(?:inf|Inf|INF)|\\.(?:nan|NaN|NAN))$"
+);
+function resolveYamlFloat(data) {
+  if (!YAML_FLOAT_PATTERN.test(data) || // Quick hack to not allow integers end with `_`
+  // Probably should update regexp & check speed
+  data[data.length - 1] === "_") {
+    return false;
+  }
+  return true;
+}
+function constructYamlFloat(data) {
+  let value = data.replace(/_/g, "").toLowerCase();
+  const sign = value[0] === "-" ? -1 : 1;
+  const digits = [];
+  if ("+-".indexOf(value[0]) >= 0) {
+    value = value.slice(1);
+  }
+  if (value === ".inf") {
+    return sign === 1 ? Number.POSITIVE_INFINITY : Number.NEGATIVE_INFINITY;
+  }
+  if (value === ".nan") {
+    return NaN;
+  }
+  if (value.indexOf(":") >= 0) {
+    value.split(":").forEach((v) => {
+      digits.unshift(parseFloat(v));
+    });
+    let valueNb = 0;
+    let base = 1;
+    digits.forEach((d) => {
+      valueNb += d * base;
+      base *= 60;
+    });
+    return sign * valueNb;
+  }
+  return sign * parseFloat(value);
+}
+var SCIENTIFIC_WITHOUT_DOT = /^[-+]?[0-9]+e/;
+function representYamlFloat(object, style) {
+  if (isNaN(object)) {
+    switch (style) {
+      case "lowercase":
+        return ".nan";
+      case "uppercase":
+        return ".NAN";
+      case "camelcase":
+        return ".NaN";
+    }
+  } else if (Number.POSITIVE_INFINITY === object) {
+    switch (style) {
+      case "lowercase":
+        return ".inf";
+      case "uppercase":
+        return ".INF";
+      case "camelcase":
+        return ".Inf";
+    }
+  } else if (Number.NEGATIVE_INFINITY === object) {
+    switch (style) {
+      case "lowercase":
+        return "-.inf";
+      case "uppercase":
+        return "-.INF";
+      case "camelcase":
+        return "-.Inf";
+    }
+  } else if (isNegativeZero(object)) {
+    return "-0.0";
+  }
+  const res = object.toString(10);
+  return SCIENTIFIC_WITHOUT_DOT.test(res) ? res.replace("e", ".e") : res;
+}
+function isFloat(object) {
+  return Object.prototype.toString.call(object) === "[object Number]" && (object % 1 !== 0 || isNegativeZero(object));
+}
+var float = new Type("tag:yaml.org,2002:float", {
+  construct: constructYamlFloat,
+  defaultStyle: "lowercase",
+  kind: "scalar",
+  predicate: isFloat,
+  represent: representYamlFloat,
+  resolve: resolveYamlFloat
+});
+
+// https://deno.land/std@0.216.0/yaml/_type/function.ts
+function reconstructFunction(code) {
+  const func2 = new Function(`return ${code}`)();
+  if (!(func2 instanceof Function)) {
+    throw new TypeError(`Expected function but got ${typeof func2}: ${code}`);
+  }
+  return func2;
+}
+var func = new Type("tag:yaml.org,2002:js/function", {
+  kind: "scalar",
+  resolve(data) {
+    if (data === null) {
+      return false;
+    }
+    try {
+      reconstructFunction(`${data}`);
+      return true;
+    } catch (_err) {
+      return false;
+    }
+  },
+  construct(data) {
+    return reconstructFunction(data);
+  },
+  predicate(object) {
+    return object instanceof Function;
+  },
+  represent(object) {
+    return object.toString();
+  }
+});
+
+// https://deno.land/std@0.216.0/yaml/_type/int.ts
+function isHexCode(c) {
+  return 48 <= /* 0 */
+  c && c <= 57 || 65 <= /* A */
+  c && c <= 70 || 97 <= /* a */
+  c && c <= 102;
+}
+function isOctCode(c) {
+  return 48 <= /* 0 */
+  c && c <= 55;
+}
+function isDecCode(c) {
+  return 48 <= /* 0 */
+  c && c <= 57;
+}
+function resolveYamlInteger(data) {
+  const max = data.length;
+  let index = 0;
+  let hasDigits = false;
+  if (!max)
+    return false;
+  let ch = data[index];
+  if (ch === "-" || ch === "+") {
+    ch = data[++index];
+  }
+  if (ch === "0") {
+    if (index + 1 === max)
+      return true;
+    ch = data[++index];
+    if (ch === "b") {
+      index++;
+      for (; index < max; index++) {
+        ch = data[index];
+        if (ch === "_")
+          continue;
+        if (ch !== "0" && ch !== "1")
+          return false;
+        hasDigits = true;
+      }
+      return hasDigits && ch !== "_";
+    }
+    if (ch === "x") {
+      index++;
+      for (; index < max; index++) {
+        ch = data[index];
+        if (ch === "_")
+          continue;
+        if (!isHexCode(data.charCodeAt(index)))
+          return false;
+        hasDigits = true;
+      }
+      return hasDigits && ch !== "_";
+    }
+    for (; index < max; index++) {
+      ch = data[index];
+      if (ch === "_")
+        continue;
+      if (!isOctCode(data.charCodeAt(index)))
+        return false;
+      hasDigits = true;
+    }
+    return hasDigits && ch !== "_";
+  }
+  if (ch === "_")
+    return false;
+  for (; index < max; index++) {
+    ch = data[index];
+    if (ch === "_")
+      continue;
+    if (ch === ":")
+      break;
+    if (!isDecCode(data.charCodeAt(index))) {
+      return false;
+    }
+    hasDigits = true;
+  }
+  if (!hasDigits || ch === "_")
+    return false;
+  if (ch !== ":")
+    return true;
+  return /^(:[0-5]?[0-9])+$/.test(data.slice(index));
+}
+function constructYamlInteger(data) {
+  let value = data;
+  const digits = [];
+  if (value.indexOf("_") !== -1) {
+    value = value.replace(/_/g, "");
+  }
+  let sign = 1;
+  let ch = value[0];
+  if (ch === "-" || ch === "+") {
+    if (ch === "-")
+      sign = -1;
+    value = value.slice(1);
+    ch = value[0];
+  }
+  if (value === "0")
+    return 0;
+  if (ch === "0") {
+    if (value[1] === "b")
+      return sign * parseInt(value.slice(2), 2);
+    if (value[1] === "x")
+      return sign * parseInt(value, 16);
+    return sign * parseInt(value, 8);
+  }
+  if (value.indexOf(":") !== -1) {
+    value.split(":").forEach((v) => {
+      digits.unshift(parseInt(v, 10));
+    });
+    let valueInt = 0;
+    let base = 1;
+    digits.forEach((d) => {
+      valueInt += d * base;
+      base *= 60;
+    });
+    return sign * valueInt;
+  }
+  return sign * parseInt(value, 10);
+}
+function isInteger(object) {
+  return Object.prototype.toString.call(object) === "[object Number]" && object % 1 === 0 && !isNegativeZero(object);
+}
+var int = new Type("tag:yaml.org,2002:int", {
+  construct: constructYamlInteger,
+  defaultStyle: "decimal",
+  kind: "scalar",
+  predicate: isInteger,
+  represent: {
+    binary(obj) {
+      return obj >= 0 ? `0b${obj.toString(2)}` : `-0b${obj.toString(2).slice(1)}`;
+    },
+    octal(obj) {
+      return obj >= 0 ? `0${obj.toString(8)}` : `-0${obj.toString(8).slice(1)}`;
+    },
+    decimal(obj) {
+      return obj.toString(10);
+    },
+    hexadecimal(obj) {
+      return obj >= 0 ? `0x${obj.toString(16).toUpperCase()}` : `-0x${obj.toString(16).toUpperCase().slice(1)}`;
+    }
+  },
+  resolve: resolveYamlInteger,
+  styleAliases: {
+    binary: [2, "bin"],
+    decimal: [10, "dec"],
+    hexadecimal: [16, "hex"],
+    octal: [8, "oct"]
+  }
+});
+
+// https://deno.land/std@0.216.0/yaml/_type/map.ts
+var map = new Type("tag:yaml.org,2002:map", {
+  construct(data) {
+    return data !== null ? data : {};
+  },
+  kind: "mapping"
+});
+
+// https://deno.land/std@0.216.0/yaml/_type/merge.ts
+function resolveYamlMerge(data) {
+  return data === "<<" || data === null;
+}
+var merge = new Type("tag:yaml.org,2002:merge", {
+  kind: "scalar",
+  resolve: resolveYamlMerge
+});
+
+// https://deno.land/std@0.216.0/yaml/_type/nil.ts
+function resolveYamlNull(data) {
+  const max = data.length;
+  return max === 1 && data === "~" || max === 4 && (data === "null" || data === "Null" || data === "NULL");
+}
+function constructYamlNull() {
+  return null;
+}
+function isNull(object) {
+  return object === null;
+}
+var nil = new Type("tag:yaml.org,2002:null", {
+  construct: constructYamlNull,
+  defaultStyle: "lowercase",
+  kind: "scalar",
+  predicate: isNull,
+  represent: {
+    canonical() {
+      return "~";
+    },
+    lowercase() {
+      return "null";
+    },
+    uppercase() {
+      return "NULL";
+    },
+    camelcase() {
+      return "Null";
+    }
+  },
+  resolve: resolveYamlNull
+});
+
+// https://deno.land/std@0.216.0/yaml/_type/omap.ts
+var { hasOwn } = Object;
+var _toString = Object.prototype.toString;
+function resolveYamlOmap(data) {
+  const objectKeys = [];
+  let pairKey = "";
+  let pairHasKey = false;
+  for (const pair of data) {
+    pairHasKey = false;
+    if (_toString.call(pair) !== "[object Object]")
+      return false;
+    for (pairKey in pair) {
+      if (hasOwn(pair, pairKey)) {
+        if (!pairHasKey)
+          pairHasKey = true;
+        else
+          return false;
+      }
+    }
+    if (!pairHasKey)
+      return false;
+    if (objectKeys.indexOf(pairKey) === -1)
+      objectKeys.push(pairKey);
+    else
+      return false;
+  }
+  return true;
+}
+function constructYamlOmap(data) {
+  return data !== null ? data : [];
+}
+var omap = new Type("tag:yaml.org,2002:omap", {
+  construct: constructYamlOmap,
+  kind: "sequence",
+  resolve: resolveYamlOmap
+});
+
+// https://deno.land/std@0.216.0/yaml/_type/pairs.ts
+var _toString2 = Object.prototype.toString;
+function resolveYamlPairs(data) {
+  const result = Array.from({ length: data.length });
+  for (let index = 0; index < data.length; index++) {
+    const pair = data[index];
+    if (_toString2.call(pair) !== "[object Object]")
+      return false;
+    const keys = Object.keys(pair);
+    if (keys.length !== 1)
+      return false;
+    result[index] = [keys[0], pair[keys[0]]];
+  }
+  return true;
+}
+function constructYamlPairs(data) {
+  if (data === null)
+    return [];
+  const result = Array.from({ length: data.length });
+  for (let index = 0; index < data.length; index += 1) {
+    const pair = data[index];
+    const keys = Object.keys(pair);
+    result[index] = [keys[0], pair[keys[0]]];
+  }
+  return result;
+}
+var pairs = new Type("tag:yaml.org,2002:pairs", {
+  construct: constructYamlPairs,
+  kind: "sequence",
+  resolve: resolveYamlPairs
+});
+
+// https://deno.land/std@0.216.0/yaml/_type/regexp.ts
+var REGEXP = /^\/(?<regexp>[\s\S]+)\/(?<modifiers>[gismuy]*)$/;
+var regexp = new Type("tag:yaml.org,2002:js/regexp", {
+  kind: "scalar",
+  resolve(data) {
+    if (data === null || !data.length) {
+      return false;
+    }
+    const regexp2 = `${data}`;
+    if (regexp2.charAt(0) === "/") {
+      if (!REGEXP.test(data)) {
+        return false;
+      }
+      const modifiers = [...regexp2.match(REGEXP)?.groups?.modifiers ?? ""];
+      if (new Set(modifiers).size < modifiers.length) {
+        return false;
+      }
+    }
+    return true;
+  },
+  construct(data) {
+    const { regexp: regexp2 = `${data}`, modifiers = "" } = `${data}`.match(REGEXP)?.groups ?? {};
+    return new RegExp(regexp2, modifiers);
+  },
+  predicate(object) {
+    return object instanceof RegExp;
+  },
+  represent(object) {
+    return object.toString();
+  }
+});
+
+// https://deno.land/std@0.216.0/yaml/_type/seq.ts
+var seq = new Type("tag:yaml.org,2002:seq", {
+  construct(data) {
+    return data !== null ? data : [];
+  },
+  kind: "sequence"
+});
+
+// https://deno.land/std@0.216.0/yaml/_type/set.ts
+var { hasOwn: hasOwn2 } = Object;
+function resolveYamlSet(data) {
+  if (data === null)
+    return true;
+  for (const key in data) {
+    if (hasOwn2(data, key)) {
+      if (data[key] !== null)
+        return false;
+    }
+  }
+  return true;
+}
+function constructYamlSet(data) {
+  return data !== null ? data : {};
+}
+var set2 = new Type("tag:yaml.org,2002:set", {
+  construct: constructYamlSet,
+  kind: "mapping",
+  resolve: resolveYamlSet
+});
+
+// https://deno.land/std@0.216.0/yaml/_type/str.ts
+var str = new Type("tag:yaml.org,2002:str", {
+  construct(data) {
+    return data !== null ? data : "";
+  },
+  kind: "scalar"
+});
+
+// https://deno.land/std@0.216.0/yaml/_type/timestamp.ts
+var YAML_DATE_REGEXP = new RegExp(
+  "^([0-9][0-9][0-9][0-9])-([0-9][0-9])-([0-9][0-9])$"
+  // [3] day
+);
+var YAML_TIMESTAMP_REGEXP = new RegExp(
+  "^([0-9][0-9][0-9][0-9])-([0-9][0-9]?)-([0-9][0-9]?)(?:[Tt]|[ \\t]+)([0-9][0-9]?):([0-9][0-9]):([0-9][0-9])(?:\\.([0-9]*))?(?:[ \\t]*(Z|([-+])([0-9][0-9]?)(?::([0-9][0-9]))?))?$"
+  // [11] tz_minute
+);
+function resolveYamlTimestamp(data) {
+  if (data === null)
+    return false;
+  if (YAML_DATE_REGEXP.exec(data) !== null)
+    return true;
+  if (YAML_TIMESTAMP_REGEXP.exec(data) !== null)
+    return true;
+  return false;
+}
+function constructYamlTimestamp(data) {
+  let match = YAML_DATE_REGEXP.exec(data);
+  if (match === null)
+    match = YAML_TIMESTAMP_REGEXP.exec(data);
+  if (match === null)
+    throw new Error("Date resolve error");
+  const year = +match[1];
+  const month = +match[2] - 1;
+  const day = +match[3];
+  if (!match[4]) {
+    return new Date(Date.UTC(year, month, day));
+  }
+  const hour = +match[4];
+  const minute = +match[5];
+  const second = +match[6];
+  let fraction = 0;
+  if (match[7]) {
+    let partFraction = match[7].slice(0, 3);
+    while (partFraction.length < 3) {
+      partFraction += "0";
+    }
+    fraction = +partFraction;
+  }
+  let delta = null;
+  if (match[9]) {
+    const tzHour = +match[10];
+    const tzMinute = +(match[11] || 0);
+    delta = (tzHour * 60 + tzMinute) * 6e4;
+    if (match[9] === "-")
+      delta = -delta;
+  }
+  const date = new Date(
+    Date.UTC(year, month, day, hour, minute, second, fraction)
+  );
+  if (delta)
+    date.setTime(date.getTime() - delta);
+  return date;
+}
+function representYamlTimestamp(date) {
+  return date.toISOString();
+}
+var timestamp = new Type("tag:yaml.org,2002:timestamp", {
+  construct: constructYamlTimestamp,
+  instanceOf: Date,
+  kind: "scalar",
+  represent: representYamlTimestamp,
+  resolve: resolveYamlTimestamp
+});
+
+// https://deno.land/std@0.216.0/yaml/_type/undefined.ts
+var undefinedType = new Type("tag:yaml.org,2002:js/undefined", {
+  kind: "scalar",
+  resolve() {
+    return true;
+  },
+  construct() {
+    return void 0;
+  },
+  predicate(object) {
+    return typeof object === "undefined";
+  },
+  represent() {
+    return "";
+  }
+});
+
+// https://deno.land/std@0.216.0/yaml/schema/failsafe.ts
+var failsafe = new Schema({
+  explicit: [str, seq, map]
+});
+
+// https://deno.land/std@0.216.0/yaml/schema/json.ts
+var json = new Schema({
+  implicit: [nil, bool, int, float],
+  include: [failsafe]
+});
+
+// https://deno.land/std@0.216.0/yaml/schema/core.ts
+var core = new Schema({
+  include: [json]
+});
+
+// https://deno.land/std@0.216.0/yaml/schema/default.ts
+var def = new Schema({
+  explicit: [binary, omap, pairs, set2],
+  implicit: [timestamp, merge],
+  include: [core]
+});
+
+// https://deno.land/std@0.216.0/yaml/schema/extended.ts
+var extended = new Schema({
+  explicit: [regexp, undefinedType],
+  include: [def]
+});
+
+// https://deno.land/std@0.216.0/yaml/_state.ts
+var State = class {
+  constructor(schema = def) {
+    this.schema = schema;
+  }
+};
+
+// https://deno.land/std@0.216.0/yaml/_loader/loader_state.ts
+var LoaderState = class extends State {
+  constructor(input, {
+    filename,
+    schema,
+    onWarning,
+    legacy = false,
+    json: json2 = false,
+    listener = null
+  }) {
+    super(schema);
+    this.input = input;
+    this.filename = filename;
+    this.onWarning = onWarning;
+    this.legacy = legacy;
+    this.json = json2;
+    this.listener = listener;
+    this.implicitTypes = this.schema.compiledImplicit;
+    this.typeMap = this.schema.compiledTypeMap;
+    this.length = input.length;
+  }
+  documents = [];
+  length;
+  lineIndent = 0;
+  lineStart = 0;
+  position = 0;
+  line = 0;
+  filename;
+  onWarning;
+  legacy;
+  json;
+  listener;
+  implicitTypes;
+  typeMap;
+  version;
+  checkLineBreaks;
+  tagMap;
+  anchorMap;
+  tag;
+  anchor;
+  kind;
+  result = "";
+};
+
+// https://deno.land/std@0.216.0/yaml/_loader/loader.ts
+var { hasOwn: hasOwn3 } = Object;
+var CONTEXT_FLOW_IN = 1;
+var CONTEXT_FLOW_OUT = 2;
+var CONTEXT_BLOCK_IN = 3;
+var CONTEXT_BLOCK_OUT = 4;
+var CHOMPING_CLIP = 1;
+var CHOMPING_STRIP = 2;
+var CHOMPING_KEEP = 3;
+var PATTERN_NON_PRINTABLE = (
+  // deno-lint-ignore no-control-regex
+  /[\x00-\x08\x0B\x0C\x0E-\x1F\x7F-\x84\x86-\x9F\uFFFE\uFFFF]|[\uD800-\uDBFF](?![\uDC00-\uDFFF])|(?:[^\uD800-\uDBFF]|^)[\uDC00-\uDFFF]/
+);
+var PATTERN_NON_ASCII_LINE_BREAKS = /[\x85\u2028\u2029]/;
+var PATTERN_FLOW_INDICATORS = /[,\[\]\{\}]/;
+var PATTERN_TAG_HANDLE = /^(?:!|!!|![a-z\-]+!)$/i;
+var PATTERN_TAG_URI = /^(?:!|[^,\[\]\{\}])(?:%[0-9a-f]{2}|[0-9a-z\-#;\/\?:@&=\+\$,_\.!~\*'\(\)\[\]])*$/i;
+function _class(obj) {
+  return Object.prototype.toString.call(obj);
+}
+function isEOL(c) {
+  return c === 10 || /* LF */
+  c === 13;
+}
+function isWhiteSpace(c) {
+  return c === 9 || /* Tab */
+  c === 32;
+}
+function isWsOrEol(c) {
+  return c === 9 || c === 32 || c === 10 || c === 13;
+}
+function isFlowIndicator(c) {
+  return c === 44 || c === 91 || c === 93 || c === 123 || c === 125;
+}
+function fromHexCode(c) {
+  if (48 <= /* 0 */
+  c && c <= 57) {
+    return c - 48;
+  }
+  const lc = c | 32;
+  if (97 <= /* a */
+  lc && lc <= 102) {
+    return lc - 97 + 10;
+  }
+  return -1;
+}
+function escapedHexLen(c) {
+  if (c === 120) {
+    return 2;
+  }
+  if (c === 117) {
+    return 4;
+  }
+  if (c === 85) {
+    return 8;
+  }
+  return 0;
+}
+function fromDecimalCode(c) {
+  if (48 <= /* 0 */
+  c && c <= 57) {
+    return c - 48;
+  }
+  return -1;
+}
+function simpleEscapeSequence(c) {
+  return c === 48 ? "\0" : c === 97 ? "\x07" : c === 98 ? "\b" : c === 116 ? "	" : c === 9 ? "	" : c === 110 ? "\n" : c === 118 ? "\v" : c === 102 ? "\f" : c === 114 ? "\r" : c === 101 ? "\x1B" : c === 32 ? " " : c === 34 ? '"' : c === 47 ? "/" : c === 92 ? "\\" : c === 78 ? "\x85" : c === 95 ? "\xA0" : c === 76 ? "\u2028" : c === 80 ? "\u2029" : "";
+}
+function charFromCodepoint(c) {
+  if (c <= 65535) {
+    return String.fromCharCode(c);
+  }
+  return String.fromCharCode(
+    (c - 65536 >> 10) + 55296,
+    (c - 65536 & 1023) + 56320
+  );
+}
+var simpleEscapeCheck = Array.from({ length: 256 });
+var simpleEscapeMap = Array.from({ length: 256 });
+for (let i = 0; i < 256; i++) {
+  simpleEscapeCheck[i] = simpleEscapeSequence(i) ? 1 : 0;
+  simpleEscapeMap[i] = simpleEscapeSequence(i);
+}
+function generateError(state, message) {
+  return new YAMLError(
+    message,
+    new Mark(
+      state.filename,
+      state.input,
+      state.position,
+      state.line,
+      state.position - state.lineStart
+    )
+  );
+}
+function throwError(state, message) {
+  throw generateError(state, message);
+}
+function throwWarning(state, message) {
+  if (state.onWarning) {
+    state.onWarning.call(null, generateError(state, message));
+  }
+}
+var directiveHandlers = {
+  YAML(state, _name, ...args) {
+    if (state.version !== null) {
+      return throwError(state, "duplication of %YAML directive");
+    }
+    if (args.length !== 1) {
+      return throwError(state, "YAML directive accepts exactly one argument");
+    }
+    const match = /^([0-9]+)\.([0-9]+)$/.exec(args[0]);
+    if (match === null) {
+      return throwError(state, "ill-formed argument of the YAML directive");
+    }
+    const major = parseInt(match[1], 10);
+    const minor = parseInt(match[2], 10);
+    if (major !== 1) {
+      return throwError(state, "unacceptable YAML version of the document");
+    }
+    state.version = args[0];
+    state.checkLineBreaks = minor < 2;
+    if (minor !== 1 && minor !== 2) {
+      return throwWarning(state, "unsupported YAML version of the document");
+    }
+  },
+  TAG(state, _name, ...args) {
+    if (args.length !== 2) {
+      return throwError(state, "TAG directive accepts exactly two arguments");
+    }
+    const handle = args[0];
+    const prefix = args[1];
+    if (!PATTERN_TAG_HANDLE.test(handle)) {
+      return throwError(
+        state,
+        "ill-formed tag handle (first argument) of the TAG directive"
+      );
+    }
+    if (state.tagMap && hasOwn3(state.tagMap, handle)) {
+      return throwError(
+        state,
+        `there is a previously declared suffix for "${handle}" tag handle`
+      );
+    }
+    if (!PATTERN_TAG_URI.test(prefix)) {
+      return throwError(
+        state,
+        "ill-formed tag prefix (second argument) of the TAG directive"
+      );
+    }
+    if (typeof state.tagMap === "undefined") {
+      state.tagMap = /* @__PURE__ */ Object.create(null);
+    }
+    state.tagMap[handle] = prefix;
+  }
+};
+function captureSegment(state, start, end, checkJson) {
+  let result;
+  if (start < end) {
+    result = state.input.slice(start, end);
+    if (checkJson) {
+      for (let position = 0, length = result.length; position < length; position++) {
+        const character = result.charCodeAt(position);
+        if (!(character === 9 || 32 <= character && character <= 1114111)) {
+          return throwError(state, "expected valid JSON character");
+        }
+      }
+    } else if (PATTERN_NON_PRINTABLE.test(result)) {
+      return throwError(state, "the stream contains non-printable characters");
+    }
+    state.result += result;
+  }
+}
+function mergeMappings(state, destination, source, overridableKeys) {
+  if (!isObject(source)) {
+    return throwError(
+      state,
+      "cannot merge mappings; the provided source object is unacceptable"
+    );
+  }
+  const keys = Object.keys(source);
+  for (let i = 0, len = keys.length; i < len; i++) {
+    const key = keys[i];
+    if (!hasOwn3(destination, key)) {
+      Object.defineProperty(destination, key, {
+        value: source[key],
+        writable: true,
+        enumerable: true,
+        configurable: true
+      });
+      overridableKeys[key] = true;
+    }
+  }
+}
+function storeMappingPair(state, result, overridableKeys, keyTag, keyNode, valueNode, startLine, startPos) {
+  if (Array.isArray(keyNode)) {
+    keyNode = Array.prototype.slice.call(keyNode);
+    for (let index = 0, quantity = keyNode.length; index < quantity; index++) {
+      if (Array.isArray(keyNode[index])) {
+        return throwError(state, "nested arrays are not supported inside keys");
+      }
+      if (typeof keyNode === "object" && _class(keyNode[index]) === "[object Object]") {
+        keyNode[index] = "[object Object]";
+      }
+    }
+  }
+  if (typeof keyNode === "object" && _class(keyNode) === "[object Object]") {
+    keyNode = "[object Object]";
+  }
+  keyNode = String(keyNode);
+  if (result === null) {
+    result = {};
+  }
+  if (keyTag === "tag:yaml.org,2002:merge") {
+    if (Array.isArray(valueNode)) {
+      for (let index = 0, quantity = valueNode.length; index < quantity; index++) {
+        mergeMappings(state, result, valueNode[index], overridableKeys);
+      }
+    } else {
+      mergeMappings(state, result, valueNode, overridableKeys);
+    }
+  } else {
+    if (!state.json && !hasOwn3(overridableKeys, keyNode) && hasOwn3(result, keyNode)) {
+      state.line = startLine || state.line;
+      state.position = startPos || state.position;
+      return throwError(state, "duplicated mapping key");
+    }
+    Object.defineProperty(result, keyNode, {
+      value: valueNode,
+      writable: true,
+      enumerable: true,
+      configurable: true
+    });
+    delete overridableKeys[keyNode];
+  }
+  return result;
+}
+function readLineBreak(state) {
+  const ch = state.input.charCodeAt(state.position);
+  if (ch === 10) {
+    state.position++;
+  } else if (ch === 13) {
+    state.position++;
+    if (state.input.charCodeAt(state.position) === 10) {
+      state.position++;
+    }
+  } else {
+    return throwError(state, "a line break is expected");
+  }
+  state.line += 1;
+  state.lineStart = state.position;
+}
+function skipSeparationSpace(state, allowComments, checkIndent) {
+  let lineBreaks = 0, ch = state.input.charCodeAt(state.position);
+  while (ch !== 0) {
+    while (isWhiteSpace(ch)) {
+      ch = state.input.charCodeAt(++state.position);
+    }
+    if (allowComments && ch === 35) {
+      do {
+        ch = state.input.charCodeAt(++state.position);
+      } while (ch !== 10 && /* LF */
+      ch !== 13 && /* CR */
+      ch !== 0);
+    }
+    if (isEOL(ch)) {
+      readLineBreak(state);
+      ch = state.input.charCodeAt(state.position);
+      lineBreaks++;
+      state.lineIndent = 0;
+      while (ch === 32) {
+        state.lineIndent++;
+        ch = state.input.charCodeAt(++state.position);
+      }
+    } else {
+      break;
+    }
+  }
+  if (checkIndent !== -1 && lineBreaks !== 0 && state.lineIndent < checkIndent) {
+    throwWarning(state, "deficient indentation");
+  }
+  return lineBreaks;
+}
+function testDocumentSeparator(state) {
+  let _position = state.position;
+  let ch = state.input.charCodeAt(_position);
+  if ((ch === 45 || /* - */
+  ch === 46) && ch === state.input.charCodeAt(_position + 1) && ch === state.input.charCodeAt(_position + 2)) {
+    _position += 3;
+    ch = state.input.charCodeAt(_position);
+    if (ch === 0 || isWsOrEol(ch)) {
+      return true;
+    }
+  }
+  return false;
+}
+function writeFoldedLines(state, count) {
+  if (count === 1) {
+    state.result += " ";
+  } else if (count > 1) {
+    state.result += repeat("\n", count - 1);
+  }
+}
+function readPlainScalar(state, nodeIndent, withinFlowCollection) {
+  const kind = state.kind;
+  const result = state.result;
+  let ch = state.input.charCodeAt(state.position);
+  if (isWsOrEol(ch) || isFlowIndicator(ch) || ch === 35 || ch === 38 || ch === 42 || ch === 33 || ch === 124 || ch === 62 || ch === 39 || ch === 34 || ch === 37 || ch === 64 || ch === 96) {
+    return false;
+  }
+  let following;
+  if (ch === 63 || /* ? */
+  ch === 45) {
+    following = state.input.charCodeAt(state.position + 1);
+    if (isWsOrEol(following) || withinFlowCollection && isFlowIndicator(following)) {
+      return false;
+    }
+  }
+  state.kind = "scalar";
+  state.result = "";
+  let captureEnd, captureStart = captureEnd = state.position;
+  let hasPendingContent = false;
+  let line = 0;
+  while (ch !== 0) {
+    if (ch === 58) {
+      following = state.input.charCodeAt(state.position + 1);
+      if (isWsOrEol(following) || withinFlowCollection && isFlowIndicator(following)) {
+        break;
+      }
+    } else if (ch === 35) {
+      const preceding = state.input.charCodeAt(state.position - 1);
+      if (isWsOrEol(preceding)) {
+        break;
+      }
+    } else if (state.position === state.lineStart && testDocumentSeparator(state) || withinFlowCollection && isFlowIndicator(ch)) {
+      break;
+    } else if (isEOL(ch)) {
+      line = state.line;
+      const lineStart = state.lineStart;
+      const lineIndent = state.lineIndent;
+      skipSeparationSpace(state, false, -1);
+      if (state.lineIndent >= nodeIndent) {
+        hasPendingContent = true;
+        ch = state.input.charCodeAt(state.position);
+        continue;
+      } else {
+        state.position = captureEnd;
+        state.line = line;
+        state.lineStart = lineStart;
+        state.lineIndent = lineIndent;
+        break;
+      }
+    }
+    if (hasPendingContent) {
+      captureSegment(state, captureStart, captureEnd, false);
+      writeFoldedLines(state, state.line - line);
+      captureStart = captureEnd = state.position;
+      hasPendingContent = false;
+    }
+    if (!isWhiteSpace(ch)) {
+      captureEnd = state.position + 1;
+    }
+    ch = state.input.charCodeAt(++state.position);
+  }
+  captureSegment(state, captureStart, captureEnd, false);
+  if (state.result) {
+    return true;
+  }
+  state.kind = kind;
+  state.result = result;
+  return false;
+}
+function readSingleQuotedScalar(state, nodeIndent) {
+  let ch, captureStart, captureEnd;
+  ch = state.input.charCodeAt(state.position);
+  if (ch !== 39) {
+    return false;
+  }
+  state.kind = "scalar";
+  state.result = "";
+  state.position++;
+  captureStart = captureEnd = state.position;
+  while ((ch = state.input.charCodeAt(state.position)) !== 0) {
+    if (ch === 39) {
+      captureSegment(state, captureStart, state.position, true);
+      ch = state.input.charCodeAt(++state.position);
+      if (ch === 39) {
+        captureStart = state.position;
+        state.position++;
+        captureEnd = state.position;
+      } else {
+        return true;
+      }
+    } else if (isEOL(ch)) {
+      captureSegment(state, captureStart, captureEnd, true);
+      writeFoldedLines(state, skipSeparationSpace(state, false, nodeIndent));
+      captureStart = captureEnd = state.position;
+    } else if (state.position === state.lineStart && testDocumentSeparator(state)) {
+      return throwError(
+        state,
+        "unexpected end of the document within a single quoted scalar"
+      );
+    } else {
+      state.position++;
+      captureEnd = state.position;
+    }
+  }
+  return throwError(
+    state,
+    "unexpected end of the stream within a single quoted scalar"
+  );
+}
+function readDoubleQuotedScalar(state, nodeIndent) {
+  let ch = state.input.charCodeAt(state.position);
+  if (ch !== 34) {
+    return false;
+  }
+  state.kind = "scalar";
+  state.result = "";
+  state.position++;
+  let captureEnd, captureStart = captureEnd = state.position;
+  let tmp;
+  while ((ch = state.input.charCodeAt(state.position)) !== 0) {
+    if (ch === 34) {
+      captureSegment(state, captureStart, state.position, true);
+      state.position++;
+      return true;
+    }
+    if (ch === 92) {
+      captureSegment(state, captureStart, state.position, true);
+      ch = state.input.charCodeAt(++state.position);
+      if (isEOL(ch)) {
+        skipSeparationSpace(state, false, nodeIndent);
+      } else if (ch < 256 && simpleEscapeCheck[ch]) {
+        state.result += simpleEscapeMap[ch];
+        state.position++;
+      } else if ((tmp = escapedHexLen(ch)) > 0) {
+        let hexLength = tmp;
+        let hexResult = 0;
+        for (; hexLength > 0; hexLength--) {
+          ch = state.input.charCodeAt(++state.position);
+          if ((tmp = fromHexCode(ch)) >= 0) {
+            hexResult = (hexResult << 4) + tmp;
+          } else {
+            return throwError(state, "expected hexadecimal character");
+          }
+        }
+        state.result += charFromCodepoint(hexResult);
+        state.position++;
+      } else {
+        return throwError(state, "unknown escape sequence");
+      }
+      captureStart = captureEnd = state.position;
+    } else if (isEOL(ch)) {
+      captureSegment(state, captureStart, captureEnd, true);
+      writeFoldedLines(state, skipSeparationSpace(state, false, nodeIndent));
+      captureStart = captureEnd = state.position;
+    } else if (state.position === state.lineStart && testDocumentSeparator(state)) {
+      return throwError(
+        state,
+        "unexpected end of the document within a double quoted scalar"
+      );
+    } else {
+      state.position++;
+      captureEnd = state.position;
+    }
+  }
+  return throwError(
+    state,
+    "unexpected end of the stream within a double quoted scalar"
+  );
+}
+function readFlowCollection(state, nodeIndent) {
+  let ch = state.input.charCodeAt(state.position);
+  let terminator;
+  let isMapping = true;
+  let result = {};
+  if (ch === 91) {
+    terminator = 93;
+    isMapping = false;
+    result = [];
+  } else if (ch === 123) {
+    terminator = 125;
+  } else {
+    return false;
+  }
+  if (state.anchor !== null && typeof state.anchor !== "undefined" && typeof state.anchorMap !== "undefined") {
+    state.anchorMap[state.anchor] = result;
+  }
+  ch = state.input.charCodeAt(++state.position);
+  const tag = state.tag, anchor = state.anchor;
+  let readNext = true;
+  let valueNode, keyNode, keyTag = keyNode = valueNode = null, isExplicitPair, isPair = isExplicitPair = false;
+  let following = 0, line = 0;
+  const overridableKeys = /* @__PURE__ */ Object.create(null);
+  while (ch !== 0) {
+    skipSeparationSpace(state, true, nodeIndent);
+    ch = state.input.charCodeAt(state.position);
+    if (ch === terminator) {
+      state.position++;
+      state.tag = tag;
+      state.anchor = anchor;
+      state.kind = isMapping ? "mapping" : "sequence";
+      state.result = result;
+      return true;
+    }
+    if (!readNext) {
+      return throwError(state, "missed comma between flow collection entries");
+    }
+    keyTag = keyNode = valueNode = null;
+    isPair = isExplicitPair = false;
+    if (ch === 63) {
+      following = state.input.charCodeAt(state.position + 1);
+      if (isWsOrEol(following)) {
+        isPair = isExplicitPair = true;
+        state.position++;
+        skipSeparationSpace(state, true, nodeIndent);
+      }
+    }
+    line = state.line;
+    composeNode(state, nodeIndent, CONTEXT_FLOW_IN, false, true);
+    keyTag = state.tag || null;
+    keyNode = state.result;
+    skipSeparationSpace(state, true, nodeIndent);
+    ch = state.input.charCodeAt(state.position);
+    if ((isExplicitPair || state.line === line) && ch === 58) {
+      isPair = true;
+      ch = state.input.charCodeAt(++state.position);
+      skipSeparationSpace(state, true, nodeIndent);
+      composeNode(state, nodeIndent, CONTEXT_FLOW_IN, false, true);
+      valueNode = state.result;
+    }
+    if (isMapping) {
+      storeMappingPair(
+        state,
+        result,
+        overridableKeys,
+        keyTag,
+        keyNode,
+        valueNode
+      );
+    } else if (isPair) {
+      result.push(
+        storeMappingPair(
+          state,
+          null,
+          overridableKeys,
+          keyTag,
+          keyNode,
+          valueNode
+        )
+      );
+    } else {
+      result.push(keyNode);
+    }
+    skipSeparationSpace(state, true, nodeIndent);
+    ch = state.input.charCodeAt(state.position);
+    if (ch === 44) {
+      readNext = true;
+      ch = state.input.charCodeAt(++state.position);
+    } else {
+      readNext = false;
+    }
+  }
+  return throwError(
+    state,
+    "unexpected end of the stream within a flow collection"
+  );
+}
+function readBlockScalar(state, nodeIndent) {
+  let chomping = CHOMPING_CLIP, didReadContent = false, detectedIndent = false, textIndent = nodeIndent, emptyLines = 0, atMoreIndented = false;
+  let ch = state.input.charCodeAt(state.position);
+  let folding = false;
+  if (ch === 124) {
+    folding = false;
+  } else if (ch === 62) {
+    folding = true;
+  } else {
+    return false;
+  }
+  state.kind = "scalar";
+  state.result = "";
+  let tmp = 0;
+  while (ch !== 0) {
+    ch = state.input.charCodeAt(++state.position);
+    if (ch === 43 || /* + */
+    ch === 45) {
+      if (CHOMPING_CLIP === chomping) {
+        chomping = ch === 43 ? CHOMPING_KEEP : CHOMPING_STRIP;
+      } else {
+        return throwError(state, "repeat of a chomping mode identifier");
+      }
+    } else if ((tmp = fromDecimalCode(ch)) >= 0) {
+      if (tmp === 0) {
+        return throwError(
+          state,
+          "bad explicit indentation width of a block scalar; it cannot be less than one"
+        );
+      } else if (!detectedIndent) {
+        textIndent = nodeIndent + tmp - 1;
+        detectedIndent = true;
+      } else {
+        return throwError(state, "repeat of an indentation width identifier");
+      }
+    } else {
+      break;
+    }
+  }
+  if (isWhiteSpace(ch)) {
+    do {
+      ch = state.input.charCodeAt(++state.position);
+    } while (isWhiteSpace(ch));
+    if (ch === 35) {
+      do {
+        ch = state.input.charCodeAt(++state.position);
+      } while (!isEOL(ch) && ch !== 0);
+    }
+  }
+  while (ch !== 0) {
+    readLineBreak(state);
+    state.lineIndent = 0;
+    ch = state.input.charCodeAt(state.position);
+    while ((!detectedIndent || state.lineIndent < textIndent) && ch === 32) {
+      state.lineIndent++;
+      ch = state.input.charCodeAt(++state.position);
+    }
+    if (!detectedIndent && state.lineIndent > textIndent) {
+      textIndent = state.lineIndent;
+    }
+    if (isEOL(ch)) {
+      emptyLines++;
+      continue;
+    }
+    if (state.lineIndent < textIndent) {
+      if (chomping === CHOMPING_KEEP) {
+        state.result += repeat(
+          "\n",
+          didReadContent ? 1 + emptyLines : emptyLines
+        );
+      } else if (chomping === CHOMPING_CLIP) {
+        if (didReadContent) {
+          state.result += "\n";
+        }
+      }
+      break;
+    }
+    if (folding) {
+      if (isWhiteSpace(ch)) {
+        atMoreIndented = true;
+        state.result += repeat(
+          "\n",
+          didReadContent ? 1 + emptyLines : emptyLines
+        );
+      } else if (atMoreIndented) {
+        atMoreIndented = false;
+        state.result += repeat("\n", emptyLines + 1);
+      } else if (emptyLines === 0) {
+        if (didReadContent) {
+          state.result += " ";
+        }
+      } else {
+        state.result += repeat("\n", emptyLines);
+      }
+    } else {
+      state.result += repeat(
+        "\n",
+        didReadContent ? 1 + emptyLines : emptyLines
+      );
+    }
+    didReadContent = true;
+    detectedIndent = true;
+    emptyLines = 0;
+    const captureStart = state.position;
+    while (!isEOL(ch) && ch !== 0) {
+      ch = state.input.charCodeAt(++state.position);
+    }
+    captureSegment(state, captureStart, state.position, false);
+  }
+  return true;
+}
+function readBlockSequence(state, nodeIndent) {
+  let line, following, detected = false, ch;
+  const tag = state.tag, anchor = state.anchor, result = [];
+  if (state.anchor !== null && typeof state.anchor !== "undefined" && typeof state.anchorMap !== "undefined") {
+    state.anchorMap[state.anchor] = result;
+  }
+  ch = state.input.charCodeAt(state.position);
+  while (ch !== 0) {
+    if (ch !== 45) {
+      break;
+    }
+    following = state.input.charCodeAt(state.position + 1);
+    if (!isWsOrEol(following)) {
+      break;
+    }
+    detected = true;
+    state.position++;
+    if (skipSeparationSpace(state, true, -1)) {
+      if (state.lineIndent <= nodeIndent) {
+        result.push(null);
+        ch = state.input.charCodeAt(state.position);
+        continue;
+      }
+    }
+    line = state.line;
+    composeNode(state, nodeIndent, CONTEXT_BLOCK_IN, false, true);
+    result.push(state.result);
+    skipSeparationSpace(state, true, -1);
+    ch = state.input.charCodeAt(state.position);
+    if ((state.line === line || state.lineIndent > nodeIndent) && ch !== 0) {
+      return throwError(state, "bad indentation of a sequence entry");
+    } else if (state.lineIndent < nodeIndent) {
+      break;
+    }
+  }
+  if (detected) {
+    state.tag = tag;
+    state.anchor = anchor;
+    state.kind = "sequence";
+    state.result = result;
+    return true;
+  }
+  return false;
+}
+function readBlockMapping(state, nodeIndent, flowIndent) {
+  const tag = state.tag, anchor = state.anchor, result = {}, overridableKeys = /* @__PURE__ */ Object.create(null);
+  let following, allowCompact = false, line, pos, keyTag = null, keyNode = null, valueNode = null, atExplicitKey = false, detected = false, ch;
+  if (state.anchor !== null && typeof state.anchor !== "undefined" && typeof state.anchorMap !== "undefined") {
+    state.anchorMap[state.anchor] = result;
+  }
+  ch = state.input.charCodeAt(state.position);
+  while (ch !== 0) {
+    following = state.input.charCodeAt(state.position + 1);
+    line = state.line;
+    pos = state.position;
+    if ((ch === 63 || /* ? */
+    ch === 58) && /* : */
+    isWsOrEol(following)) {
+      if (ch === 63) {
+        if (atExplicitKey) {
+          storeMappingPair(
+            state,
+            result,
+            overridableKeys,
+            keyTag,
+            keyNode,
+            null
+          );
+          keyTag = keyNode = valueNode = null;
+        }
+        detected = true;
+        atExplicitKey = true;
+        allowCompact = true;
+      } else if (atExplicitKey) {
+        atExplicitKey = false;
+        allowCompact = true;
+      } else {
+        return throwError(
+          state,
+          "incomplete explicit mapping pair; a key node is missed; or followed by a non-tabulated empty line"
+        );
+      }
+      state.position += 1;
+      ch = following;
+    } else if (composeNode(state, flowIndent, CONTEXT_FLOW_OUT, false, true)) {
+      if (state.line === line) {
+        ch = state.input.charCodeAt(state.position);
+        while (isWhiteSpace(ch)) {
+          ch = state.input.charCodeAt(++state.position);
+        }
+        if (ch === 58) {
+          ch = state.input.charCodeAt(++state.position);
+          if (!isWsOrEol(ch)) {
+            return throwError(
+              state,
+              "a whitespace character is expected after the key-value separator within a block mapping"
+            );
+          }
+          if (atExplicitKey) {
+            storeMappingPair(
+              state,
+              result,
+              overridableKeys,
+              keyTag,
+              keyNode,
+              null
+            );
+            keyTag = keyNode = valueNode = null;
+          }
+          detected = true;
+          atExplicitKey = false;
+          allowCompact = false;
+          keyTag = state.tag;
+          keyNode = state.result;
+        } else if (detected) {
+          return throwError(
+            state,
+            "can not read an implicit mapping pair; a colon is missed"
+          );
+        } else {
+          state.tag = tag;
+          state.anchor = anchor;
+          return true;
+        }
+      } else if (detected) {
+        return throwError(
+          state,
+          "can not read a block mapping entry; a multiline key may not be an implicit key"
+        );
+      } else {
+        state.tag = tag;
+        state.anchor = anchor;
+        return true;
+      }
+    } else {
+      break;
+    }
+    if (state.line === line || state.lineIndent > nodeIndent) {
+      if (composeNode(state, nodeIndent, CONTEXT_BLOCK_OUT, true, allowCompact)) {
+        if (atExplicitKey) {
+          keyNode = state.result;
+        } else {
+          valueNode = state.result;
+        }
+      }
+      if (!atExplicitKey) {
+        storeMappingPair(
+          state,
+          result,
+          overridableKeys,
+          keyTag,
+          keyNode,
+          valueNode,
+          line,
+          pos
+        );
+        keyTag = keyNode = valueNode = null;
+      }
+      skipSeparationSpace(state, true, -1);
+      ch = state.input.charCodeAt(state.position);
+    }
+    if (state.lineIndent > nodeIndent && ch !== 0) {
+      return throwError(state, "bad indentation of a mapping entry");
+    } else if (state.lineIndent < nodeIndent) {
+      break;
+    }
+  }
+  if (atExplicitKey) {
+    storeMappingPair(
+      state,
+      result,
+      overridableKeys,
+      keyTag,
+      keyNode,
+      null
+    );
+  }
+  if (detected) {
+    state.tag = tag;
+    state.anchor = anchor;
+    state.kind = "mapping";
+    state.result = result;
+  }
+  return detected;
+}
+function readTagProperty(state) {
+  let position, isVerbatim = false, isNamed = false, tagHandle = "", tagName, ch;
+  ch = state.input.charCodeAt(state.position);
+  if (ch !== 33)
+    return false;
+  if (state.tag !== null) {
+    return throwError(state, "duplication of a tag property");
+  }
+  ch = state.input.charCodeAt(++state.position);
+  if (ch === 60) {
+    isVerbatim = true;
+    ch = state.input.charCodeAt(++state.position);
+  } else if (ch === 33) {
+    isNamed = true;
+    tagHandle = "!!";
+    ch = state.input.charCodeAt(++state.position);
+  } else {
+    tagHandle = "!";
+  }
+  position = state.position;
+  if (isVerbatim) {
+    do {
+      ch = state.input.charCodeAt(++state.position);
+    } while (ch !== 0 && ch !== 62);
+    if (state.position < state.length) {
+      tagName = state.input.slice(position, state.position);
+      ch = state.input.charCodeAt(++state.position);
+    } else {
+      return throwError(
+        state,
+        "unexpected end of the stream within a verbatim tag"
+      );
+    }
+  } else {
+    while (ch !== 0 && !isWsOrEol(ch)) {
+      if (ch === 33) {
+        if (!isNamed) {
+          tagHandle = state.input.slice(position - 1, state.position + 1);
+          if (!PATTERN_TAG_HANDLE.test(tagHandle)) {
+            return throwError(
+              state,
+              "named tag handle cannot contain such characters"
+            );
+          }
+          isNamed = true;
+          position = state.position + 1;
+        } else {
+          return throwError(
+            state,
+            "tag suffix cannot contain exclamation marks"
+          );
+        }
+      }
+      ch = state.input.charCodeAt(++state.position);
+    }
+    tagName = state.input.slice(position, state.position);
+    if (PATTERN_FLOW_INDICATORS.test(tagName)) {
+      return throwError(
+        state,
+        "tag suffix cannot contain flow indicator characters"
+      );
+    }
+  }
+  if (tagName && !PATTERN_TAG_URI.test(tagName)) {
+    return throwError(
+      state,
+      `tag name cannot contain such characters: ${tagName}`
+    );
+  }
+  if (isVerbatim) {
+    state.tag = tagName;
+  } else if (typeof state.tagMap !== "undefined" && hasOwn3(state.tagMap, tagHandle)) {
+    state.tag = state.tagMap[tagHandle] + tagName;
+  } else if (tagHandle === "!") {
+    state.tag = `!${tagName}`;
+  } else if (tagHandle === "!!") {
+    state.tag = `tag:yaml.org,2002:${tagName}`;
+  } else {
+    return throwError(state, `undeclared tag handle "${tagHandle}"`);
+  }
+  return true;
+}
+function readAnchorProperty(state) {
+  let ch = state.input.charCodeAt(state.position);
+  if (ch !== 38)
+    return false;
+  if (state.anchor !== null) {
+    return throwError(state, "duplication of an anchor property");
+  }
+  ch = state.input.charCodeAt(++state.position);
+  const position = state.position;
+  while (ch !== 0 && !isWsOrEol(ch) && !isFlowIndicator(ch)) {
+    ch = state.input.charCodeAt(++state.position);
+  }
+  if (state.position === position) {
+    return throwError(
+      state,
+      "name of an anchor node must contain at least one character"
+    );
+  }
+  state.anchor = state.input.slice(position, state.position);
+  return true;
+}
+function readAlias(state) {
+  let ch = state.input.charCodeAt(state.position);
+  if (ch !== 42)
+    return false;
+  ch = state.input.charCodeAt(++state.position);
+  const _position = state.position;
+  while (ch !== 0 && !isWsOrEol(ch) && !isFlowIndicator(ch)) {
+    ch = state.input.charCodeAt(++state.position);
+  }
+  if (state.position === _position) {
+    return throwError(
+      state,
+      "name of an alias node must contain at least one character"
+    );
+  }
+  const alias = state.input.slice(_position, state.position);
+  if (typeof state.anchorMap !== "undefined" && !hasOwn3(state.anchorMap, alias)) {
+    return throwError(state, `unidentified alias "${alias}"`);
+  }
+  if (typeof state.anchorMap !== "undefined") {
+    state.result = state.anchorMap[alias];
+  }
+  skipSeparationSpace(state, true, -1);
+  return true;
+}
+function composeNode(state, parentIndent, nodeContext, allowToSeek, allowCompact) {
+  let allowBlockScalars, allowBlockCollections, indentStatus = 1, atNewLine = false, hasContent = false, type, flowIndent, blockIndent;
+  if (state.listener && state.listener !== null) {
+    state.listener("open", state);
+  }
+  state.tag = null;
+  state.anchor = null;
+  state.kind = null;
+  state.result = null;
+  const allowBlockStyles = allowBlockScalars = allowBlockCollections = CONTEXT_BLOCK_OUT === nodeContext || CONTEXT_BLOCK_IN === nodeContext;
+  if (allowToSeek) {
+    if (skipSeparationSpace(state, true, -1)) {
+      atNewLine = true;
+      if (state.lineIndent > parentIndent) {
+        indentStatus = 1;
+      } else if (state.lineIndent === parentIndent) {
+        indentStatus = 0;
+      } else if (state.lineIndent < parentIndent) {
+        indentStatus = -1;
+      }
+    }
+  }
+  if (indentStatus === 1) {
+    while (readTagProperty(state) || readAnchorProperty(state)) {
+      if (skipSeparationSpace(state, true, -1)) {
+        atNewLine = true;
+        allowBlockCollections = allowBlockStyles;
+        if (state.lineIndent > parentIndent) {
+          indentStatus = 1;
+        } else if (state.lineIndent === parentIndent) {
+          indentStatus = 0;
+        } else if (state.lineIndent < parentIndent) {
+          indentStatus = -1;
+        }
+      } else {
+        allowBlockCollections = false;
+      }
+    }
+  }
+  if (allowBlockCollections) {
+    allowBlockCollections = atNewLine || allowCompact;
+  }
+  if (indentStatus === 1 || CONTEXT_BLOCK_OUT === nodeContext) {
+    const cond = CONTEXT_FLOW_IN === nodeContext || CONTEXT_FLOW_OUT === nodeContext;
+    flowIndent = cond ? parentIndent : parentIndent + 1;
+    blockIndent = state.position - state.lineStart;
+    if (indentStatus === 1) {
+      if (allowBlockCollections && (readBlockSequence(state, blockIndent) || readBlockMapping(state, blockIndent, flowIndent)) || readFlowCollection(state, flowIndent)) {
+        hasContent = true;
+      } else {
+        if (allowBlockScalars && readBlockScalar(state, flowIndent) || readSingleQuotedScalar(state, flowIndent) || readDoubleQuotedScalar(state, flowIndent)) {
+          hasContent = true;
+        } else if (readAlias(state)) {
+          hasContent = true;
+          if (state.tag !== null || state.anchor !== null) {
+            return throwError(
+              state,
+              "alias node should not have Any properties"
+            );
+          }
+        } else if (readPlainScalar(state, flowIndent, CONTEXT_FLOW_IN === nodeContext)) {
+          hasContent = true;
+          if (state.tag === null) {
+            state.tag = "?";
+          }
+        }
+        if (state.anchor !== null && typeof state.anchorMap !== "undefined") {
+          state.anchorMap[state.anchor] = state.result;
+        }
+      }
+    } else if (indentStatus === 0) {
+      hasContent = allowBlockCollections && readBlockSequence(state, blockIndent);
+    }
+  }
+  if (state.tag !== null && state.tag !== "!") {
+    if (state.tag === "?") {
+      for (let typeIndex = 0, typeQuantity = state.implicitTypes.length; typeIndex < typeQuantity; typeIndex++) {
+        type = state.implicitTypes[typeIndex];
+        if (type.resolve(state.result)) {
+          state.result = type.construct(state.result);
+          state.tag = type.tag;
+          if (state.anchor !== null && typeof state.anchorMap !== "undefined") {
+            state.anchorMap[state.anchor] = state.result;
+          }
+          break;
+        }
+      }
+    } else if (hasOwn3(state.typeMap[state.kind || "fallback"], state.tag)) {
+      type = state.typeMap[state.kind || "fallback"][state.tag];
+      if (state.result !== null && type.kind !== state.kind) {
+        return throwError(
+          state,
+          `unacceptable node kind for !<${state.tag}> tag; it should be "${type.kind}", not "${state.kind}"`
+        );
+      }
+      if (!type.resolve(state.result)) {
+        return throwError(
+          state,
+          `cannot resolve a node with !<${state.tag}> explicit tag`
+        );
+      } else {
+        state.result = type.construct(state.result);
+        if (state.anchor !== null && typeof state.anchorMap !== "undefined") {
+          state.anchorMap[state.anchor] = state.result;
+        }
+      }
+    } else {
+      return throwError(state, `unknown tag !<${state.tag}>`);
+    }
+  }
+  if (state.listener && state.listener !== null) {
+    state.listener("close", state);
+  }
+  return state.tag !== null || state.anchor !== null || hasContent;
+}
+function readDocument(state) {
+  const documentStart = state.position;
+  let position, directiveName, directiveArgs, hasDirectives = false, ch;
+  state.version = null;
+  state.checkLineBreaks = state.legacy;
+  state.tagMap = /* @__PURE__ */ Object.create(null);
+  state.anchorMap = /* @__PURE__ */ Object.create(null);
+  while ((ch = state.input.charCodeAt(state.position)) !== 0) {
+    skipSeparationSpace(state, true, -1);
+    ch = state.input.charCodeAt(state.position);
+    if (state.lineIndent > 0 || ch !== 37) {
+      break;
+    }
+    hasDirectives = true;
+    ch = state.input.charCodeAt(++state.position);
+    position = state.position;
+    while (ch !== 0 && !isWsOrEol(ch)) {
+      ch = state.input.charCodeAt(++state.position);
+    }
+    directiveName = state.input.slice(position, state.position);
+    directiveArgs = [];
+    if (directiveName.length < 1) {
+      return throwError(
+        state,
+        "directive name must not be less than one character in length"
+      );
+    }
+    while (ch !== 0) {
+      while (isWhiteSpace(ch)) {
+        ch = state.input.charCodeAt(++state.position);
+      }
+      if (ch === 35) {
+        do {
+          ch = state.input.charCodeAt(++state.position);
+        } while (ch !== 0 && !isEOL(ch));
+        break;
+      }
+      if (isEOL(ch))
+        break;
+      position = state.position;
+      while (ch !== 0 && !isWsOrEol(ch)) {
+        ch = state.input.charCodeAt(++state.position);
+      }
+      directiveArgs.push(state.input.slice(position, state.position));
+    }
+    if (ch !== 0)
+      readLineBreak(state);
+    if (hasOwn3(directiveHandlers, directiveName)) {
+      directiveHandlers[directiveName](state, directiveName, ...directiveArgs);
+    } else {
+      throwWarning(state, `unknown document directive "${directiveName}"`);
+    }
+  }
+  skipSeparationSpace(state, true, -1);
+  if (state.lineIndent === 0 && state.input.charCodeAt(state.position) === 45 && state.input.charCodeAt(state.position + 1) === 45 && state.input.charCodeAt(state.position + 2) === 45) {
+    state.position += 3;
+    skipSeparationSpace(state, true, -1);
+  } else if (hasDirectives) {
+    return throwError(state, "directives end mark is expected");
+  }
+  composeNode(state, state.lineIndent - 1, CONTEXT_BLOCK_OUT, false, true);
+  skipSeparationSpace(state, true, -1);
+  if (state.checkLineBreaks && PATTERN_NON_ASCII_LINE_BREAKS.test(
+    state.input.slice(documentStart, state.position)
+  )) {
+    throwWarning(state, "non-ASCII line breaks are interpreted as content");
+  }
+  state.documents.push(state.result);
+  if (state.position === state.lineStart && testDocumentSeparator(state)) {
+    if (state.input.charCodeAt(state.position) === 46) {
+      state.position += 3;
+      skipSeparationSpace(state, true, -1);
+    }
+    return;
+  }
+  if (state.position < state.length - 1) {
+    return throwError(
+      state,
+      "end of the stream or a document separator is expected"
+    );
+  }
+}
+function loadDocuments(input, options) {
+  input = String(input);
+  options = options || {};
+  if (input.length !== 0) {
+    if (input.charCodeAt(input.length - 1) !== 10 && input.charCodeAt(input.length - 1) !== 13) {
+      input += "\n";
+    }
+    if (input.charCodeAt(0) === 65279) {
+      input = input.slice(1);
+    }
+  }
+  const state = new LoaderState(input, options);
+  state.input += "\0";
+  while (state.input.charCodeAt(state.position) === 32) {
+    state.lineIndent += 1;
+    state.position += 1;
+  }
+  while (state.position < state.length - 1) {
+    readDocument(state);
+  }
+  return state.documents;
+}
+function load(input, options) {
+  const documents = loadDocuments(input, options);
+  if (documents.length === 0) {
+    return null;
+  }
+  if (documents.length === 1) {
+    return documents[0];
+  }
+  throw new YAMLError(
+    "expected a single document in the stream, but found more"
+  );
+}
+
+// https://deno.land/std@0.216.0/yaml/parse.ts
+function parse3(content, options) {
+  return load(content, options);
+}
+
+// https://deno.land/std@0.216.0/yaml/_dumper/dumper_state.ts
+var { hasOwn: hasOwn4 } = Object;
+
+// https://deno.land/std@0.216.0/yaml/_dumper/dumper.ts
+var { hasOwn: hasOwn5 } = Object;
+var ESCAPE_SEQUENCES = {};
+ESCAPE_SEQUENCES[0] = "\\0";
+ESCAPE_SEQUENCES[7] = "\\a";
+ESCAPE_SEQUENCES[8] = "\\b";
+ESCAPE_SEQUENCES[9] = "\\t";
+ESCAPE_SEQUENCES[10] = "\\n";
+ESCAPE_SEQUENCES[11] = "\\v";
+ESCAPE_SEQUENCES[12] = "\\f";
+ESCAPE_SEQUENCES[13] = "\\r";
+ESCAPE_SEQUENCES[27] = "\\e";
+ESCAPE_SEQUENCES[34] = '\\"';
+ESCAPE_SEQUENCES[92] = "\\\\";
+ESCAPE_SEQUENCES[133] = "\\N";
+ESCAPE_SEQUENCES[160] = "\\_";
+ESCAPE_SEQUENCES[8232] = "\\L";
+ESCAPE_SEQUENCES[8233] = "\\P";
+
+// ../../../../../../Users/justyns/dev/silverbullet-ai/use-space-config/sbai.ts
+async function reloadSettingsPage(pageName) {
+  if (pageName === "SETTINGS" || pageName === "SECRETS") {
+    await initializeOpenAI(true);
+  }
+}
+async function reloadConfig2() {
+  await initializeOpenAI(true);
+}
+async function selectModelFromConfig() {
+  if (!aiSettings || !aiSettings.textModels) {
+    await initializeOpenAI(false);
+  }
+  const modelOptions = aiSettings.textModels.map((model) => ({
+    ...model,
+    name: model.name,
+    description: model.description || `${model.modelName} on ${model.provider}`
+  }));
+  const selectedModel = await editor_exports.filterBox("Select a model", modelOptions);
+  if (!selectedModel) {
+    await editor_exports.flashNotification("No model selected.", "error");
+    return;
+  }
+  const selectedModelName = selectedModel.name;
+  await setSelectedTextModel(selectedModel);
+  await configureSelectedModel(selectedModel);
+  await editor_exports.flashNotification(`Selected model: ${selectedModelName}`);
+  console.log(`Selected model:`, selectedModel);
+}
+async function selectImageModelFromConfig() {
+  if (!aiSettings || !aiSettings.imageModels) {
+    await initializeOpenAI(false);
+  }
+  const imageModelOptions = aiSettings.imageModels.map((model) => ({
+    ...model,
+    name: model.name,
+    description: model.description || `${model.modelName} on ${model.provider}`
+  }));
+  const selectedImageModel = await editor_exports.filterBox(
+    "Select an image model",
+    imageModelOptions
+  );
+  if (!selectedImageModel) {
+    await editor_exports.flashNotification("No image model selected.", "error");
+    return;
+  }
+  const selectedImageModelName = selectedImageModel.name;
+  await setSelectedImageModel(selectedImageModel);
+  await configureSelectedImageModel(selectedImageModel);
+  await editor_exports.flashNotification(
+    `Selected image model: ${selectedImageModelName}`
+  );
+  console.log(`Selected image model:`, selectedImageModel);
+}
+async function selectEmbeddingModelFromConfig() {
+  if (!aiSettings || !aiSettings.embeddingModels) {
+    await initializeOpenAI(false);
+  }
+  const embeddingModelOptions = aiSettings.embeddingModels.map((model) => ({
+    ...model,
+    name: model.name,
+    description: model.description || `${model.modelName} on ${model.provider}`
+  }));
+  const selectedEmbeddingModel = await editor_exports.filterBox(
+    "Select an embedding model",
+    embeddingModelOptions
+  );
+  if (!selectedEmbeddingModel) {
+    await editor_exports.flashNotification("No embedding model selected.", "error");
+    return;
+  }
+  const selectedEmbeddingModelName = selectedEmbeddingModel.name;
+  await setSelectedEmbeddingModel(
+    selectedEmbeddingModel
+  );
+  await configureSelectedEmbeddingModel(
+    selectedEmbeddingModel
+  );
+  await editor_exports.flashNotification(
+    `Selected embedding model: ${selectedEmbeddingModelName}`
+  );
+  console.log(`Selected embedding model:`, selectedEmbeddingModel);
+}
+async function callOpenAIwithNote() {
+  await initIfNeeded();
+  const selectedTextInfo = await getSelectedTextOrNote();
+  const userPrompt = await editor_exports.prompt(
+    "Please enter a prompt to send to the LLM. Selected text or the entire note will also be sent as context."
+  );
+  const noteName = await editor_exports.getCurrentPage();
+  const currentDate = /* @__PURE__ */ new Date();
+  const dateString = currentDate.toISOString().split("T")[0];
+  const dayString = currentDate.toLocaleDateString("en-US", {
+    weekday: "long"
+  });
+  await currentAIProvider.streamChatIntoEditor({
+    messages: [
+      {
+        role: "system",
+        content: "You are an AI note assistant. Follow all user instructions and use the note context and note content to help follow those instructions. Use Markdown for any formatting."
+      },
+      {
+        role: "user",
+        content: `Note Context: Today is ${dayString}, ${dateString}. The current note name is "${noteName}".
+User Prompt: ${userPrompt}
 Note Content:
-${e.text}`}],stream:!0},e.to)}async function w0(){await ae();let e=await pn();if(console.log("selectedTextInfo",e),e.text.length>0){let t=await x.getCurrentPage(),i=await ye.chatWithAI({messages:[{role:"user",content:`Please summarize this note using markdown for any formatting. Your summary will be appended to the end of this note, do not include any of the note contents yourself. Keep the summary brief. The note name is ${t}.
+${selectedTextInfo.text}`
+      }
+    ],
+    stream: true
+  }, selectedTextInfo.to);
+}
+async function summarizeNote() {
+  await initIfNeeded();
+  const selectedTextInfo = await getSelectedTextOrNote();
+  console.log("selectedTextInfo", selectedTextInfo);
+  if (selectedTextInfo.text.length > 0) {
+    const noteName = await editor_exports.getCurrentPage();
+    const response = await currentAIProvider.chatWithAI({
+      messages: [{
+        role: "user",
+        content: `Please summarize this note using markdown for any formatting. Your summary will be appended to the end of this note, do not include any of the note contents yourself. Keep the summary brief. The note name is ${noteName}.
 
-${e.text}`}],stream:!1});return console.log("OpenAI response:",i),{summary:i,selectedTextInfo:e}}return{summary:"",selectedTextInfo:null}}async function v0(){let{summary:e,selectedTextInfo:t}=await w0();e&&t&&await x.insertAtPos(`
-
-`+e,t.to)}async function S0(){let{summary:e}=await w0();e?await x.showPanel("rhs",2,e):await x.flashNotification("No summary available.")}async function Wh(){await ae();let e=await x.getText(),t=await x.getCurrentPage(),i=(await Qg("tag select name where parent = 'page' order by name")).map(u=>u.name);console.log("All tags:",i);let r=`You are an AI tagging assistant. Please provide a short list of tags, separated by spaces. Follow these guidelines:
+${selectedTextInfo.text}`
+      }],
+      stream: false
+    });
+    console.log("OpenAI response:", response);
+    return {
+      summary: response,
+      selectedTextInfo
+    };
+  }
+  return { summary: "", selectedTextInfo: null };
+}
+async function insertSummary() {
+  const { summary, selectedTextInfo } = await summarizeNote();
+  if (summary && selectedTextInfo) {
+    await editor_exports.insertAtPos(
+      "\n\n" + summary,
+      selectedTextInfo.to
+    );
+  }
+}
+async function openSummaryPanel() {
+  const { summary } = await summarizeNote();
+  if (summary) {
+    await editor_exports.showPanel("rhs", 2, summary);
+  } else {
+    await editor_exports.flashNotification("No summary available.");
+  }
+}
+async function tagNoteWithAI() {
+  await initIfNeeded();
+  const noteContent = await editor_exports.getText();
+  const noteName = await editor_exports.getCurrentPage();
+  const allTags = (await query(
+    "tag select name where parent = 'page' order by name"
+  )).map((tag) => tag.name);
+  console.log("All tags:", allTags);
+  const systemPrompt = `You are an AI tagging assistant. Please provide a short list of tags, separated by spaces. Follow these guidelines:
     - Only return tags and no other content.
     - Tags must be one word only and in lowercase.
     - Use existing tags as a starting point.
     - Suggest tags sparingly, treating them as thematic descriptors rather than keywords.
 
     The following tags are currently being used by other notes:
-    ${i.join(", ")}
+    ${allTags.join(", ")}
     
     Always follow the below rules, if any, given by the user:
-    ${C.promptInstructions.tagRules}`,n=`Page Title: ${t}
+    ${aiSettings.promptInstructions.tagRules}`;
+  const userPrompt = `Page Title: ${noteName}
 
 Page Content:
-${e}`,o=(await ye.singleMessageChat(n,r)).trim().replace(/,/g,"").split(/\s+/),a=await Oe.parseMarkdown(e),l=await At(a),h=[...new Set([...l.tags||[],...o])];l.tags=h,console.log("Current frontmatter:",l);let c=await po(a,l);console.log("updatedNoteContent",c),await x.dispatch(c),await x.flashNotification("Note tagged successfully.")}async function qh(){await ae();let e=await x.getText(),t=await x.getCurrentPage(),i=[{name:"Generating suggestions...",description:""}];x.filterBox("Loading...",i,"Retrieving suggestions from LLM provider.").then(h=>{console.log("Selected option (initial):",h)});let n="";C.promptInstructions.pageRenameSystem?n=C.promptInstructions.pageRenameSystem:n=`You are an AI note-naming assistant. Your task is to suggest three to five possible names for the provided note content. Please adhere to the following guidelines:
+${noteContent}`;
+  const response = await currentAIProvider.singleMessageChat(
+    userPrompt,
+    systemPrompt
+  );
+  const tags = response.trim().replace(/,/g, "").split(/\s+/);
+  const tree = await markdown_exports.parseMarkdown(noteContent);
+  const frontMatter = await extractFrontmatter(tree);
+  const updatedTags = [.../* @__PURE__ */ new Set([...frontMatter.tags || [], ...tags])];
+  frontMatter.tags = updatedTags;
+  console.log("Current frontmatter:", frontMatter);
+  const frontMatterChange = await prepareFrontmatterDispatch(tree, frontMatter);
+  console.log("updatedNoteContent", frontMatterChange);
+  await editor_exports.dispatch(frontMatterChange);
+  await editor_exports.flashNotification("Note tagged successfully.");
+}
+async function suggestPageName() {
+  await initIfNeeded();
+  const noteContent = await editor_exports.getText();
+  const noteName = await editor_exports.getCurrentPage();
+  const loadingOption = [{
+    name: "Generating suggestions...",
+    description: ""
+  }];
+  const filterBoxPromise = editor_exports.filterBox(
+    "Loading...",
+    loadingOption,
+    "Retrieving suggestions from LLM provider."
+  );
+  filterBoxPromise.then((selectedOption) => {
+    console.log("Selected option (initial):", selectedOption);
+  });
+  let systemPrompt = "";
+  if (aiSettings.promptInstructions.pageRenameSystem) {
+    systemPrompt = aiSettings.promptInstructions.pageRenameSystem;
+  } else {
+    systemPrompt = `You are an AI note-naming assistant. Your task is to suggest three to five possible names for the provided note content. Please adhere to the following guidelines:
     - Provide each name on a new line.
     - Use only spaces, forward slashes (as folder separators), and hyphens as special characters.
     - Ensure the names are concise, descriptive, and relevant to the content.
     - Avoid suggesting the same name as the current note.
     - Include as much detail as possible within 3 to 10 words.
     - Start names with ASCII characters only.
-    - Do not use markdown or any other formatting in your response.`;let o=(await ye.singleMessageChat(`Current Page Title: ${t}
+    - Do not use markdown or any other formatting in your response.`;
+  }
+  const response = await currentAIProvider.singleMessageChat(
+    `Current Page Title: ${noteName}
 
 Page Content:
-${e}`,`${n}
+${noteContent}`,
+    `${systemPrompt}
 
 Always follow the below rules, if any, given by the user:
-${C.promptInstructions.pageRenameRules}`,!0)).trim().split(`
-`).filter(h=>h.trim()!=="").map(h=>h.replace(/^[*-]\s*/,"").trim());o.push(t),o=[...new Set(o)],o.length===0&&await x.flashNotification("No suggestions available.");let a=await x.filterBox("New page name",o.map(h=>({name:h})),"Select a new page name from one of the suggestions below.");if(!a){await x.flashNotification("No page name selected.","error");return}console.log("selectedSuggestion",a);let l=await K.invokeFunction("index.renamePageCommand",{oldPage:t,page:a.name});console.log("renamedPage",l),l||await x.flashNotification("Error renaming page.","error")}async function Yh(){await ae();let e=await x.getText(),t=await x.getCurrentPage(),i=["title","tags"],n=await ye.singleMessageChat(`Current Page Title: ${t}
-
-Page Content:
-${e}`,`You are an AI note enhancing assistant. Your task is to understand the content of a note, detect and extract important information, and convert it to frontmatter attributes. Please adhere to the following guidelines:
+${aiSettings.promptInstructions.pageRenameRules}`,
+    true
+  );
+  let suggestions = response.trim().split("\n").filter(
+    (line) => line.trim() !== ""
+  ).map((line) => line.replace(/^[*-]\s*/, "").trim());
+  suggestions.push(noteName);
+  suggestions = [...new Set(suggestions)];
+  if (suggestions.length === 0) {
+    await editor_exports.flashNotification("No suggestions available.");
+  }
+  const selectedSuggestion = await editor_exports.filterBox(
+    "New page name",
+    suggestions.map((suggestion) => ({
+      name: suggestion
+    })),
+    "Select a new page name from one of the suggestions below."
+  );
+  if (!selectedSuggestion) {
+    await editor_exports.flashNotification("No page name selected.", "error");
+    return;
+  }
+  console.log("selectedSuggestion", selectedSuggestion);
+  const renamedPage = await system_exports.invokeFunction("index.renamePageCommand", {
+    oldPage: noteName,
+    page: selectedSuggestion.name
+  });
+  console.log("renamedPage", renamedPage);
+  if (!renamedPage) {
+    await editor_exports.flashNotification("Error renaming page.", "error");
+  }
+}
+async function enhanceNoteFrontMatter() {
+  await initIfNeeded();
+  const noteContent = await editor_exports.getText();
+  const noteName = await editor_exports.getCurrentPage();
+  const blacklistedAttrs = ["title", "tags"];
+  const systemPrompt = `You are an AI note enhancing assistant. Your task is to understand the content of a note, detect and extract important information, and convert it to frontmatter attributes. Please adhere to the following guidelines:
       - Only return valid YAML frontmatter.
       - Do not use any markdown or any other formatting in your response.
       - Do not include --- in your response.
@@ -174,19 +5819,421 @@ ${e}`,`You are an AI note enhancing assistant. Your task is to understand the co
       - Do not return a new note title.
       - Do not use special characters in key names.  Only ASCII.
       - Only return important information that would be useful when searching or filtering notes.
-      
+      `;
+  const response = await currentAIProvider.singleMessageChat(
+    `Current Page Title: ${noteName}
+
+Page Content:
+${noteContent}`,
+    `${systemPrompt}
 
 Always follow the below rules, if any, given by the user:
-${C.promptInstructions.enhanceFrontMatterPrompt}`,!0);console.log("frontmatter returned by enhanceNoteFrontMatter",n);try{let s=p0(n);if(typeof s!="object"||Array.isArray(s)||!s)throw new Error("Invalid YAML: Not an object");i.forEach(c=>{delete s[c]});let o=await Oe.parseMarkdown(e),l={...await At(o),...s},h=await po(o,l);console.log("updatedNoteContent",h),await x.dispatch(h)}catch(s){console.error("Invalid YAML returned by enhanceNoteFrontMatter",s),await x.flashNotification("Error: Invalid Frontmatter YAML returned.","error");return}await x.flashNotification("Frontmatter enhanced successfully.","info")}async function x0(){await Wh(),await Yh(),await qh()}async function P0(){let e=await pn(),t=e.to;await ye.streamChatIntoEditor({messages:[{role:"system",content:"You are an AI note assistant in a markdown-based note tool."},{role:"user",content:e.text}],stream:!0},t)}async function k0(){await ae();let e=await Ds();if(e.length===0){await x.flashNotification("Error: The page does not match the required format for a chat.");return}e.unshift(en);let t=await tr(e);console.log("enrichedMessages",t);let i=await ci();await x.insertAtPos(`
+${aiSettings.promptInstructions.enhanceFrontMatterPrompt}`,
+    true
+  );
+  console.log("frontmatter returned by enhanceNoteFrontMatter", response);
+  try {
+    const newFrontMatter = parse3(response);
+    if (typeof newFrontMatter !== "object" || Array.isArray(newFrontMatter) || !newFrontMatter) {
+      throw new Error("Invalid YAML: Not an object");
+    }
+    blacklistedAttrs.forEach((attr) => {
+      delete newFrontMatter[attr];
+    });
+    const tree = await markdown_exports.parseMarkdown(noteContent);
+    const frontMatter = await extractFrontmatter(tree);
+    const updatedFrontmatter = {
+      ...frontMatter,
+      ...newFrontMatter
+    };
+    const frontMatterChange = await prepareFrontmatterDispatch(
+      tree,
+      updatedFrontmatter
+    );
+    console.log("updatedNoteContent", frontMatterChange);
+    await editor_exports.dispatch(frontMatterChange);
+  } catch (e) {
+    console.error("Invalid YAML returned by enhanceNoteFrontMatter", e);
+    await editor_exports.flashNotification(
+      "Error: Invalid Frontmatter YAML returned.",
+      "error"
+    );
+    return;
+  }
+  await editor_exports.flashNotification(
+    "Frontmatter enhanced successfully.",
+    "info"
+  );
+}
+async function enhanceNoteWithAI() {
+  await tagNoteWithAI();
+  await enhanceNoteFrontMatter();
+  await suggestPageName();
+}
+async function streamOpenAIWithSelectionAsPrompt() {
+  const selectedTextInfo = await getSelectedTextOrNote();
+  const cursorPos = selectedTextInfo.to;
+  await currentAIProvider.streamChatIntoEditor({
+    messages: [
+      {
+        role: "system",
+        content: "You are an AI note assistant in a markdown-based note tool."
+      },
+      { role: "user", content: selectedTextInfo.text }
+    ],
+    stream: true
+  }, cursorPos);
+}
+async function streamChatOnPage() {
+  await initIfNeeded();
+  const messages = await convertPageToMessages();
+  if (messages.length === 0) {
+    await editor_exports.flashNotification(
+      "Error: The page does not match the required format for a chat."
+    );
+    return;
+  }
+  messages.unshift(chatSystemPrompt);
+  const enrichedMessages = await enrichChatMessages(messages);
+  console.log("enrichedMessages", enrichedMessages);
+  let cursorPos = await getPageLength();
+  await editor_exports.insertAtPos("\n\n**assistant**: ", cursorPos);
+  cursorPos += "\n\n**assistant**: ".length;
+  await editor_exports.insertAtPos("\n\n**user**: ", cursorPos);
+  await editor_exports.moveCursor(cursorPos + "\n\n**user**: ".length);
+  try {
+    await currentAIProvider.streamChatIntoEditor({
+      messages: enrichedMessages,
+      stream: true
+    }, cursorPos);
+  } catch (error) {
+    console.error("Error streaming chat on page:", error);
+    await editor_exports.flashNotification("Error streaming chat on page.", "error");
+  }
+}
+async function promptAndGenerateImage() {
+  await initIfNeeded();
+  if (!aiSettings.imageModels || aiSettings.imageModels.length === 0) {
+    await editor_exports.flashNotification("No image models available.", "error");
+    return;
+  }
+  try {
+    const prompt2 = await editor_exports.prompt("Enter a prompt for DALL\xB7E:");
+    if (!prompt2 || !prompt2.trim()) {
+      await editor_exports.flashNotification(
+        "No prompt entered. Operation cancelled.",
+        "error"
+      );
+      return;
+    }
+    const imageOptions = {
+      prompt: prompt2,
+      numImages: 1,
+      size: "1024x1024",
+      quality: "hd"
+    };
+    const imageData = await currentImageProvider.generateImage(imageOptions);
+    if (imageData && imageData.data && imageData.data.length > 0) {
+      const base64Image = imageData.data[0].b64_json;
+      const revisedPrompt = imageData.data[0].revised_prompt;
+      const decodedImage = new Uint8Array(decodeBase64(base64Image));
+      const finalFileName = `dall-e-${Date.now()}.png`;
+      let prefix = folderName(await editor_exports.getCurrentPage()) + "/";
+      if (prefix === "/") {
+        prefix = "";
+      }
+      await space_exports.writeAttachment(prefix + finalFileName, decodedImage);
+      const markdownImg = `![${finalFileName}](${finalFileName})
+*${revisedPrompt}*`;
+      await editor_exports.insertAtCursor(markdownImg);
+      await editor_exports.flashNotification(
+        "Image generated and inserted with caption successfully."
+      );
+    } else {
+      await editor_exports.flashNotification("Failed to generate image.", "error");
+    }
+  } catch (error) {
+    console.error("Error generating image with DALL\xB7E:", error);
+    await editor_exports.flashNotification("Error generating image.", "error");
+  }
+}
+async function queryAI(userPrompt, systemPrompt) {
+  try {
+    await initIfNeeded();
+    const defaultSystemPrompt = "You are an AI note assistant helping to render content for a note. Please follow user instructions and keep your response short and concise.";
+    const response = await currentAIProvider.singleMessageChat(
+      userPrompt,
+      systemPrompt || defaultSystemPrompt
+    );
+    return response;
+  } catch (error) {
+    console.error("Error querying OpenAI:", error);
+    throw error;
+  }
+}
+async function testEmbeddingGeneration() {
+  await initIfNeeded();
+  const text = await editor_exports.prompt("Enter some text to embed:");
+  if (!text) {
+    await editor_exports.flashNotification("No text entered.", "error");
+    return;
+  }
+  const embedding = await currentEmbeddingProvider.generateEmbeddings({
+    text
+  });
+  await editor_exports.insertAtCursor(`
 
-**assistant**: `,i),i+=17,await x.insertAtPos(`
+Embedding: ${embedding}`);
+}
 
-**user**: `,i),await x.moveCursor(i+12);try{await ye.streamChatIntoEditor({messages:t,stream:!0},i)}catch(r){console.error("Error streaming chat on page:",r),await x.flashNotification("Error streaming chat on page.","error")}}async function Q0(){if(await ae(),!C.imageModels||C.imageModels.length===0){await x.flashNotification("No image models available.","error");return}try{let e=await x.prompt("Enter a prompt for DALL\xB7E:");if(!e||!e.trim()){await x.flashNotification("No prompt entered. Operation cancelled.","error");return}let t={prompt:e,numImages:1,size:"1024x1024",quality:"hd"},i=await Js.generateImage(t);if(i&&i.data&&i.data.length>0){let r=i.data[0].b64_json,n=i.data[0].revised_prompt,s=new Uint8Array($g(r)),o=`dall-e-${Date.now()}.png`,a=bg(await x.getCurrentPage())+"/";a==="/"&&(a=""),await me.writeAttachment(a+o,s);let l=`![${o}](${o})
-*${n}*`;await x.insertAtCursor(l),await x.flashNotification("Image generated and inserted with caption successfully.")}else await x.flashNotification("Failed to generate image.","error")}catch(e){console.error("Error generating image with DALL\xB7E:",e),await x.flashNotification("Error generating image.","error")}}async function $0(e,t){try{return await ae(),await ye.singleMessageChat(e,t||"You are an AI note assistant helping to render content for a note. Please follow user instructions and keep your response short and concise.")}catch(i){throw console.error("Error querying OpenAI:",i),i}}async function T0(){await ae();let e=await x.prompt("Enter some text to embed:");if(!e){await x.flashNotification("No text entered.","error");return}let t=await He.generateEmbeddings({text:e});await x.insertAtCursor(`
-
-Embedding: ${t}`)}var C0={aiPromptSlashCommplete:Sg,queryAI:$0,reloadConfig:O0,summarizeNote:S0,insertSummary:v0,callOpenAI:b0,tagNoteWithAI:Wh,promptAndGenerateImage:Q0,streamOpenAIWithSelectionAsPrompt:P0,streamChatOnPage:k0,insertAiPromptFromTemplate:xg,suggestPageName:qh,enhanceNoteFrontMatter:Yh,enhanceNoteWithAI:x0,selectTextModel:m0,selectImageModel:g0,selectEmbeddingModel:y0,testEmbeddingGeneration:T0,getAllEmbeddings:fh,searchEmbeddings:ph,queueEmbeddingGeneration:hg,processEmbeddingsQueue:cg,processSummaryQueue:ug,generateEmbeddings:fg,generateEmbeddingsOnServer:Hr,searchEmbeddingsForChat:js,searchCombinedEmbeddings:Ns,searchSummaryEmbeddings:pg,readPageSearchEmbeddings:Og,writePageSearchEmbeddings:mg,getPageMetaSearchEmbeddings:Oh,searchCommand:yg,updateSearchPage:gg},A0={name:"silverbullet-ai",requiredPermissions:["fetch"],functions:{aiPromptSlashCommplete:{path:"src/prompts.ts:aiPromptSlashComplete",events:["slash:complete"]},queryAI:{path:"sbai.ts:queryAI"},reloadConfig:{path:"sbai.ts:reloadConfig",events:["page:saved"]},summarizeNote:{path:"sbai.ts:openSummaryPanel",command:{name:"AI: Summarize Note and open summary"}},insertSummary:{path:"sbai.ts:insertSummary",command:{name:"AI: Insert Summary"}},callOpenAI:{path:"sbai.ts:callOpenAIwithNote",command:{name:"AI: Call OpenAI with Note as context"}},tagNoteWithAI:{path:"sbai.ts:tagNoteWithAI",command:{name:"AI: Generate tags for note"}},promptAndGenerateImage:{path:"sbai.ts:promptAndGenerateImage",command:{name:"AI: Generate and insert image using DallE"}},streamOpenAIWithSelectionAsPrompt:{path:"sbai.ts:streamOpenAIWithSelectionAsPrompt",command:{name:"AI: Stream response with selection or note as prompt"}},streamChatOnPage:{path:"sbai.ts:streamChatOnPage",command:{name:"AI: Chat on current page",key:"Ctrl-Shift-Enter",mac:"Cmd-Shift-Enter"}},insertAiPromptFromTemplate:{path:"src/prompts.ts:insertAiPromptFromTemplate",command:{name:"AI: Execute AI Prompt from Custom Template"}},suggestPageName:{path:"sbai.ts:suggestPageName",command:{name:"AI: Suggest Page Name"}},enhanceNoteFrontMatter:{path:"sbai.ts:enhanceNoteFrontMatter",command:{name:"AI: Generate Note FrontMatter"}},enhanceNoteWithAI:{path:"sbai.ts:enhanceNoteWithAI",command:{name:"AI: Enhance Note"}},selectTextModel:{path:"sbai.ts:selectModelFromConfig",command:{name:"AI: Select Text Model from Config"}},selectImageModel:{path:"sbai.ts:selectImageModelFromConfig",command:{name:"AI: Select Image Model from Config"}},selectEmbeddingModel:{path:"sbai.ts:selectEmbeddingModelFromConfig",command:{name:"AI: Select Embedding Model from Config"}},testEmbeddingGeneration:{path:"sbai.ts:testEmbeddingGeneration",command:{name:"AI: Test Embedding Generation"}},getAllEmbeddings:{path:"src/embeddings.ts:getAllEmbeddings",env:"server"},searchEmbeddings:{path:"src/embeddings.ts:searchEmbeddings",env:"server"},queueEmbeddingGeneration:{path:"src/embeddings.ts:queueEmbeddingGeneration",env:"server",events:["page:index"]},processEmbeddingsQueue:{path:"src/embeddings.ts:processEmbeddingsQueue",mqSubscriptions:[{queue:"aiEmbeddingsQueue",batchSize:1,autoAck:!0,pollInterval:6e5}]},processSummaryQueue:{path:"src/embeddings.ts:processSummaryQueue",mqSubscriptions:[{queue:"aiSummaryQueue",batchSize:1,autoAck:!0,pollInterval:6e5}]},generateEmbeddings:{path:"src/embeddings.ts:generateEmbeddings"},generateEmbeddingsOnServer:{path:"src/embeddings.ts:generateEmbeddingsOnServer"},searchEmbeddingsForChat:{path:"src/embeddings.ts:searchEmbeddingsForChat"},searchCombinedEmbeddings:{path:"src/embeddings.ts:searchCombinedEmbeddings"},searchSummaryEmbeddings:{path:"src/embeddings.ts:searchSummaryEmbeddings"},readPageSearchEmbeddings:{path:"src/embeddings.ts:readFileEmbeddings",pageNamespace:{pattern:"\u{1F916} .+",operation:"readFile"}},writePageSearchEmbeddings:{path:"src/embeddings.ts:writeFileEmbeddings",pageNamespace:{pattern:"\u{1F916} .+",operation:"writeFile"}},getPageMetaSearchEmbeddings:{path:"src/embeddings.ts:getFileMetaEmbeddings",pageNamespace:{pattern:"\u{1F916} .+",operation:"getFileMeta"}},searchCommand:{path:"src/embeddings.ts:searchCommand",command:{name:"AI: Search"}},updateSearchPage:{path:"src/embeddings.ts:updateSearchPage",events:["editor:pageLoaded","editor:pageReloaded"]}},assets:{}},WM={manifest:A0,functionMapping:C0};Lh(C0,A0);export{WM as plug};
-/*! Bundled license information:
-
-js-yaml/dist/js-yaml.mjs:
-  (*! js-yaml 4.1.0 https://github.com/nodeca/js-yaml @license MIT *)
-*/
+// 54969c656d5cb084.js
+var functionMapping = {
+  aiPromptSlashCommplete: aiPromptSlashComplete,
+  queryAI,
+  reloadSettingsPageEvent: reloadSettingsPage,
+  reloadConfigEvent: reloadConfig2,
+  summarizeNote: openSummaryPanel,
+  insertSummary,
+  callOpenAI: callOpenAIwithNote,
+  tagNoteWithAI,
+  promptAndGenerateImage,
+  streamOpenAIWithSelectionAsPrompt,
+  streamChatOnPage,
+  insertAiPromptFromTemplate,
+  suggestPageName,
+  enhanceNoteFrontMatter,
+  enhanceNoteWithAI,
+  selectTextModel: selectModelFromConfig,
+  selectImageModel: selectImageModelFromConfig,
+  selectEmbeddingModel: selectEmbeddingModelFromConfig,
+  testEmbeddingGeneration,
+  getAllEmbeddings,
+  searchEmbeddings,
+  queueEmbeddingGeneration,
+  processEmbeddingsQueue,
+  processSummaryQueue,
+  generateEmbeddings,
+  generateEmbeddingsOnServer,
+  searchEmbeddingsForChat,
+  searchCombinedEmbeddings,
+  searchSummaryEmbeddings,
+  readPageSearchEmbeddings: readFileEmbeddings,
+  writePageSearchEmbeddings: writeFileEmbeddings,
+  getPageMetaSearchEmbeddings: getFileMetaEmbeddings,
+  searchCommand,
+  updateSearchPage
+};
+var manifest = {
+  "name": "silverbullet-ai",
+  "requiredPermissions": [
+    "fetch"
+  ],
+  "functions": {
+    "aiPromptSlashCommplete": {
+      "path": "src/prompts.ts:aiPromptSlashComplete",
+      "events": [
+        "slash:complete"
+      ]
+    },
+    "queryAI": {
+      "path": "sbai.ts:queryAI"
+    },
+    "reloadSettingsPageEvent": {
+      "path": "sbai.ts:reloadSettingsPage",
+      "events": [
+        "page:saved"
+      ]
+    },
+    "reloadConfigEvent": {
+      "path": "sbai.ts:reloadConfig",
+      "events": [
+        "config:loaded"
+      ]
+    },
+    "summarizeNote": {
+      "path": "sbai.ts:openSummaryPanel",
+      "command": {
+        "name": "AI: Summarize Note and open summary"
+      }
+    },
+    "insertSummary": {
+      "path": "sbai.ts:insertSummary",
+      "command": {
+        "name": "AI: Insert Summary"
+      }
+    },
+    "callOpenAI": {
+      "path": "sbai.ts:callOpenAIwithNote",
+      "command": {
+        "name": "AI: Call OpenAI with Note as context"
+      }
+    },
+    "tagNoteWithAI": {
+      "path": "sbai.ts:tagNoteWithAI",
+      "command": {
+        "name": "AI: Generate tags for note"
+      }
+    },
+    "promptAndGenerateImage": {
+      "path": "sbai.ts:promptAndGenerateImage",
+      "command": {
+        "name": "AI: Generate and insert image using DallE"
+      }
+    },
+    "streamOpenAIWithSelectionAsPrompt": {
+      "path": "sbai.ts:streamOpenAIWithSelectionAsPrompt",
+      "command": {
+        "name": "AI: Stream response with selection or note as prompt"
+      }
+    },
+    "streamChatOnPage": {
+      "path": "sbai.ts:streamChatOnPage",
+      "command": {
+        "name": "AI: Chat on current page",
+        "key": "Ctrl-Shift-Enter",
+        "mac": "Cmd-Shift-Enter"
+      }
+    },
+    "insertAiPromptFromTemplate": {
+      "path": "src/prompts.ts:insertAiPromptFromTemplate",
+      "command": {
+        "name": "AI: Execute AI Prompt from Custom Template"
+      }
+    },
+    "suggestPageName": {
+      "path": "sbai.ts:suggestPageName",
+      "command": {
+        "name": "AI: Suggest Page Name"
+      }
+    },
+    "enhanceNoteFrontMatter": {
+      "path": "sbai.ts:enhanceNoteFrontMatter",
+      "command": {
+        "name": "AI: Generate Note FrontMatter"
+      }
+    },
+    "enhanceNoteWithAI": {
+      "path": "sbai.ts:enhanceNoteWithAI",
+      "command": {
+        "name": "AI: Enhance Note"
+      }
+    },
+    "selectTextModel": {
+      "path": "sbai.ts:selectModelFromConfig",
+      "command": {
+        "name": "AI: Select Text Model from Config"
+      }
+    },
+    "selectImageModel": {
+      "path": "sbai.ts:selectImageModelFromConfig",
+      "command": {
+        "name": "AI: Select Image Model from Config"
+      }
+    },
+    "selectEmbeddingModel": {
+      "path": "sbai.ts:selectEmbeddingModelFromConfig",
+      "command": {
+        "name": "AI: Select Embedding Model from Config"
+      }
+    },
+    "testEmbeddingGeneration": {
+      "path": "sbai.ts:testEmbeddingGeneration",
+      "command": {
+        "name": "AI: Test Embedding Generation"
+      }
+    },
+    "getAllEmbeddings": {
+      "path": "src/embeddings.ts:getAllEmbeddings",
+      "env": "server"
+    },
+    "searchEmbeddings": {
+      "path": "src/embeddings.ts:searchEmbeddings",
+      "env": "server"
+    },
+    "queueEmbeddingGeneration": {
+      "path": "src/embeddings.ts:queueEmbeddingGeneration",
+      "env": "server",
+      "events": [
+        "page:index"
+      ]
+    },
+    "processEmbeddingsQueue": {
+      "path": "src/embeddings.ts:processEmbeddingsQueue",
+      "mqSubscriptions": [
+        {
+          "queue": "aiEmbeddingsQueue",
+          "batchSize": 1,
+          "autoAck": true,
+          "pollInterval": 6e5
+        }
+      ]
+    },
+    "processSummaryQueue": {
+      "path": "src/embeddings.ts:processSummaryQueue",
+      "mqSubscriptions": [
+        {
+          "queue": "aiSummaryQueue",
+          "batchSize": 1,
+          "autoAck": true,
+          "pollInterval": 6e5
+        }
+      ]
+    },
+    "generateEmbeddings": {
+      "path": "src/embeddings.ts:generateEmbeddings"
+    },
+    "generateEmbeddingsOnServer": {
+      "path": "src/embeddings.ts:generateEmbeddingsOnServer"
+    },
+    "searchEmbeddingsForChat": {
+      "path": "src/embeddings.ts:searchEmbeddingsForChat"
+    },
+    "searchCombinedEmbeddings": {
+      "path": "src/embeddings.ts:searchCombinedEmbeddings"
+    },
+    "searchSummaryEmbeddings": {
+      "path": "src/embeddings.ts:searchSummaryEmbeddings"
+    },
+    "readPageSearchEmbeddings": {
+      "path": "src/embeddings.ts:readFileEmbeddings",
+      "pageNamespace": {
+        "pattern": "\u{1F916} .+",
+        "operation": "readFile"
+      }
+    },
+    "writePageSearchEmbeddings": {
+      "path": "src/embeddings.ts:writeFileEmbeddings",
+      "pageNamespace": {
+        "pattern": "\u{1F916} .+",
+        "operation": "writeFile"
+      }
+    },
+    "getPageMetaSearchEmbeddings": {
+      "path": "src/embeddings.ts:getFileMetaEmbeddings",
+      "pageNamespace": {
+        "pattern": "\u{1F916} .+",
+        "operation": "getFileMeta"
+      }
+    },
+    "searchCommand": {
+      "path": "src/embeddings.ts:searchCommand",
+      "command": {
+        "name": "AI: Search"
+      }
+    },
+    "updateSearchPage": {
+      "path": "src/embeddings.ts:updateSearchPage",
+      "events": [
+        "editor:pageLoaded",
+        "editor:pageReloaded"
+      ]
+    }
+  },
+  "assets": {}
+};
+var plug = { manifest, functionMapping };
+setupMessageListener(functionMapping, manifest);
+export {
+  plug
+};
+//# sourceMappingURL=silverbullet-ai.plug.js.map

--- a/silverbullet-ai.plug.yaml
+++ b/silverbullet-ai.plug.yaml
@@ -9,10 +9,16 @@ functions:
   queryAI:
     path: sbai.ts:queryAI
 
-  reloadConfig:
-    path: sbai.ts:reloadConfig
+  reloadSettingsPageEvent:
+    path: sbai.ts:reloadSettingsPage
     events:
       - page:saved
+
+  reloadConfigEvent:
+    path: sbai.ts:reloadConfig
+    events:
+      - config:loaded
+
   summarizeNote:
     path: sbai.ts:openSummaryPanel
     command:

--- a/src/embeddings.test.ts
+++ b/src/embeddings.test.ts
@@ -1,9 +1,9 @@
 import { assertEquals } from "https://deno.land/std@0.224.0/assert/mod.ts";
 import "./mocks/syscalls.ts";
+import { syscall } from "./mocks/syscalls.ts";
 import { aiSettings, initializeOpenAI } from "./init.ts";
 import {
   canIndexPage,
-  indexEmbeddings,
   shouldIndexEmbeddings,
   shouldIndexSummaries,
 } from "./embeddings.ts";

--- a/src/embeddings.ts
+++ b/src/embeddings.ts
@@ -674,6 +674,7 @@ export async function updateSearchPage() {
       );
     } catch (error) {
       console.error("Error searching embeddings", error);
+      // deno-fmt-ignore
       loadingText += "\n\n> **error** ⚠️ Failed to search through embeddings.\n";
       loadingText += `> ${error}\n\n`;
       await editor.setText(loadingText);

--- a/src/embeddings.ts
+++ b/src/embeddings.ts
@@ -655,8 +655,8 @@ export async function updateSearchPage() {
       queryEmbedding = await generateEmbeddingsOnServer(phrase);
     } catch (error) {
       console.error("Error generating query vector embeddings", error);
-      loadingText +=
-        "\n\n> **error** ⚠️ Failed to generate query vector embeddings.\n";
+      // deno-fmt-ignore
+      loadingText += "\n\n> **error** ⚠️ Failed to generate query vector embeddings.\n";
       loadingText += `> ${error}\n\n`;
       await editor.setText(loadingText);
       return;

--- a/src/init.ts
+++ b/src/init.ts
@@ -1,5 +1,4 @@
 import { readSecret } from "https://deno.land/x/silverbullet@0.9.4/plug-api/lib/secrets_page.ts";
-import { readSetting } from "https://deno.land/x/silverbullet@0.7.7/plug-api/lib/settings_page.ts";
 import { clientStore, system } from "@silverbulletmd/silverbullet/syscalls";
 import { DallEProvider } from "./providers/dalle.ts";
 import { GeminiEmbeddingProvider, GeminiProvider } from "./providers/gemini.ts";
@@ -347,7 +346,7 @@ async function loadAndMergeSettings() {
     indexSummaryPrompt: "",
     enhanceFrontMatterPrompt: "",
   };
-  const newSettings = await readSetting("ai", {});
+  const newSettings = await system.getSpaceConfig("ai", {});
   const newCombinedSettings = { ...defaultSettings, ...newSettings };
   newCombinedSettings.chat = {
     ...defaultChatSettings,

--- a/src/mocks/syscalls.ts
+++ b/src/mocks/syscalls.ts
@@ -1,5 +1,6 @@
 import { parse as parseYAML } from "https://deno.land/std@0.216.0/yaml/mod.ts";
 import { parseMarkdown } from "$common/markdown_parser/parser.ts";
+import { syscall } from "@silverbulletmd/silverbullet/syscalls";
 
 let editorText = "Mock data";
 (globalThis as any).editorText;
@@ -71,3 +72,5 @@ function invokeFunctionMock(args: readonly any[]) {
       throw Error(`Missing invokeFunction mock for ${args[0]}`);
   }
 }
+
+export { syscall };


### PR DESCRIPTION
Fixes #58 

- Added support for space-config in Changelog.md.
- Renamed reloadConfig to reloadSettingsPage and created a new reloadConfig for config:loaded event.
- Updated silverbullet-ai.plug.yaml to handle new events.
- Replaced readSetting with system.getSpaceConfig in init.ts.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **New Features**
	- Introduced support for "space-config," enhancing user flexibility in configuring spaces.
- **Improvements**
	- Enhanced performance and maintainability through various optimizations.
	- Shifted to a more centralized approach for managing settings, improving modularity and scalability.
	- Improved error handling for query vector embeddings to provide clearer feedback.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->