### PR TITLE
Switch documentation to a combination of silverbullet-pub and mkdocs

### DIFF
--- a/.github/workflows/gh-pages-docs.yml
+++ b/.github/workflows/gh-pages-docs.yml
@@ -55,6 +55,7 @@ jobs:
           pip install mkdocs-material==9.5.34
           pip install mkdocs-git-revision-date-localized-plugin==1.2.9
           pip install mdx_truly_sane_lists==1.3
+          pip install mkdocs-include-dir-to-nav==1.2.0
           mkdocs build
           mkdir -pv site/Library/AICore
           cp -Rv docs/Library/AICore/* site/Library/AICore/
@@ -62,7 +63,8 @@ jobs:
       - name: Upload artifact
         uses: actions/upload-pages-artifact@v3
         with:
-          path: ./docs/_public
+          # path: ./docs/_public
+          path: ./site
 
   # Deployment job
   deploy:

--- a/.github/workflows/gh-pages-docs.yml
+++ b/.github/workflows/gh-pages-docs.yml
@@ -48,7 +48,16 @@ jobs:
 
       - name: Build Docs site
         run: |
-          SB_DB_BACKEND=memory deno run --unstable-kv --unstable-worker-options -A https://edge.silverbullet.md/silverbullet.js plug:run docs/ pub.publishAll && cp -v docs/style.css docs/_public/
+          ./render-docs.sh
+
+      - name: Run mkdocs
+        run: |
+          pip install mkdocs-material==9.5.34
+          pip install mkdocs-git-revision-date-localized-plugin==1.2.9
+          pip install mdx_truly_sane_lists==1.3
+          mkdocs build
+          mkdir -pv site/Library/AICore
+          cp -Rv docs/Library/AICore/* site/Library/AICore/
 
       - name: Upload artifact
         uses: actions/upload-pages-artifact@v3

--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,4 @@ docs/Library/Core
 SECRETS.md
 cov_profile
 test?space*
+site/

--- a/docs/AI Core Library.md
+++ b/docs/AI Core Library.md
@@ -18,7 +18,7 @@ libraries:
 - import: "[[!ai.silverbullet.md/Library/AICore/*]]"
 ```
 
-Once added, run the {[Libraries: Update]} command to download the libraries. **Note**: This needs to run from a client that is not in sync-mode due to CORs issues.
+Once added, run the {[Libraries: Update]} command to download the libraries.
 
 
 The included templates, prompts, and space scripts are briefly described below. Please consider [contributing](https://github.com/justyns/silverbullet-ai) any templates or prompts you find useful.
@@ -28,7 +28,7 @@ The included templates, prompts, and space scripts are briefly described below. 
 ```query
 template
 where name =~ /^Library\/AICore/
-render [[Library/Core/Query/Template]]
+render [[Library/AIDocs/Query/AI Template]]
 ```
 
 # Included Space Script

--- a/docs/AI Core Library.md
+++ b/docs/AI Core Library.md
@@ -36,6 +36,6 @@ render [[Library/AIDocs/Query/AI Template]]
 ```query
 page
 where name =~ /^Library\/AICore\/Space Script/
-render [[Library/Core/Query/Template]]
+render [[Library/AIDocs/Query/AI Template]]
 ```
 

--- a/docs/Changelog.md
+++ b/docs/Changelog.md
@@ -29,6 +29,7 @@ This page is a brief overview of each version.
 - AICore Library: Add `aiSplitTodo` slash command and [[^Library/AICore/AIPrompt/AI Split Task]] templated prompt to split a task into smaller subtasks.
 - AICore Library: Add template prompts for rewriting text, mostly as a demo for the `replace-smart` insertAt option.
 - Remove need for duplicate `description` frontmatter field for templated prompts.
+- Revamp docs website to use mkdocs (and mkdocs-material) in addition to silverbullet-pub to handle the silverbullet-specific things like templates/queries.
 
 ---
 ## 0.3.2

--- a/docs/Changelog.md
+++ b/docs/Changelog.md
@@ -72,6 +72,7 @@ This page is a brief overview of each version.
 ---
 ## 0.0.11
 - Support for custom chat message enrichment functions, see [[Configuration/Custom Enrichment Functions]]
+
 ---
 ## 0.0.10
 - Add WIP docs and docs workflow by [@justyns](https://github.com/justyns) in [#20](https://github.com/justyns/silverbullet-ai/pull/20)

--- a/docs/Commands/AI: Call OpenAI with Note as context.md
+++ b/docs/Commands/AI: Call OpenAI with Note as context.md
@@ -5,3 +5,5 @@ commandSummary: "Prompts the user for a custom prompt to send to the LLM.  If th
 If the user has no text selected, the entire note is used as the note content.
 The response is streamed to the cursor position."
 ---
+
+> **warning**: Deprecated. Use [[Templated Prompts]] instead.

--- a/docs/Commands/AI: Generate Note FrontMatter.md
+++ b/docs/Commands/AI: Generate Note FrontMatter.md
@@ -5,7 +5,7 @@ commandSummary: "Extracts important information from the current note and conver
 to frontmatter attributes."
 ---
 
-**Experimental**: This is new and not well-tested.  Please submit feedback if you have ideas for making it better.
+> **note**: **Experimental**: This is new and not well-tested.  Please submit feedback if you have ideas for making it better.
 
 This command will attempt to extract useful information from a note and then generate frontmatter attributes for that note.
 

--- a/docs/Commands/AI: Insert Summary.md
+++ b/docs/Commands/AI: Insert Summary.md
@@ -4,3 +4,5 @@ commandName: "AI: Insert Summary"
 commandSummary: "Uses a built-in prompt to ask the LLM for a summary of either the entire note, or the selected
 text.  Inserts the summary at the cursor's position."
 ---
+
+> **warning**: Deprecated. Use [[Templated Prompts]] instead.

--- a/docs/Commands/AI: Select Embedding Model from Config.md
+++ b/docs/Commands/AI: Select Embedding Model from Config.md
@@ -3,3 +3,7 @@ tags: commands
 commandName: "AI: Select Embedding Model from Config"
 commandSummary: "Prompts the user to select an embedding model from the configured models."
 ---
+
+```template
+{{@page.commandSummary}}
+```

--- a/docs/Commands/AI: Select Image Model from Config.md
+++ b/docs/Commands/AI: Select Image Model from Config.md
@@ -3,3 +3,7 @@ tags: commands
 commandName: "AI: Select Image Model from Config"
 commandSummary: "Prompts the user to select an image model from the configured models."
 ---
+
+```template
+{{@page.commandSummary}}
+```

--- a/docs/Commands/AI: Select Text Model from Config.md
+++ b/docs/Commands/AI: Select Text Model from Config.md
@@ -3,3 +3,7 @@ tags: commands
 commandName: "AI: Select Text Model from Config"
 commandSummary: "Prompts the user to select a text/llm model from the configured models."
 ---
+
+```template
+{{@page.commandSummary}}
+```

--- a/docs/Commands/AI: Stream response with selection or note as prompt.md
+++ b/docs/Commands/AI: Stream response with selection or note as prompt.md
@@ -3,3 +3,5 @@ tags: commands
 commandName: "AI: Stream response with selection or note as prompt"
 commandSummary: "Streams a conversation with the LLM, inserting the responses at the cursor position as it is received."
 ---
+
+> **warning**: Deprecated. Use [[Templated Prompts]] instead.

--- a/docs/Commands/AI: Summarize Note and open summary.md
+++ b/docs/Commands/AI: Summarize Note and open summary.md
@@ -4,3 +4,5 @@ commandName: "AI: Summarize Note and open summary"
 commandSummary: "Uses a built-in prompt to ask the LLM for a summary of either the entire note, or the selected
 text.  Opens the resulting summary in a temporary right pane."
 ---
+
+> **warning**: Deprecated. Use [[Templated Prompts]] instead.

--- a/docs/Commands/AI: Test Embedding Generation.md
+++ b/docs/Commands/AI: Test Embedding Generation.md
@@ -4,3 +4,7 @@ commandName: "AI: Test Embedding Generation"
 commandSummary: "Function to test generating embeddings.  Just puts the result in the current note, but
 isn't too helpful for most cases."
 ---
+
+```template
+{{@page.commandSummary}}
+```

--- a/docs/Development.md
+++ b/docs/Development.md
@@ -24,3 +24,19 @@ deno task build && cp *.plug.js /my/space/_plug/
 ```
 
 SilverBullet will automatically sync and load the new version of the plug (or speed up this process by running the {[Sync: Now]} command).
+
+
+## Docs
+
+Documentation is located in the `docs/` directory and rendered using a combination of the [silverbullet-pub plugin](https://github.com/silverbulletmd/silverbullet-pub) and [mkdocs](https://github.com/mkdocs/mkdocs).
+
+To make changes, use silverbullet locally like: `silverbullet docs/`
+
+If you want to see changes in real-time, open up two terminals and run these two commands:
+
+- `mkdocs serve -a localhost:9000`
+- `find docs -name \*.md -type f | egrep -v 'public' | entr bash ./render-docs.sh`
+
+The first starts a local development server of mkdocs. The second uses the [entr](https://github.com/eradman/entr) command to run silverbullet-pub every time a file changes inside the silverbullet docs/ directory.
+
+Markdown files inside of docs/ can also be manually edited using any editor.

--- a/docs/Installation.md
+++ b/docs/Installation.md
@@ -10,7 +10,7 @@ For in-development code from the main branch:
 - github:justyns/silverbullet-ai/silverbullet-ai.plug.js
 ```
 
-For the latest "release" code, mostly also still in development for now:
+For the latest [release](https://github.com/justyns/silverbullet-ai/releases) version:
 
 ```yaml
 - ghr:justyns/silverbullet-ai/0.3.2

--- a/docs/Library/AIDocs/Query/AI Template.md
+++ b/docs/Library/AIDocs/Query/AI Template.md
@@ -2,7 +2,7 @@
 tags: template
 ---
 
-* [[{{ref}}]] {{#if aiprompt}}{{aiprompt.description}}{{else}}{{description}}{{/if}}
+* **{{ref}}** {{#if aiprompt}}{{aiprompt.description}}{{else}}{{description}}{{/if}}
 {{#if aiprompt.usage}}
   * **Usage:** {{aiprompt.usage}}
 {{/if}}

--- a/docs/Library/AIDocs/Query/AI Template.md
+++ b/docs/Library/AIDocs/Query/AI Template.md
@@ -1,0 +1,8 @@
+---
+tags: template
+---
+
+* [[{{ref}}]] {{#if aiprompt}}{{aiprompt.description}}{{else}}{{description}}{{/if}}
+{{#if aiprompt.usage}}
+  * **Usage:** {{aiprompt.usage}}
+{{/if}}

--- a/docs/Quick Start.md
+++ b/docs/Quick Start.md
@@ -51,7 +51,7 @@ ai:
 
 Run `AI: Select Text Model from Config`, choose one of the models you just configured.
 
-> **note** If you only have one model configured, it will be selected automatically.
+> **note**: If you only have one model configured, it will be selected automatically.
 
 Open a new note, run [[Commands/AI: Chat on current page]] or press (CTRL|CMD)+SHIFT+ENTER to start a chat session.
 

--- a/docs/Templated Prompts.md
+++ b/docs/Templated Prompts.md
@@ -3,7 +3,7 @@ tags: sidebar
 navOrder: 20
 ---
 
-**NOTE:** All built-in prompts may be replaced with templated prompts eventually.
+> **note:** All built-in prompts may be replaced with templated prompts eventually.
 
 As of 0.0.6, you can use template notes to create your own custom prompts to send to the LLM.
 

--- a/docs/mkdocs-sb.py
+++ b/docs/mkdocs-sb.py
@@ -1,0 +1,45 @@
+import logging
+import re
+import mkdocs.plugins
+import os.path
+
+log = logging.getLogger('mkdocs')
+
+root_dir = os.path.abspath(os.path.join(os.path.dirname(__file__)))
+
+def find_target_file(root_dir, link):
+    # Implement the logic to find the target file
+    # This is a placeholder implementation
+    potential_path = os.path.join(root_dir, f"{link}.md")
+    return potential_path if os.path.exists(potential_path) else None
+
+def replace_wiki_link(match, root_dir, page):
+    # Wiki links in silverbullet are always relative from the root space directory
+    link = match.group(1).strip()
+    alias = match.group(2).strip() if len(match.groups()) > 1 and match.group(2) else os.path.basename(link)
+    target_path = find_target_file(root_dir, link)
+    log.info(f"target_path: {target_path}")
+    log.info(f"page.file.abs_src_path: {page.file.abs_src_path}")
+    if target_path:
+        relative_path = os.path.relpath(target_path, os.path.dirname(os.path.dirname(page.file.abs_src_path)))
+        log.info(f"wiki link: {link} -> {relative_path}")
+        return f'[{alias}]({relative_path})'
+    else:
+        log.warning(f"Target file not found for wiki link: {link}")
+        return f'[{alias}]({link}.md)'
+
+def convert_admonitions(markdown):
+    # Convert blockquotes with bold headers to MkDocs-style admonitions
+    # Matches lines starting with "> **Header**:" and captures the header and content
+    return re.sub(r'^> \*\*([\w\s]+)\*\*:\s*(.*(?:\n(?!>).*)*)', r'!!! \1\n\n    \2', markdown, flags=re.MULTILINE)
+
+def process_links(markdown, root_dir, page):
+    # Convert wiki-style links [[Page]] or [[Page|Alias]] to Markdown links
+    # Captures the page name and optional alias, then calls replace_wiki_link function
+    return re.sub(r'\[\[([^|\]]+)(?:\|([^\]]+))?\]\]', lambda m: replace_wiki_link(m, root_dir, page), markdown)
+
+@mkdocs.plugins.event_priority(-50)
+def on_page_markdown(markdown, page, **kwargs):
+    markdown = process_links(markdown, root_dir, page)
+    markdown = convert_admonitions(markdown)
+    return markdown

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,0 +1,76 @@
+site_name: Silverbullet AI Plug
+repo_url: https://github.com/justyns/silverbullet-ai
+edit_uri: edit/main/docs/
+docs_dir: docs/_public
+theme:
+  name: material
+  color_mode: auto
+  user_color_mode_toggle: true
+  palette: 
+    # Palette toggle for light mode
+    - media: "(prefers-color-scheme: light)"
+      scheme: default
+      toggle:
+        icon: material/brightness-7
+        name: Switch to dark mode
+    # Palette toggle for dark mode
+    - media: "(prefers-color-scheme: dark)"
+      scheme: slate
+      toggle:
+        icon: material/brightness-4
+        name: Switch to light mode
+  features:
+    - navigation.footer
+    - content.action.edit
+    - content.code.copy
+    - content.code.annotate
+
+markdown_extensions:
+  - pymdownx.highlight:
+      anchor_linenums: true
+      line_spans: __span
+      pygments_lang_class: true
+  - pymdownx.inlinehilite
+  - pymdownx.snippets
+  - pymdownx.superfences
+  - pymdownx.keys
+  - admonition
+  - pymdownx.details
+  - footnotes
+  # - wikilinks
+  # - def_list
+  - mdx_truly_sane_lists
+
+extra:
+  social:
+    - icon: fontawesome/brands/github
+      link: https://github.com/justyns/silverbullet-ai
+
+# plugins:
+  # TODO: Doesn't really work with pub since it creates new files
+  # - git-revision-date-localized:
+  #     enable_creation_date: true
+  # - optimize
+
+hooks:
+  - docs/mkdocs-sb.py
+
+watch:
+  - docs/_public
+  - docs/mkdocs-sb.py
+  - mkdocs.yml
+
+exclude_docs: |
+  SETTINGS.md
+  PLUGS.md
+  SECRETS.md
+  template/
+  Library/
+  Features.md
+  Commands.md
+
+nav:
+  - Home: index.md
+  - Quick Start.md
+  - Installation.md
+  - Changelog.md

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -21,9 +21,14 @@ theme:
         name: Switch to light mode
   features:
     - navigation.footer
+    - navigation.path
+    - navigation.indexes
     - content.action.edit
     - content.code.copy
     - content.code.annotate
+    - search.suggest
+    - search.highlight
+    - search.share
 
 markdown_extensions:
   - pymdownx.highlight:
@@ -46,7 +51,9 @@ extra:
     - icon: fontawesome/brands/github
       link: https://github.com/justyns/silverbullet-ai
 
-# plugins:
+plugins:
+  - include_dir_to_nav
+  - search
   # TODO: Doesn't really work with pub since it creates new files
   # - git-revision-date-localized:
   #     enable_creation_date: true
@@ -73,4 +80,14 @@ nav:
   - Home: index.md
   - Quick Start.md
   - Installation.md
+  - Configuration:
+    - Configuration.md
+    - Configuration
+  - AI Core Library.md
+  - Templated Prompts.md
+  - Commands:
+    - Commands
+  - Providers:
+    - Providers
   - Changelog.md
+  - Development.md

--- a/render-docs.sh
+++ b/render-docs.sh
@@ -1,0 +1,15 @@
+#!env bash
+
+# Publish using the pub plugin to render code blocks/queries/etc
+SB_DB_BACKEND=memory deno run --unstable-kv --unstable-worker-options -A https://edge.silverbullet.md/silverbullet.js plug:run docs/ pub.publishAll && cp -v docs/style.css docs/_public/
+
+# Delete html files
+find docs/_public -type f -name \*.html -delete
+find docs/_public -type d -empty -delete
+
+# Delete extra sb-specific files
+
+rm -fv \
+    docs/_public/SETTINGS.md \
+    docs/_public/PLUGS.md \
+    docs/_public/*.css


### PR DESCRIPTION
UI stuff is not my strongsuit, and I'd rather not try making a full-fledged docs website. After looking at a few options, I settled on using mkdocs-material which looks pretty good imo.

Docs are now being rendered first by silverbullet-pub to render queries/templates, and then being processed by mkdocs (and mkdocs-material) to turn it into a prettier docs website.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced `aiSplitTodo` slash command for enhanced task management.
	- Added template prompts for text rewriting in the AICore Library.
	- Created a new template structure for AI documentation.

- **Documentation Updates**
	- Updated various command documents to indicate deprecation and encourage transitioning to "Templated Prompts."
	- Enhanced clarity and structure of documentation with formatting adjustments and new sections for local development.
	- Improved the installation instructions with a direct link to the latest release.

- **Bug Fixes**
	- Removed specific sync-mode requirement from library update instructions for simplicity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->